### PR TITLE
feat: app-wide redesign (turn 2) with light/dark theme support

### DIFF
--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -205,7 +205,10 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                             gradient: const LinearGradient(
                               begin: Alignment.topLeft,
                               end: Alignment.bottomRight,
-                              colors: [Color(0xFF17B85A), Color(0xFFC6E23F)],
+                              colors: [
+                                BJJColors.brandGradStart,
+                                BJJColors.brandGradEnd,
+                              ],
                             ),
                             borderRadius: BorderRadius.circular(17),
                           ),

--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -162,265 +162,306 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
+    final tk = ChokeTokens.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.accountTitle),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.logout),
-            tooltip: l10n.importChangeKey,
-            onPressed: _showImportDialog,
-          ),
-        ],
-      ),
       body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Profile Header
-              Center(
-                child: Column(
-                  children: [
-                    Container(
-                      width: 80,
-                      height: 80,
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: [colors.primary, colors.secondary],
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                        ),
-                        borderRadius: BorderRadius.circular(24),
-                      ),
-                      child: Icon(
-                        Icons.shield,
-                        size: 40,
-                        color: colors.onPrimary,
-                      ),
+        child: Column(
+          children: [
+            // Header: title + import/change key action
+            Padding(
+              padding: const EdgeInsets.fromLTRB(22, 10, 14, 6),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    l10n.accountTitle,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
                     ),
-                    const SizedBox(height: 16),
-                    Text(
-                      l10n.yourNostrIdentity,
-                      style: theme.textTheme.headlineSmall,
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      l10n.keypairDescription,
-                      style: theme.textTheme.bodyMedium,
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 32),
-
-              // Public Key Section (npub)
-              _buildSectionTitle(context, l10n.publicKeyNpub),
-              const SizedBox(height: 8),
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: colors.surface,
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                    color: colors.primary.withValues(alpha: 0.3),
                   ),
-                ),
-                child: Column(
-                  children: [
-                    npubAsync.when(
-                      data: (npub) => Column(
-                        children: [
-                          Text(
-                            npub ?? l10n.generating,
-                            style: TextStyle(
-                              color: colors.onSurface,
-                              fontFamily: 'monospace',
-                              fontSize: 13,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                          const SizedBox(height: 12),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                            children: [
-                              if (npub != null) ...[
-                                _buildActionButton(
-                                  context: context,
-                                  icon: Icons.copy,
-                                  label: l10n.copy,
-                                  onTap: () =>
-                                      _copyToClipboard(npub, l10n.publicKey),
-                                ),
-                                _buildActionButton(
-                                  context: context,
-                                  icon: Icons.qr_code,
-                                  label: l10n.showQr,
-                                  onTap: () => _showQRCode(context, npub),
-                                ),
-                              ] else
-                                Text(
-                                  l10n.keyUnavailable,
-                                  style: theme.textTheme.bodyMedium,
-                                ),
-                            ],
-                          ),
-                        ],
-                      ),
-                      loading: () => const CircularProgressIndicator(),
-                      error: (_, __) => Text(
-                        l10n.errorLoadingKey,
-                        style: TextStyle(color: colors.error),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 24),
-
-              // Private Key Section (nsec)
-              _buildSectionTitle(context, l10n.privateKeyNsec),
-              const SizedBox(height: 8),
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: colors.surface,
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                    color: colors.error.withValues(alpha: 0.3),
+                  IconButton(
+                    icon: Icon(Icons.logout, color: tk.muted, size: 21),
+                    tooltip: l10n.importChangeKey,
+                    onPressed: _showImportDialog,
                   ),
-                ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(20, 6, 20, 24),
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    // Identity header
                     Row(
                       children: [
-                        Icon(
-                          Icons.warning_amber,
-                          color: colors.error.withValues(alpha: 0.8),
-                          size: 20,
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            l10n.neverSharePrivateKey,
-                            style: TextStyle(
-                              color: colors.error.withValues(alpha: 0.8),
-                              fontSize: 12,
+                        Container(
+                          width: 52,
+                          height: 52,
+                          decoration: BoxDecoration(
+                            gradient: const LinearGradient(
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                              colors: [Color(0xFF17B85A), Color(0xFFC6E23F)],
                             ),
+                            borderRadius: BorderRadius.circular(17),
+                          ),
+                          child: const Icon(
+                            Icons.shield,
+                            size: 28,
+                            color: BJJColors.white,
+                          ),
+                        ),
+                        const SizedBox(width: 13),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                l10n.yourNostrIdentity,
+                                style: const TextStyle(
+                                  fontSize: 19,
+                                  fontWeight: FontWeight.bold,
+                                  height: 1.1,
+                                ),
+                              ),
+                              Text(
+                                l10n.keypairDescription,
+                                style:
+                                    TextStyle(fontSize: 12.5, color: tk.muted),
+                              ),
+                            ],
                           ),
                         ),
                       ],
                     ),
-                    const SizedBox(height: 16),
-                    nsecAsync.when(
-                      data: (nsec) => Column(
-                        children: [
-                          GestureDetector(
-                            onTap: () {
-                              setState(() => _isNsecVisible = !_isNsecVisible);
-                            },
-                            child: Container(
-                              padding: const EdgeInsets.all(12),
-                              decoration: BoxDecoration(
-                                color: theme.scaffoldBackgroundColor,
-                                borderRadius: BorderRadius.circular(12),
+                    const SizedBox(height: 18),
+
+                    // Public Key (npub)
+                    _buildSectionTitle(context, l10n.publicKeyNpub, tk),
+                    const SizedBox(height: 8),
+                    Container(
+                      padding: const EdgeInsets.all(15),
+                      decoration: BoxDecoration(
+                        color: tk.card,
+                        borderRadius: BorderRadius.circular(16),
+                        border: Border.all(color: tk.cardBorder),
+                      ),
+                      child: npubAsync.when(
+                        data: (npub) => Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              npub ?? l10n.generating,
+                              style: TextStyle(
+                                color: tk.accent.withOpacity(.85),
+                                fontFamily: 'monospace',
+                                fontSize: 12.5,
+                                height: 1.5,
                               ),
-                              child: Row(
+                            ),
+                            const SizedBox(height: 12),
+                            if (npub != null)
+                              Row(
                                 children: [
                                   Expanded(
-                                    child: Text(
-                                      _isNsecVisible
-                                          ? (nsec ?? l10n.generating)
-                                          : '••••••••••••••••••••••••••••••••••••••••••••••••••',
-                                      style: TextStyle(
-                                        color: _isNsecVisible
-                                            ? colors.onSurface
-                                            : theme.textTheme.bodyMedium?.color,
-                                        fontFamily: 'monospace',
-                                        fontSize: 13,
-                                      ),
+                                    child: _buildActionButton(
+                                      context: context,
+                                      icon: Icons.copy,
+                                      label: l10n.copy,
+                                      onTap: () => _copyToClipboard(
+                                          npub, l10n.publicKey),
                                     ),
                                   ),
-                                  Icon(
-                                    _isNsecVisible
-                                        ? Icons.visibility_off
-                                        : Icons.visibility,
-                                    color: theme.textTheme.bodyMedium?.color,
+                                  const SizedBox(width: 9),
+                                  Expanded(
+                                    child: _buildActionButton(
+                                      context: context,
+                                      icon: Icons.qr_code,
+                                      label: l10n.showQr,
+                                      onTap: () => _showQRCode(context, npub),
+                                    ),
                                   ),
                                 ],
+                              )
+                            else
+                              Text(
+                                l10n.keyUnavailable,
+                                style: theme.textTheme.bodyMedium,
                               ),
+                          ],
+                        ),
+                        loading: () =>
+                            const Center(child: CircularProgressIndicator()),
+                        error: (_, __) => Text(
+                          l10n.errorLoadingKey,
+                          style: TextStyle(color: colors.error),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 18),
+
+                    // Private Key (nsec)
+                    _buildSectionTitle(context, l10n.privateKeyNsec, tk),
+                    const SizedBox(height: 8),
+                    Container(
+                      padding: const EdgeInsets.all(15),
+                      decoration: BoxDecoration(
+                        color: tk.dangerFg.withOpacity(.07),
+                        borderRadius: BorderRadius.circular(16),
+                        border: Border.all(color: tk.dangerFg.withOpacity(.35)),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              Icon(
+                                Icons.warning_amber,
+                                color: tk.dangerFg,
+                                size: 17,
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Text(
+                                  l10n.neverSharePrivateKey,
+                                  style: TextStyle(
+                                    color: tk.dangerFg,
+                                    fontSize: 12.5,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 11),
+                          nsecAsync.when(
+                            data: (nsec) => Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                GestureDetector(
+                                  onTap: () {
+                                    setState(
+                                        () => _isNsecVisible = !_isNsecVisible);
+                                  },
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 14, vertical: 12),
+                                    decoration: BoxDecoration(
+                                      color: tk.field,
+                                      borderRadius: BorderRadius.circular(11),
+                                      border: Border.all(
+                                        color: tk.dangerFg.withOpacity(.2),
+                                      ),
+                                    ),
+                                    child: Row(
+                                      children: [
+                                        Expanded(
+                                          child: Text(
+                                            _isNsecVisible
+                                                ? (nsec ?? l10n.generating)
+                                                : '••••••••••••••••••••',
+                                            style: TextStyle(
+                                              color: _isNsecVisible
+                                                  ? colors.onSurface
+                                                  : tk.muted,
+                                              fontFamily: 'monospace',
+                                              fontSize:
+                                                  _isNsecVisible ? 12.5 : 15,
+                                              letterSpacing:
+                                                  _isNsecVisible ? 0 : 3,
+                                            ),
+                                          ),
+                                        ),
+                                        Icon(
+                                          _isNsecVisible
+                                              ? Icons.visibility_off
+                                              : Icons.visibility,
+                                          color: tk.muted,
+                                          size: 19,
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(height: 9),
+                                Text(
+                                  l10n.tapToReveal,
+                                  style: TextStyle(
+                                      fontSize: 11.5, color: tk.faint),
+                                ),
+                                if (_isNsecVisible) ...[
+                                  const SizedBox(height: 11),
+                                  _buildActionButton(
+                                    context: context,
+                                    icon: Icons.copy,
+                                    label: l10n.copyToClipboard,
+                                    onTap: () => _copyToClipboard(
+                                        nsec ?? '', l10n.privateKey),
+                                  ),
+                                ],
+                              ],
+                            ),
+                            loading: () => const Center(
+                                child: CircularProgressIndicator()),
+                            error: (_, __) => Text(
+                              l10n.errorLoadingKey,
+                              style: TextStyle(color: colors.error),
                             ),
                           ),
-                          const SizedBox(height: 12),
-                          Text(
-                            l10n.tapToReveal,
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              fontSize: 12,
-                            ),
-                          ),
-                          const SizedBox(height: 12),
-                          if (_isNsecVisible)
-                            _buildActionButton(
-                              context: context,
-                              icon: Icons.copy,
-                              label: l10n.copyToClipboard,
-                              onTap: () =>
-                                  _copyToClipboard(nsec ?? '', l10n.privateKey),
-                            ),
                         ],
                       ),
-                      loading: () => const CircularProgressIndicator(),
-                      error: (_, __) => Text(
-                        l10n.errorLoadingKey,
-                        style: TextStyle(color: colors.error),
-                      ),
+                    ),
+                    const SizedBox(height: 18),
+
+                    // Security Tips
+                    _buildSectionTitle(context, l10n.securityTips, tk),
+                    const SizedBox(height: 8),
+                    _buildTipCard(
+                      context: context,
+                      icon: Icons.cloud_upload_outlined,
+                      iconColor: tk.accent,
+                      title: l10n.tipBackupTitle,
+                      description: l10n.tipBackupDescription,
+                    ),
+                    const SizedBox(height: 8),
+                    _buildTipCard(
+                      context: context,
+                      icon: Icons.block,
+                      iconColor: tk.goldFg,
+                      title: l10n.tipNeverShareTitle,
+                      description: l10n.tipNeverShareDescription,
+                    ),
+                    const SizedBox(height: 8),
+                    _buildTipCard(
+                      context: context,
+                      icon: Icons.phone_android,
+                      iconColor: tk.statusFinishedFg,
+                      title: l10n.tipSecureStorageTitle,
+                      description: l10n.tipSecureStorageDescription,
                     ),
                   ],
                 ),
               ),
-              const SizedBox(height: 32),
-
-              // Security Tips
-              _buildSectionTitle(context, l10n.securityTips),
-              const SizedBox(height: 8),
-              _buildTipCard(
-                context: context,
-                icon: Icons.backup,
-                title: l10n.tipBackupTitle,
-                description: l10n.tipBackupDescription,
-              ),
-              const SizedBox(height: 8),
-              _buildTipCard(
-                context: context,
-                icon: Icons.no_accounts,
-                title: l10n.tipNeverShareTitle,
-                description: l10n.tipNeverShareDescription,
-              ),
-              const SizedBox(height: 8),
-              _buildTipCard(
-                context: context,
-                icon: Icons.phone_android,
-                title: l10n.tipSecureStorageTitle,
-                description: l10n.tipSecureStorageDescription,
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
 
-  Widget _buildSectionTitle(BuildContext context, String title) {
-    final theme = Theme.of(context);
+  Widget _buildSectionTitle(
+      BuildContext context, String title, ChokeTokens tk) {
     return Text(
       title.toUpperCase(),
       style: TextStyle(
-        color: theme.textTheme.bodyMedium?.color,
-        fontSize: 12,
+        color: tk.muted,
+        fontSize: 11,
         fontWeight: FontWeight.w600,
-        letterSpacing: 1.5,
+        letterSpacing: 1.4,
       ),
     );
   }
@@ -431,26 +472,33 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
     required String label,
     required VoidCallback onTap,
   }) {
-    final colors = Theme.of(context).colorScheme;
+    final tk = ChokeTokens.of(context);
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(12),
+      borderRadius: BorderRadius.circular(11),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
         decoration: BoxDecoration(
-          color: colors.primary.withValues(alpha: 0.2),
-          borderRadius: BorderRadius.circular(12),
+          color: tk.accent.withOpacity(.1),
+          borderRadius: BorderRadius.circular(11),
+          border: Border.all(color: tk.accent.withOpacity(.4)),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(icon, color: colors.primary, size: 18),
-            const SizedBox(width: 6),
-            Text(
-              label,
-              style: TextStyle(
-                color: colors.primary,
-                fontWeight: FontWeight.w500,
+            Icon(icon, color: tk.accent, size: 16),
+            const SizedBox(width: 7),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: tk.accent,
+                  fontSize: 13.5,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
           ],
@@ -462,20 +510,30 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
   Widget _buildTipCard({
     required BuildContext context,
     required IconData icon,
+    required Color iconColor,
     required String title,
     required String description,
   }) {
-    final theme = Theme.of(context);
-    final colors = theme.colorScheme;
+    final colors = Theme.of(context).colorScheme;
+    final tk = ChokeTokens.of(context);
     return Container(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
       decoration: BoxDecoration(
-        color: colors.surface,
-        borderRadius: BorderRadius.circular(12),
+        color: tk.card,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: tk.cardBorder),
       ),
       child: Row(
         children: [
-          Icon(icon, color: colors.secondary, size: 20),
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              color: iconColor.withOpacity(.14),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, color: iconColor, size: 19),
+          ),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -485,14 +543,14 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                   title,
                   style: TextStyle(
                     color: colors.onSurface,
-                    fontWeight: FontWeight.w500,
+                    fontWeight: FontWeight.w600,
                     fontSize: 14,
                   ),
                 ),
                 const SizedBox(height: 2),
                 Text(
                   description,
-                  style: theme.textTheme.bodyMedium?.copyWith(fontSize: 12),
+                  style: TextStyle(fontSize: 12, color: tk.muted),
                 ),
               ],
             ),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -25,7 +25,7 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final filteredMatches = ref.watch(filteredMatchListProvider);
-    final allMatches = ref.watch(matchFeedProvider);
+    final allMatches = ref.watch(recentMatchListProvider);
     final statusFilter = ref.watch(statusFilterProvider);
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
@@ -49,7 +49,10 @@ class HomeScreen extends ConsumerWidget {
                       gradient: const LinearGradient(
                         begin: Alignment.topLeft,
                         end: Alignment.bottomRight,
-                        colors: [Color(0xFF17B85A), Color(0xFFC6E23F)],
+                        colors: [
+                          BJJColors.brandGradStart,
+                          BJJColors.brandGradEnd,
+                        ],
                       ),
                       borderRadius: BorderRadius.circular(13),
                     ),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -25,30 +25,46 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final filteredMatches = ref.watch(filteredMatchListProvider);
+    final allMatches = ref.watch(matchFeedProvider);
     final statusFilter = ref.watch(statusFilterProvider);
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
-    final colors = theme.colorScheme;
+    final tk = ChokeTokens.of(context);
 
     return Scaffold(
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(builder: (_) => const CreateMatchScreen()),
-          );
-        },
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: _buildFab(context, tk),
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Header
+            // Header: logo mark + title + subtitle
             Padding(
-              padding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
+                  Container(
+                    width: 42,
+                    height: 42,
+                    decoration: BoxDecoration(
+                      gradient: const LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [Color(0xFF17B85A), Color(0xFFC6E23F)],
+                      ),
+                      borderRadius: BorderRadius.circular(13),
+                    ),
+                    child: const Center(
+                      child: Text(
+                        'C',
+                        style: TextStyle(
+                          color: BJJColors.white,
+                          fontSize: 24,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
                   Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -56,12 +72,13 @@ class HomeScreen extends ConsumerWidget {
                         l10n.appTitle,
                         style: theme.textTheme.headlineMedium?.copyWith(
                           fontWeight: FontWeight.bold,
+                          letterSpacing: -.5,
+                          height: 1.05,
                         ),
                       ),
-                      const SizedBox(height: 4),
                       Text(
                         l10n.homeSubtitle,
-                        style: theme.textTheme.bodyMedium,
+                        style: TextStyle(fontSize: 12.5, color: tk.muted),
                       ),
                     ],
                   ),
@@ -69,38 +86,28 @@ class HomeScreen extends ConsumerWidget {
               ),
             ),
 
-            // Filter chips
+            // Filter chips with counts
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: _buildFilterChips(context, ref, statusFilter),
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+              child:
+                  _buildFilterChips(context, ref, statusFilter, allMatches, tk),
             ),
-
-            const SizedBox(height: 16),
 
             // Match list
             Expanded(
-              child: Container(
-                decoration: BoxDecoration(
-                  color: colors.surfaceContainerHighest,
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(32),
-                    topRight: Radius.circular(32),
-                  ),
-                ),
-                child: filteredMatches.isEmpty
-                    ? _buildEmptyState(context)
-                    : ListView.builder(
-                        padding: const EdgeInsets.all(20),
-                        itemCount: filteredMatches.length,
-                        itemBuilder: (context, index) {
-                          final match = filteredMatches[index];
-                          return Padding(
-                            padding: const EdgeInsets.only(bottom: 12),
-                            child: _buildMatchCard(context, ref, match),
-                          );
-                        },
-                      ),
-              ),
+              child: filteredMatches.isEmpty
+                  ? _buildEmptyState(context)
+                  : ListView.builder(
+                      padding: const EdgeInsets.fromLTRB(20, 2, 20, 80),
+                      itemCount: filteredMatches.length,
+                      itemBuilder: (context, index) {
+                        final match = filteredMatches[index];
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 11),
+                          child: _buildMatchCard(context, ref, match, tk),
+                        );
+                      },
+                    ),
             ),
           ],
         ),
@@ -108,46 +115,91 @@ class HomeScreen extends ConsumerWidget {
     );
   }
 
+  Widget _buildFab(BuildContext context, ChokeTokens tk) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const CreateMatchScreen()),
+        );
+      },
+      child: Container(
+        width: 58,
+        height: 58,
+        decoration: BoxDecoration(
+          gradient: tk.gradient,
+          borderRadius: BorderRadius.circular(19),
+          boxShadow: [
+            BoxShadow(
+              color: tk.gradTop.withOpacity(.4),
+              blurRadius: 22,
+              offset: const Offset(0, 8),
+            ),
+          ],
+        ),
+        child: Icon(Icons.add, color: tk.onGrad, size: 28),
+      ),
+    );
+  }
+
   Widget _buildFilterChips(
-      BuildContext context, WidgetRef ref, Set<MatchStatus> selected) {
+    BuildContext context,
+    WidgetRef ref,
+    Set<MatchStatus> selected,
+    List<Match> allMatches,
+    ChokeTokens tk,
+  ) {
     final l10n = AppLocalizations.of(context);
-    final theme = Theme.of(context);
 
     return Wrap(
       spacing: 8,
       runSpacing: 8,
       children: MatchStatus.values.map((status) {
         final isSelected = selected.contains(status);
-        return FilterChip(
-          label: Text(_statusLabel(l10n, status)),
-          selected: isSelected,
-          onSelected: (value) {
+        final count = allMatches.where((m) => m.status == status).length;
+        final color = _statusAccent(tk, status);
+
+        return GestureDetector(
+          onTap: () {
             final current =
                 Set<MatchStatus>.from(ref.read(statusFilterProvider));
-            if (value) {
-              current.add(status);
-            } else {
+            if (isSelected) {
               current.remove(status);
+            } else {
+              current.add(status);
             }
             ref.read(statusFilterProvider.notifier).state = current;
           },
-          selectedColor: _statusColor(status).withOpacity(0.2),
-          checkmarkColor: _statusColor(status),
-          labelStyle: TextStyle(
-            color: isSelected
-                ? _statusColor(status)
-                : theme.textTheme.bodyMedium?.color,
-            fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
-            fontSize: 12,
-          ),
-          backgroundColor: theme.colorScheme.surface,
-          side: BorderSide(
-            color: isSelected
-                ? _statusColor(status).withOpacity(0.5)
-                : theme.colorScheme.outline.withOpacity(0.3),
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 7),
+            decoration: BoxDecoration(
+              color: isSelected ? color.withOpacity(.16) : null,
+              borderRadius: BorderRadius.circular(99),
+              border: Border.all(
+                color: isSelected ? color.withOpacity(.4) : tk.cardBorder,
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (status == MatchStatus.inProgress) ...[
+                  Container(
+                    width: 7,
+                    height: 7,
+                    decoration:
+                        BoxDecoration(color: color, shape: BoxShape.circle),
+                  ),
+                  const SizedBox(width: 6),
+                ],
+                Text(
+                  '${_statusLabel(l10n, status)} · $count',
+                  style: TextStyle(
+                    color: isSelected ? color : tk.muted,
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
           ),
         );
       }).toList(),
@@ -183,12 +235,162 @@ class HomeScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildMatchCard(BuildContext context, WidgetRef ref, Match match) {
+  Widget _buildMatchCard(
+      BuildContext context, WidgetRef ref, Match match, ChokeTokens tk) {
     final l10n = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final colors = theme.colorScheme;
+    final colors = Theme.of(context).colorScheme;
     final f1Color = _hexToColor(match.f1Color, colors.outline);
     final f2Color = _hexToColor(match.f2Color, colors.outline);
+    final isLive = match.status == MatchStatus.inProgress;
+    final isCanceled = match.status == MatchStatus.canceled;
+
+    final card = Container(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+      decoration: BoxDecoration(
+        gradient: isLive
+            ? LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  tk.accent.withOpacity(.12),
+                  tk.accent.withOpacity(.03),
+                ],
+              )
+            : null,
+        color: isLive ? null : tk.card,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: isLive ? tk.accent.withOpacity(.45) : tk.cardBorder,
+        ),
+      ),
+      child: Column(
+        children: [
+          // Top row: match ID + status chip
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '#${match.id}',
+                style: TextStyle(
+                  color: tk.faint,
+                  fontSize: 12,
+                  fontFamily: 'monospace',
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              _buildStatusChip(context, match.status, tk),
+            ],
+          ),
+          const SizedBox(height: 11),
+          // Fighters + score row
+          Row(
+            children: [
+              Expanded(
+                child: Row(
+                  children: [
+                    Container(
+                      width: 9,
+                      height: 9,
+                      decoration:
+                          BoxDecoration(color: f1Color, shape: BoxShape.circle),
+                    ),
+                    const SizedBox(width: 9),
+                    Flexible(
+                      child: Text(
+                        match.f1Name,
+                        style: TextStyle(
+                          color: colors.onSurface,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (match.f1Adv > 0) ...[
+                      const SizedBox(width: 6),
+                      _buildSmallBadge('A:${match.f1Adv}', tk.goldFg),
+                    ],
+                    if (match.f1Pen > 0) ...[
+                      const SizedBox(width: 4),
+                      _buildSmallBadge('P:${match.f1Pen}', tk.dangerFg),
+                    ],
+                  ],
+                ),
+              ),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    '${match.f1Score}',
+                    style: TextStyle(
+                      color: match.f1Score > match.f2Score && !isCanceled
+                          ? tk.accent
+                          : tk.muted,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 27,
+                      height: 1,
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 9),
+                    child: Text(
+                      l10n.vs,
+                      style: TextStyle(fontSize: 12, color: tk.faint),
+                    ),
+                  ),
+                  Text(
+                    '${match.f2Score}',
+                    style: TextStyle(
+                      color: match.f2Score > match.f1Score && !isCanceled
+                          ? tk.accent
+                          : tk.muted,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 27,
+                      height: 1,
+                    ),
+                  ),
+                ],
+              ),
+              Expanded(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    if (match.f2Adv > 0) ...[
+                      _buildSmallBadge('A:${match.f2Adv}', tk.goldFg),
+                      const SizedBox(width: 6),
+                    ],
+                    if (match.f2Pen > 0) ...[
+                      _buildSmallBadge('P:${match.f2Pen}', tk.dangerFg),
+                      const SizedBox(width: 4),
+                    ],
+                    Flexible(
+                      child: Text(
+                        match.f2Name,
+                        textAlign: TextAlign.right,
+                        style: TextStyle(
+                          color: colors.onSurface,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 9),
+                    Container(
+                      width: 9,
+                      height: 9,
+                      decoration:
+                          BoxDecoration(color: f2Color, shape: BoxShape.circle),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
 
     return InkWell(
       onTap: () {
@@ -200,165 +402,47 @@ class HomeScreen extends ConsumerWidget {
           ),
         );
       },
-      borderRadius: BorderRadius.circular(16),
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: colors.surface,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: colors.shadow.withOpacity(0.06),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
+      borderRadius: BorderRadius.circular(18),
+      child: isCanceled ? Opacity(opacity: .72, child: card) : card,
+    );
+  }
+
+  Widget _buildStatusChip(
+      BuildContext context, MatchStatus status, ChokeTokens tk) {
+    final l10n = AppLocalizations.of(context);
+    final (fg, bg) = switch (status) {
+      MatchStatus.waiting => (tk.goldFg, tk.goldFg.withOpacity(.14)),
+      MatchStatus.inProgress => (tk.accent, tk.accent.withOpacity(.2)),
+      MatchStatus.finished => (tk.statusFinishedFg, tk.statusFinishedBg),
+      MatchStatus.canceled => (tk.statusCanceledFg, tk.statusCanceledBg),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(99),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (status == MatchStatus.inProgress) ...[
+            Container(
+              width: 6,
+              height: 6,
+              decoration: BoxDecoration(color: fg, shape: BoxShape.circle),
             ),
+            const SizedBox(width: 6),
           ],
-        ),
-        child: Column(
-          children: [
-            // Top row: match ID + status badge
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  '#${match.id}',
-                  style: TextStyle(
-                    color: theme.textTheme.bodyMedium?.color,
-                    fontSize: 12,
-                    fontFamily: 'monospace',
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-                Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                  decoration: BoxDecoration(
-                    color: _statusColor(match.status).withOpacity(0.15),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Text(
-                    _statusLabel(l10n, match.status),
-                    style: TextStyle(
-                      color: _statusColor(match.status),
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-              ],
+          Text(
+            _statusLabel(l10n, status),
+            style: TextStyle(
+              color: fg,
+              fontSize: 11.5,
+              fontWeight: FontWeight.w600,
             ),
-
-            const SizedBox(height: 12),
-
-            // Score row
-            Row(
-              children: [
-                // Fighter 1
-                Container(
-                  width: 10,
-                  height: 10,
-                  decoration: BoxDecoration(
-                    color: f1Color,
-                    shape: BoxShape.circle,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    match.f1Name,
-                    style: TextStyle(
-                      color: colors.onSurface,
-                      fontWeight: FontWeight.w500,
-                      fontSize: 14,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                Text(
-                  '${match.f1Score}',
-                  style: TextStyle(
-                    color: match.f1Score > match.f2Score
-                        ? colors.primary
-                        : colors.onSurface,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 20,
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  child: Text(
-                    l10n.vs,
-                    style: theme.textTheme.bodyMedium?.copyWith(fontSize: 12),
-                  ),
-                ),
-                Text(
-                  '${match.f2Score}',
-                  style: TextStyle(
-                    color: match.f2Score > match.f1Score
-                        ? colors.primary
-                        : colors.onSurface,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 20,
-                  ),
-                ),
-                Expanded(
-                  child: Text(
-                    match.f2Name,
-                    textAlign: TextAlign.right,
-                    style: TextStyle(
-                      color: colors.onSurface,
-                      fontWeight: FontWeight.w500,
-                      fontSize: 14,
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Container(
-                  width: 10,
-                  height: 10,
-                  decoration: BoxDecoration(
-                    color: f2Color,
-                    shape: BoxShape.circle,
-                  ),
-                ),
-              ],
-            ),
-
-            // Advantages/Penalties row
-            if (match.f1Adv > 0 ||
-                match.f2Adv > 0 ||
-                match.f1Pen > 0 ||
-                match.f2Pen > 0) ...[
-              const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Row(
-                    children: [
-                      if (match.f1Adv > 0)
-                        _buildSmallBadge('A:${match.f1Adv}', BJJColors.gold),
-                      if (match.f1Pen > 0) ...[
-                        const SizedBox(width: 4),
-                        _buildSmallBadge('P:${match.f1Pen}', BJJColors.error),
-                      ],
-                    ],
-                  ),
-                  Row(
-                    children: [
-                      if (match.f2Adv > 0)
-                        _buildSmallBadge('A:${match.f2Adv}', BJJColors.gold),
-                      if (match.f2Pen > 0) ...[
-                        const SizedBox(width: 4),
-                        _buildSmallBadge('P:${match.f2Pen}', BJJColors.error),
-                      ],
-                    ],
-                  ),
-                ],
-              ),
-            ],
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -367,26 +451,26 @@ class HomeScreen extends ConsumerWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.12),
+        color: color.withOpacity(0.14),
         borderRadius: BorderRadius.circular(6),
       ),
       child: Text(
         text,
         style: TextStyle(
           color: color,
-          fontSize: 10,
-          fontWeight: FontWeight.w500,
+          fontSize: 10.5,
+          fontWeight: FontWeight.w600,
         ),
       ),
     );
   }
 
-  Color _statusColor(MatchStatus status) {
+  Color _statusAccent(ChokeTokens tk, MatchStatus status) {
     return switch (status) {
-      MatchStatus.waiting => BJJColors.gold,
-      MatchStatus.inProgress => BJJColors.green,
-      MatchStatus.finished => BJJColors.info,
-      MatchStatus.canceled => BJJColors.error,
+      MatchStatus.waiting => tk.goldFg,
+      MatchStatus.inProgress => tk.accent,
+      MatchStatus.finished => tk.statusFinishedFg,
+      MatchStatus.canceled => tk.statusCanceledFg,
     };
   }
 

--- a/lib/features/home/providers/home_providers.dart
+++ b/lib/features/home/providers/home_providers.dart
@@ -87,22 +87,25 @@ final matchFeedProvider =
   return MatchFeedNotifier(nostrService);
 });
 
-/// Filtered match list based on status filter and 24h window.
+/// Matches from the last 24 hours regardless of status.
 /// Uses the Nostr event created_at (not match.startAt) for the time filter.
-final filteredMatchListProvider = Provider<List<Match>>((ref) {
+/// This is the base set the home screen displays and counts from.
+final recentMatchListProvider = Provider<List<Match>>((ref) {
   final feedNotifier = ref.watch(matchFeedProvider.notifier);
   final matches = ref.watch(matchFeedProvider);
-  final statusFilter = ref.watch(statusFilterProvider);
 
   final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
   final cutoff = now - 86400; // 24 hours ago
 
   return matches.where((m) {
-    // Filter by status
-    if (!statusFilter.contains(m.status)) return false;
-    // Filter by event created_at within last 24 hours
     final createdAt = feedNotifier.getCreatedAt(m.id);
-    if (createdAt != null && createdAt < cutoff) return false;
-    return true;
+    return createdAt == null || createdAt >= cutoff;
   }).toList();
+});
+
+/// Recent matches narrowed by the selected status filter.
+final filteredMatchListProvider = Provider<List<Match>>((ref) {
+  final matches = ref.watch(recentMatchListProvider);
+  final statusFilter = ref.watch(statusFilterProvider);
+  return matches.where((m) => statusFilter.contains(m.status)).toList();
 });

--- a/lib/features/match/create_match_screen.dart
+++ b/lib/features/match/create_match_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
@@ -127,224 +126,344 @@ class _CreateMatchScreenState extends ConsumerState<CreateMatchScreen> {
       _durationInitialized = true;
     }
     final l10n = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final colors = theme.colorScheme;
+    final tk = ChokeTokens.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.newMatch),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).pop(),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Header: back button + title
+            Padding(
+              padding: const EdgeInsets.fromLTRB(18, 12, 18, 8),
+              child: Row(
+                children: [
+                  _buildBackButton(context, tk),
+                  const SizedBox(width: 12),
+                  Text(
+                    l10n.newMatch,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Fighter cards with VS circle in between
+                      Stack(
+                        alignment: Alignment.center,
+                        children: [
+                          Column(
+                            children: [
+                              _buildFighterCard(
+                                context: context,
+                                label: l10n.fighter1,
+                                controller: _f1NameController,
+                                selectedColor: _f1Color,
+                                onColorSelected: (c) =>
+                                    setState(() => _f1Color = c),
+                                validatorMessage: l10n.fighter1NameRequired,
+                              ),
+                              const SizedBox(height: 12),
+                              _buildFighterCard(
+                                context: context,
+                                label: l10n.fighter2,
+                                controller: _f2NameController,
+                                selectedColor: _f2Color,
+                                onColorSelected: (c) =>
+                                    setState(() => _f2Color = c),
+                                validatorMessage: l10n.fighter2NameRequired,
+                              ),
+                            ],
+                          ),
+                          _buildVsBadge(context, tk),
+                        ],
+                      ),
+
+                      const SizedBox(height: 18),
+
+                      // Duration
+                      _buildSectionLabel(context, l10n.matchDuration, tk),
+                      const SizedBox(height: 10),
+                      _buildDurationSelector(context, tk),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            // Fixed bottom create button
+            Container(
+              padding: const EdgeInsets.fromLTRB(20, 14, 20, 18),
+              decoration: BoxDecoration(
+                border: Border(top: BorderSide(color: tk.cardBorder)),
+              ),
+              child: _buildGradientButton(
+                context: context,
+                tk: tk,
+                enabled: !_isPublishing,
+                onTap: _createMatch,
+                child: _isPublishing
+                    ? SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: tk.onGrad,
+                        ),
+                      )
+                    : Text(
+                        l10n.createMatch,
+                        style: TextStyle(
+                          color: tk.onGrad,
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+              ),
+            ),
+          ],
         ),
       ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(24),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Fighter 1
-                _buildSectionLabel(context, l10n.fighter1),
-                const SizedBox(height: 8),
-                TextFormField(
-                  controller: _f1NameController,
-                  style: TextStyle(color: colors.onSurface),
-                  decoration: InputDecoration(
-                    hintText: l10n.enterFighterName,
-                    prefixIcon: Icon(Icons.person, color: colors.primary),
-                  ),
-                  validator: (value) {
-                    if (value == null || value.trim().isEmpty) {
-                      return l10n.fighter1NameRequired;
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 12),
-                _buildColorPicker(
-                  context: context,
-                  label: l10n.fighter1Color,
-                  selectedColor: _f1Color,
-                  onColorSelected: (color) => setState(() => _f1Color = color),
-                ),
+    );
+  }
 
-                const SizedBox(height: 32),
+  Widget _buildBackButton(BuildContext context, ChokeTokens tk) {
+    return GestureDetector(
+      onTap: () => Navigator.of(context).pop(),
+      child: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: tk.field,
+          borderRadius: BorderRadius.circular(11),
+          border: Border.all(color: tk.cardBorder),
+        ),
+        child: const Icon(Icons.arrow_back_ios_new, size: 17),
+      ),
+    );
+  }
 
-                // Fighter 2
-                _buildSectionLabel(context, l10n.fighter2),
-                const SizedBox(height: 8),
-                TextFormField(
-                  controller: _f2NameController,
-                  style: TextStyle(color: colors.onSurface),
-                  decoration: InputDecoration(
-                    hintText: l10n.enterFighterName,
-                    prefixIcon: Icon(Icons.person, color: colors.secondary),
-                  ),
-                  validator: (value) {
-                    if (value == null || value.trim().isEmpty) {
-                      return l10n.fighter2NameRequired;
-                    }
-                    return null;
-                  },
-                ),
-                const SizedBox(height: 12),
-                _buildColorPicker(
-                  context: context,
-                  label: l10n.fighter2Color,
-                  selectedColor: _f2Color,
-                  onColorSelected: (color) => setState(() => _f2Color = color),
-                ),
-
-                const SizedBox(height: 32),
-
-                // Duration
-                _buildSectionLabel(context, l10n.matchDuration),
-                const SizedBox(height: 12),
-                _buildDurationSelector(context),
-
-                const SizedBox(height: 48),
-
-                // Create button
-                SizedBox(
-                  width: double.infinity,
-                  height: 56,
-                  child: ElevatedButton(
-                    onPressed: _isPublishing ? null : _createMatch,
-                    child: _isPublishing
-                        ? const SizedBox(
-                            width: 24,
-                            height: 24,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Text(
-                            l10n.createMatch,
-                            style: const TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                  ),
-                ),
-              ],
-            ),
+  Widget _buildVsBadge(BuildContext context, ChokeTokens tk) {
+    final theme = Theme.of(context);
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: theme.scaffoldBackgroundColor,
+        shape: BoxShape.circle,
+        border: Border.all(color: tk.cardBorder, width: 1.5),
+      ),
+      child: Center(
+        child: Text(
+          AppLocalizations.of(context).vs.toUpperCase(),
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w700,
+            color: tk.muted,
           ),
         ),
       ),
     );
   }
 
-  Widget _buildSectionLabel(BuildContext context, String label) {
+  Widget _buildSectionLabel(
+      BuildContext context, String label, ChokeTokens tk) {
     return Text(
       label.toUpperCase(),
       style: TextStyle(
-        color: Theme.of(context).textTheme.bodyMedium?.color,
-        fontSize: 12,
+        color: tk.muted,
+        fontSize: 11,
         fontWeight: FontWeight.w600,
-        letterSpacing: 1.5,
+        letterSpacing: 1.4,
       ),
     );
   }
 
-  Widget _buildColorPicker({
+  Widget _buildFighterCard({
     required BuildContext context,
     required String label,
+    required TextEditingController controller,
+    required Color selectedColor,
+    required ValueChanged<Color> onColorSelected,
+    required String validatorMessage,
+  }) {
+    final l10n = AppLocalizations.of(context);
+    final tk = ChokeTokens.of(context);
+    final colors = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.all(15),
+      decoration: BoxDecoration(
+        color: tk.card,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: selectedColor.withOpacity(.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildSectionLabel(context, label, tk),
+          const SizedBox(height: 10),
+          TextFormField(
+            controller: controller,
+            style: TextStyle(
+              color: colors.onSurface,
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+            ),
+            decoration: InputDecoration(
+              hintText: l10n.enterFighterName,
+              isDense: true,
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 13, vertical: 13),
+              prefixIcon: Icon(Icons.person_outline,
+                  color: selectedColor == BJJColors.white
+                      ? tk.muted
+                      : selectedColor,
+                  size: 20),
+            ),
+            validator: (value) {
+              if (value == null || value.trim().isEmpty) {
+                return validatorMessage;
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 12),
+          _buildColorDots(
+            context: context,
+            selectedColor: selectedColor,
+            onColorSelected: onColorSelected,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildColorDots({
+    required BuildContext context,
     required Color selectedColor,
     required ValueChanged<Color> onColorSelected,
   }) {
     final theme = Theme.of(context);
-    final colors = theme.colorScheme;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: theme.textTheme.bodyMedium?.copyWith(fontSize: 12),
-        ),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 10,
-          runSpacing: 10,
-          children: BJJColors.fighterPalette.map((color) {
-            final isSelected = color == selectedColor;
-            return GestureDetector(
-              onTap: () => onColorSelected(color),
-              child: Container(
-                width: 36,
-                height: 36,
-                decoration: BoxDecoration(
-                  color: color,
-                  shape: BoxShape.circle,
-                  border: Border.all(
-                    color: isSelected
-                        ? colors.onSurface
-                        : colors.outline.withValues(alpha: 0.5),
-                    width: isSelected ? 3 : 1,
-                  ),
-                  boxShadow: isSelected
-                      ? [
-                          BoxShadow(
-                            color: color.withValues(alpha: 0.4),
-                            blurRadius: 8,
-                            spreadRadius: 2,
-                          ),
-                        ]
-                      : null,
-                ),
-                child: isSelected
-                    ? Icon(
-                        Icons.check,
-                        color: color == BJJColors.white
-                            ? BJJColors.navy
-                            : BJJColors.white,
-                        size: 18,
-                      )
-                    : null,
-              ),
-            );
-          }).toList(),
-        ),
-      ],
-    );
-  }
+    final tk = ChokeTokens.of(context);
 
-  Widget _buildDurationSelector(BuildContext context) {
-    final theme = Theme.of(context);
-    final colors = theme.colorScheme;
     return Wrap(
-      spacing: 10,
-      runSpacing: 10,
-      children: defaultDurationOptions.map((seconds) {
-        final isSelected = seconds == _duration;
+      spacing: 9,
+      runSpacing: 9,
+      children: BJJColors.fighterPalette.map((color) {
+        final isSelected = color == selectedColor;
         return GestureDetector(
-          onTap: () => setState(() => _duration = seconds),
+          onTap: () => onColorSelected(color),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            width: 26,
+            height: 26,
             decoration: BoxDecoration(
-              color: isSelected ? colors.primary : colors.surface,
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: isSelected
-                    ? colors.primary
-                    : colors.outline.withValues(alpha: 0.5),
-              ),
-            ),
-            child: Text(
-              _formatDuration(seconds),
-              style: TextStyle(
-                color: isSelected
-                    ? colors.onPrimary
-                    : theme.textTheme.bodyMedium?.color,
-                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
-                fontSize: 16,
-                fontFamily: 'monospace',
-              ),
+              color: color,
+              shape: BoxShape.circle,
+              border: color == BJJColors.white || color == BJJColors.navy
+                  ? Border.all(color: tk.cardBorder)
+                  : null,
+              boxShadow: isSelected
+                  ? [
+                      BoxShadow(
+                        color: theme.scaffoldBackgroundColor,
+                        spreadRadius: 2,
+                      ),
+                      BoxShadow(
+                        color: color == BJJColors.white ? tk.muted : color,
+                        spreadRadius: 3.5,
+                      ),
+                    ]
+                  : null,
             ),
           ),
         );
       }).toList(),
+    );
+  }
+
+  Widget _buildDurationSelector(BuildContext context, ChokeTokens tk) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: defaultDurationOptions.map((seconds) {
+          final isSelected = seconds == _duration;
+          return Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: GestureDetector(
+              onTap: () => setState(() => _duration = seconds),
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 15, vertical: 11),
+                decoration: BoxDecoration(
+                  gradient: isSelected ? tk.gradient : null,
+                  borderRadius: BorderRadius.circular(12),
+                  border: isSelected
+                      ? null
+                      : Border.all(color: tk.cardBorder, width: 1),
+                  boxShadow: isSelected
+                      ? [
+                          BoxShadow(
+                            color: tk.gradTop.withOpacity(.3),
+                            blurRadius: 16,
+                            offset: const Offset(0, 6),
+                          ),
+                        ]
+                      : null,
+                ),
+                child: Text(
+                  _formatDuration(seconds),
+                  style: TextStyle(
+                    color: isSelected ? tk.onGrad : tk.muted,
+                    fontWeight: isSelected ? FontWeight.w700 : FontWeight.w600,
+                    fontSize: 15,
+                    fontFamily: 'monospace',
+                  ),
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _buildGradientButton({
+    required BuildContext context,
+    required ChokeTokens tk,
+    required bool enabled,
+    required VoidCallback onTap,
+    required Widget child,
+  }) {
+    return GestureDetector(
+      onTap: enabled ? onTap : null,
+      child: Opacity(
+        opacity: enabled ? 1 : .6,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          decoration: BoxDecoration(
+            gradient: tk.gradient,
+            borderRadius: BorderRadius.circular(15),
+            boxShadow: [
+              BoxShadow(
+                color: tk.gradTop.withOpacity(.35),
+                blurRadius: 22,
+                offset: const Offset(0, 8),
+              ),
+            ],
+          ),
+          child: Center(child: child),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -218,7 +218,7 @@ class SettingsScreen extends ConsumerWidget {
       width: 36,
       height: 36,
       decoration: BoxDecoration(
-        color: tk.accent.withOpacity(.14),
+        color: tk.accent.withValues(alpha: .14),
         borderRadius: BorderRadius.circular(10),
       ),
       child: Icon(icon, color: tk.accent, size: 20),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../shared/providers/locale_provider.dart';
 import '../../shared/providers/theme_provider.dart';
 import '../../shared/providers/match_duration_provider.dart';
+import '../../shared/theme/app_theme.dart';
 import 'screens/relay_management_screen.dart';
 
 /// Provider for package info
@@ -31,94 +32,83 @@ class SettingsScreen extends ConsumerWidget {
     final currentThemeMode = ref.watch(themeModeProvider);
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
+    final tk = ChokeTokens.of(context);
 
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.settingsTitle)),
-      body: ListView(
-        padding: const EdgeInsets.all(16.0),
-        children: [
-          // Language
-          _buildSectionTitle(context, l10n.sectionLanguage),
-          Card(
-            child: ListTile(
-              leading: Icon(Icons.language, color: colors.primary),
-              title: Text(l10n.language),
-              subtitle: Text(
-                currentLocale != null
-                    ? _localeNames[currentLocale.languageCode] ??
-                        currentLocale.languageCode
-                    : l10n.systemDefault,
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+          children: [
+            // Header
+            Padding(
+              padding: const EdgeInsets.fromLTRB(2, 6, 2, 14),
+              child: Text(
+                l10n.settingsTitle,
+                style:
+                    const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
               ),
-              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            ),
+
+            // Language
+            _buildSectionTitle(context, l10n.sectionLanguage, tk),
+            _buildListRow(
+              context: context,
+              tk: tk,
+              icon: Icons.language,
+              title: l10n.language,
+              subtitle: currentLocale != null
+                  ? _localeNames[currentLocale.languageCode] ??
+                      currentLocale.languageCode
+                  : l10n.systemDefault,
               onTap: () => _showLanguagePicker(context, ref),
             ),
-          ),
-          const SizedBox(height: 16),
-          // Appearance
-          _buildSectionTitle(context, l10n.sectionAppearance),
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
+            const SizedBox(height: 18),
+
+            // Appearance — 3-segment theme selector, single line
+            _buildSectionTitle(context, l10n.sectionAppearance, tk),
+            Container(
+              padding: const EdgeInsets.all(15),
+              decoration: BoxDecoration(
+                color: tk.card,
+                borderRadius: BorderRadius.circular(15),
+                border: Border.all(color: tk.cardBorder),
+              ),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(
                     children: [
-                      Icon(Icons.palette, color: colors.primary),
-                      const SizedBox(width: 12),
+                      _buildIconTile(tk, Icons.contrast),
+                      const SizedBox(width: 11),
                       Text(
                         l10n.themeMode,
-                        style: theme.textTheme.titleMedium,
+                        style: const TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
                       ),
                     ],
                   ),
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: SegmentedButton<ThemeMode>(
-                      segments: [
-                        ButtonSegment<ThemeMode>(
-                          value: ThemeMode.system,
-                          icon: const Icon(Icons.brightness_auto),
-                          label: Text(l10n.systemDefault),
-                        ),
-                        ButtonSegment<ThemeMode>(
-                          value: ThemeMode.dark,
-                          icon: const Icon(Icons.dark_mode),
-                          label: Text(l10n.dark),
-                        ),
-                        ButtonSegment<ThemeMode>(
-                          value: ThemeMode.light,
-                          icon: const Icon(Icons.light_mode),
-                          label: Text(l10n.light),
-                        ),
-                      ],
-                      selected: {currentThemeMode},
-                      onSelectionChanged: (Set<ThemeMode> selected) {
-                        ref
-                            .read(themeModeProvider.notifier)
-                            .setThemeMode(selected.first);
-                      },
-                    ),
-                  ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: 13),
+                  _buildThemeSegments(context, ref, currentThemeMode, tk),
+                  const SizedBox(height: 11),
                   Text(
                     l10n.followSystemTheme,
-                    style: theme.textTheme.bodySmall,
+                    style: TextStyle(fontSize: 12, color: tk.faint),
                   ),
                 ],
               ),
             ),
-          ),
-          const SizedBox(height: 16),
-          // Nostr
-          _buildSectionTitle(context, l10n.sectionNostr),
-          Card(
-            child: ListTile(
-              leading: Icon(Icons.dns, color: colors.primary),
-              title: Text(l10n.relays),
-              subtitle: Text(l10n.manageRelayConnections),
-              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            const SizedBox(height: 18),
+
+            // Nostr
+            _buildSectionTitle(context, l10n.sectionNostr, tk),
+            _buildListRow(
+              context: context,
+              tk: tk,
+              icon: Icons.dns_outlined,
+              title: l10n.relays,
+              subtitle: l10n.manageRelayConnections,
               onTap: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
@@ -127,93 +117,233 @@ class SettingsScreen extends ConsumerWidget {
                 );
               },
             ),
-          ),
-          const SizedBox(height: 16),
-          // Match
-          _buildSectionTitle(context, l10n.sectionMatch),
-          Card(
-            child: Consumer(
+            const SizedBox(height: 18),
+
+            // Match
+            _buildSectionTitle(context, l10n.sectionMatch, tk),
+            Consumer(
               builder: (context, ref, _) {
                 final duration = ref.watch(matchDurationProvider);
-                return ListTile(
-                  leading: Icon(Icons.timer, color: colors.primary),
-                  title: Text(l10n.defaultMatchDuration),
-                  subtitle: Text(formatDuration(duration)),
-                  trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+                return _buildListRow(
+                  context: context,
+                  tk: tk,
+                  icon: Icons.timer_outlined,
+                  title: l10n.defaultMatchDuration,
+                  subtitle: formatDuration(duration),
+                  subtitleStyle: TextStyle(
+                    color: tk.accent,
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w600,
+                    fontFamily: 'monospace',
+                  ),
                   onTap: () => _showDurationPicker(context, ref, duration),
                 );
               },
             ),
-          ),
-          const SizedBox(height: 16),
-          // About
-          _buildSectionTitle(context, l10n.sectionAbout),
-          Card(
-            child: Column(
-              children: [
-                ListTile(
-                  leading: Icon(Icons.code, color: colors.primary),
-                  title: Text(l10n.sourceCode),
-                  subtitle: const Text('github.com/grunch/choke'),
-                  trailing: const Icon(Icons.open_in_new, size: 16),
-                  onTap: () => launchUrl(
-                    Uri.parse('https://github.com/grunch/choke'),
-                    mode: LaunchMode.externalApplication,
-                  ),
-                ),
-                const Divider(height: 1),
-                ListTile(
-                  leading: Icon(Icons.description, color: colors.primary),
-                  title: Text(l10n.licenseLabel),
-                  subtitle: Text(l10n.licenseSubtitle),
-                  trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-                  onTap: () => _showLicenseScreen(context),
-                ),
-              ],
+            const SizedBox(height: 18),
+
+            // About
+            _buildSectionTitle(context, l10n.sectionAbout, tk),
+            _buildListRow(
+              context: context,
+              tk: tk,
+              icon: Icons.code,
+              title: l10n.sourceCode,
+              subtitle: 'github.com/grunch/choke',
+              trailingIcon: Icons.open_in_new,
+              onTap: () => launchUrl(
+                Uri.parse('https://github.com/grunch/choke'),
+                mode: LaunchMode.externalApplication,
+              ),
             ),
-          ),
-          const SizedBox(height: 32),
-          // Built by Pana footer
-          Consumer(
-            builder: (context, ref, child) {
-              final packageInfo = ref.watch(packageInfoProvider);
-              final versionText = packageInfo.when(
-                data: (info) => 'v${info.version}',
-                loading: () => '...',
-                error: (error, stackTrace) {
-                  debugPrint('Failed to load package info: $error');
-                  return '—';
-                },
-              );
-              return Center(
-                child: Column(
-                  children: [
-                    const Text(
-                      '⬛⬛⬛🟥⬛',
-                      style: TextStyle(fontSize: 12, letterSpacing: 2),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      l10n.builtBy('Pana'),
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colors.onSurface.withValues(alpha: 0.5),
+            const SizedBox(height: 8),
+            _buildListRow(
+              context: context,
+              tk: tk,
+              icon: Icons.description_outlined,
+              title: l10n.licenseLabel,
+              subtitle: l10n.licenseSubtitle,
+              onTap: () => _showLicenseScreen(context),
+            ),
+            const SizedBox(height: 32),
+
+            // Built by Pana footer
+            Consumer(
+              builder: (context, ref, child) {
+                final packageInfo = ref.watch(packageInfoProvider);
+                final versionText = packageInfo.when(
+                  data: (info) => 'v${info.version}',
+                  loading: () => '...',
+                  error: (error, stackTrace) {
+                    debugPrint('Failed to load package info: $error');
+                    return '—';
+                  },
+                );
+                return Center(
+                  child: Column(
+                    children: [
+                      const Text(
+                        '⬛⬛⬛🟥⬛',
+                        style: TextStyle(fontSize: 12, letterSpacing: 2),
                       ),
+                      const SizedBox(height: 4),
+                      Text(
+                        l10n.builtBy('Pana'),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colors.onSurface.withValues(alpha: 0.5),
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        versionText,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colors.onSurface.withValues(alpha: 0.35),
+                          fontSize: 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIconTile(ChokeTokens tk, IconData icon) {
+    return Container(
+      width: 36,
+      height: 36,
+      decoration: BoxDecoration(
+        color: tk.accent.withOpacity(.14),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Icon(icon, color: tk.accent, size: 20),
+    );
+  }
+
+  Widget _buildListRow({
+    required BuildContext context,
+    required ChokeTokens tk,
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    TextStyle? subtitleStyle,
+    IconData trailingIcon = Icons.chevron_right,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(15),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 13),
+        decoration: BoxDecoration(
+          color: tk.card,
+          borderRadius: BorderRadius.circular(15),
+          border: Border.all(color: tk.cardBorder),
+        ),
+        child: Row(
+          children: [
+            _buildIconTile(tk, icon),
+            const SizedBox(width: 13),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
                     ),
-                    const SizedBox(height: 2),
-                    Text(
-                      versionText,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: colors.onSurface.withValues(alpha: 0.35),
-                        fontSize: 11,
+                  ),
+                  const SizedBox(height: 1),
+                  Text(
+                    subtitle,
+                    style: subtitleStyle ??
+                        TextStyle(fontSize: 12.5, color: tk.muted),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            Icon(trailingIcon, color: tk.faint, size: 19),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Custom 3-segment theme selector — always a single line
+  Widget _buildThemeSegments(
+    BuildContext context,
+    WidgetRef ref,
+    ThemeMode current,
+    ChokeTokens tk,
+  ) {
+    final l10n = AppLocalizations.of(context);
+    final segments = [
+      (ThemeMode.system, Icons.brightness_auto_outlined, l10n.systemDefault),
+      (ThemeMode.dark, Icons.dark_mode_outlined, l10n.dark),
+      (ThemeMode.light, Icons.light_mode_outlined, l10n.light),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: tk.field,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: tk.cardBorder),
+      ),
+      child: Row(
+        children: segments.map((seg) {
+          final (mode, icon, label) = seg;
+          final isSelected = current == mode;
+          return Expanded(
+            child: GestureDetector(
+              onTap: () =>
+                  ref.read(themeModeProvider.notifier).setThemeMode(mode),
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 9),
+                margin: const EdgeInsets.symmetric(horizontal: 2),
+                decoration: BoxDecoration(
+                  gradient: isSelected ? tk.gradient : null,
+                  borderRadius: BorderRadius.circular(9),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      isSelected ? Icons.check : icon,
+                      size: 15,
+                      color: isSelected ? tk.onGrad : tk.muted,
+                    ),
+                    const SizedBox(width: 6),
+                    Flexible(
+                      child: FittedBox(
+                        fit: BoxFit.scaleDown,
+                        child: Text(
+                          label,
+                          maxLines: 1,
+                          style: TextStyle(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: isSelected ? tk.onGrad : tk.muted,
+                          ),
+                        ),
                       ),
                     ),
                   ],
                 ),
-              );
-            },
-          ),
-          const SizedBox(height: 24),
-        ],
+              ),
+            ),
+          );
+        }).toList(),
       ),
     );
   }
@@ -338,14 +468,18 @@ class SettingsScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildSectionTitle(BuildContext context, String title) {
+  Widget _buildSectionTitle(
+      BuildContext context, String title, ChokeTokens tk) {
     return Padding(
-      padding: const EdgeInsets.only(left: 16, bottom: 8),
+      padding: const EdgeInsets.only(left: 2, bottom: 9),
       child: Text(
         title.toUpperCase(),
-        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-              letterSpacing: 1.5,
-            ),
+        style: TextStyle(
+          color: tk.sectionTint,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 1.4,
+        ),
       ),
     );
   }

--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -38,6 +38,10 @@ class BJJColors {
   /// Text/icon color on top of the green gradient
   static const Color onGreenGrad = Color(0xFF062012);
 
+  /// Brand mark gradient (home logo, account identity avatar)
+  static const Color brandGradStart = Color(0xFF17B85A);
+  static const Color brandGradEnd = Color(0xFFC6E23F);
+
   // Championship Gold - The Achievement
   /// Bold gold representing achievement, excellence, and championship spirit.
   /// Usage: Accents, badges, awards, special highlights

--- a/lib/shared/theme/app_theme.dart
+++ b/lib/shared/theme/app_theme.dart
@@ -12,6 +12,16 @@ class BJJColors {
   static const Color navy = Color(0xFF121A2E);
   static const Color navyDark = Color(0xFF0D1117);
 
+  // Refreshed dark palette (design turn 2)
+  /// App background in dark mode
+  static const Color ink = Color(0xFF090E1A);
+
+  /// Card surface in dark mode
+  static const Color inkCard = Color(0xFF111A2C);
+
+  /// Inner field surface in dark mode (inputs, segmented tracks)
+  static const Color inkField = Color(0xFF0B1322);
+
   // BJJ Green - The Growth
   /// Vibrant green symbolizing growth, progress, and the journey through belt ranks.
   /// Usage: Primary actions, CTAs, success states, highlights
@@ -19,12 +29,24 @@ class BJJColors {
   static const Color greenLight = Color(0xFF2DC45C);
   static const Color greenDark = Color(0xFF15823E);
 
+  /// Bright accent green from the refreshed dark design
+  static const Color greenBright = Color(0xFF2FD46C);
+
+  /// Bottom stop of the primary button gradient
+  static const Color greenGradEnd = Color(0xFF1CA653);
+
+  /// Text/icon color on top of the green gradient
+  static const Color onGreenGrad = Color(0xFF062012);
+
   // Championship Gold - The Achievement
   /// Bold gold representing achievement, excellence, and championship spirit.
   /// Usage: Accents, badges, awards, special highlights
   static const Color gold = Color(0xFFF5B800);
   static const Color goldLight = Color(0xFFFFCC33);
   static const Color goldDark = Color(0xFFC49400);
+
+  /// Refreshed gold accent from the design
+  static const Color goldBright = Color(0xFFF5C518);
 
   // Pure White - The Clarity
   /// Clean white for clarity, purity, and the traditional white gi.
@@ -42,6 +64,9 @@ class BJJColors {
   static const Color warning = gold;
   static const Color success = green;
   static const Color info = Color(0xFF2196F3);
+
+  /// Refreshed red accent from the design
+  static const Color redBright = Color(0xFFF0554E);
 
   // Extended palette for fighter color selection
   static const Color red = Color(0xFFD32F2F);
@@ -62,108 +87,296 @@ class BJJColors {
   ];
 }
 
+/// Design tokens from the refreshed design (turn 2), themed for both
+/// light and dark mode. Access via [ChokeTokens.of].
+class ChokeTokens extends ThemeExtension<ChokeTokens> {
+  /// Card surface color
+  final Color card;
+
+  /// Subtle card border
+  final Color cardBorder;
+
+  /// Inner field surface (inputs, segmented tracks) — darker than card
+  final Color field;
+
+  /// Secondary text
+  final Color muted;
+
+  /// Tertiary/faint text
+  final Color faint;
+
+  /// Bright accent (green)
+  final Color accent;
+
+  /// Section title tint (Ajustes-style headers)
+  final Color sectionTint;
+
+  /// Primary button gradient stops
+  final Color gradTop;
+  final Color gradBottom;
+
+  /// Foreground on the gradient
+  final Color onGrad;
+
+  /// "Finalizado" status chip
+  final Color statusFinishedFg;
+  final Color statusFinishedBg;
+
+  /// "Cancelado" status chip
+  final Color statusCanceledFg;
+  final Color statusCanceledBg;
+
+  /// Gold accent readable on this theme's card
+  final Color goldFg;
+
+  /// Danger/red accent readable on this theme's card
+  final Color dangerFg;
+
+  const ChokeTokens({
+    required this.card,
+    required this.cardBorder,
+    required this.field,
+    required this.muted,
+    required this.faint,
+    required this.accent,
+    required this.sectionTint,
+    required this.gradTop,
+    required this.gradBottom,
+    required this.onGrad,
+    required this.statusFinishedFg,
+    required this.statusFinishedBg,
+    required this.statusCanceledFg,
+    required this.statusCanceledBg,
+    required this.goldFg,
+    required this.dangerFg,
+  });
+
+  /// Primary button gradient
+  LinearGradient get gradient => LinearGradient(
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+        colors: [gradTop, gradBottom],
+      );
+
+  static ChokeTokens of(BuildContext context) {
+    final theme = Theme.of(context);
+    return theme.extension<ChokeTokens>() ??
+        (theme.brightness == Brightness.dark ? dark : light);
+  }
+
+  static const dark = ChokeTokens(
+    card: BJJColors.inkCard,
+    cardBorder: Color(0x0FFFFFFF),
+    field: BJJColors.inkField,
+    muted: Color(0x80E8EEF7),
+    faint: Color(0x73E8EEF7),
+    accent: BJJColors.greenBright,
+    sectionTint: Color(0xFF4FCF83),
+    gradTop: BJJColors.greenBright,
+    gradBottom: BJJColors.greenGradEnd,
+    onGrad: BJJColors.onGreenGrad,
+    statusFinishedFg: Color(0xFF7FB0FF),
+    statusFinishedBg: Color(0x264C8DFF),
+    statusCanceledFg: Color(0xFFF0817B),
+    statusCanceledBg: Color(0x26F0554E),
+    goldFg: BJJColors.goldBright,
+    dangerFg: BJJColors.redBright,
+  );
+
+  static const light = ChokeTokens(
+    card: BJJColors.white,
+    cardBorder: Color(0x14121A2E),
+    field: Color(0xFFEDF1F6),
+    muted: Color(0x99121A2E),
+    faint: Color(0x6B121A2E),
+    accent: Color(0xFF17A254),
+    sectionTint: Color(0xFF148746),
+    gradTop: BJJColors.greenBright,
+    gradBottom: BJJColors.greenGradEnd,
+    onGrad: BJJColors.onGreenGrad,
+    statusFinishedFg: Color(0xFF3466CC),
+    statusFinishedBg: Color(0x244C8DFF),
+    statusCanceledFg: Color(0xFFC2423B),
+    statusCanceledBg: Color(0x1FF0554E),
+    goldFg: Color(0xFFA07E00),
+    dangerFg: Color(0xFFC2423B),
+  );
+
+  @override
+  ChokeTokens copyWith({
+    Color? card,
+    Color? cardBorder,
+    Color? field,
+    Color? muted,
+    Color? faint,
+    Color? accent,
+    Color? sectionTint,
+    Color? gradTop,
+    Color? gradBottom,
+    Color? onGrad,
+    Color? statusFinishedFg,
+    Color? statusFinishedBg,
+    Color? statusCanceledFg,
+    Color? statusCanceledBg,
+    Color? goldFg,
+    Color? dangerFg,
+  }) {
+    return ChokeTokens(
+      card: card ?? this.card,
+      cardBorder: cardBorder ?? this.cardBorder,
+      field: field ?? this.field,
+      muted: muted ?? this.muted,
+      faint: faint ?? this.faint,
+      accent: accent ?? this.accent,
+      sectionTint: sectionTint ?? this.sectionTint,
+      gradTop: gradTop ?? this.gradTop,
+      gradBottom: gradBottom ?? this.gradBottom,
+      onGrad: onGrad ?? this.onGrad,
+      statusFinishedFg: statusFinishedFg ?? this.statusFinishedFg,
+      statusFinishedBg: statusFinishedBg ?? this.statusFinishedBg,
+      statusCanceledFg: statusCanceledFg ?? this.statusCanceledFg,
+      statusCanceledBg: statusCanceledBg ?? this.statusCanceledBg,
+      goldFg: goldFg ?? this.goldFg,
+      dangerFg: dangerFg ?? this.dangerFg,
+    );
+  }
+
+  @override
+  ChokeTokens lerp(ThemeExtension<ChokeTokens>? other, double t) {
+    if (other is! ChokeTokens) return this;
+    return ChokeTokens(
+      card: Color.lerp(card, other.card, t)!,
+      cardBorder: Color.lerp(cardBorder, other.cardBorder, t)!,
+      field: Color.lerp(field, other.field, t)!,
+      muted: Color.lerp(muted, other.muted, t)!,
+      faint: Color.lerp(faint, other.faint, t)!,
+      accent: Color.lerp(accent, other.accent, t)!,
+      sectionTint: Color.lerp(sectionTint, other.sectionTint, t)!,
+      gradTop: Color.lerp(gradTop, other.gradTop, t)!,
+      gradBottom: Color.lerp(gradBottom, other.gradBottom, t)!,
+      onGrad: Color.lerp(onGrad, other.onGrad, t)!,
+      statusFinishedFg:
+          Color.lerp(statusFinishedFg, other.statusFinishedFg, t)!,
+      statusFinishedBg:
+          Color.lerp(statusFinishedBg, other.statusFinishedBg, t)!,
+      statusCanceledFg:
+          Color.lerp(statusCanceledFg, other.statusCanceledFg, t)!,
+      statusCanceledBg:
+          Color.lerp(statusCanceledBg, other.statusCanceledBg, t)!,
+      goldFg: Color.lerp(goldFg, other.goldFg, t)!,
+      dangerFg: Color.lerp(dangerFg, other.dangerFg, t)!,
+    );
+  }
+}
+
 /// App Theme Configuration
 class AppTheme {
   static ThemeData get darkTheme {
     return ThemeData(
       useMaterial3: true,
       brightness: Brightness.dark,
-      scaffoldBackgroundColor: BJJColors.navy,
+      scaffoldBackgroundColor: BJJColors.ink,
+      extensions: const [ChokeTokens.dark],
       colorScheme: const ColorScheme.dark(
-        primary: BJJColors.green,
-        onPrimary: BJJColors.white,
-        secondary: BJJColors.gold,
+        primary: BJJColors.greenBright,
+        onPrimary: BJJColors.onGreenGrad,
+        secondary: BJJColors.goldBright,
         onSecondary: BJJColors.navy,
-        surface: BJJColors.navyDark,
-        onSurface: BJJColors.white,
-        error: BJJColors.error,
+        surface: BJJColors.inkCard,
+        onSurface: Color(0xFFE8EEF7),
+        error: BJJColors.redBright,
         onError: BJJColors.white,
       ),
       appBarTheme: const AppBarTheme(
-        backgroundColor: BJJColors.navy,
-        foregroundColor: BJJColors.white,
+        backgroundColor: BJJColors.ink,
+        foregroundColor: Color(0xFFE8EEF7),
         elevation: 0,
         centerTitle: true,
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: BJJColors.green,
-          foregroundColor: BJJColors.white,
+          backgroundColor: BJJColors.greenBright,
+          foregroundColor: BJJColors.onGreenGrad,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: BJJColors.green,
-          side: const BorderSide(color: BJJColors.green, width: 2),
+          foregroundColor: BJJColors.greenBright,
+          side: const BorderSide(color: BJJColors.greenBright, width: 2),
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
       ),
       textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(foregroundColor: BJJColors.gold),
+        style: TextButton.styleFrom(foregroundColor: BJJColors.goldBright),
       ),
       cardTheme: CardThemeData(
-        color: BJJColors.navyDark,
-        elevation: 4,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        color: BJJColors.inkCard,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(15),
+          side: const BorderSide(color: Color(0x0FFFFFFF)),
+        ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: BJJColors.navyDark,
+        fillColor: BJJColors.inkField,
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: const BorderSide(color: BJJColors.greyDark),
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: Color(0x14FFFFFF)),
         ),
         enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: const BorderSide(color: BJJColors.greyDark),
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: Color(0x14FFFFFF)),
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: const BorderSide(color: BJJColors.green, width: 2),
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: BJJColors.greenBright, width: 2),
         ),
         labelStyle: const TextStyle(color: BJJColors.grey),
-        hintStyle: const TextStyle(color: BJJColors.greyDark),
+        hintStyle: const TextStyle(color: Color(0x66E8EEF7)),
       ),
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: BJJColors.navy,
-        selectedItemColor: BJJColors.green,
-        unselectedItemColor: BJJColors.grey,
+        backgroundColor: BJJColors.inkField,
+        selectedItemColor: BJJColors.greenBright,
+        unselectedItemColor: Color(0x8CE8EEF7),
         type: BottomNavigationBarType.fixed,
       ),
       floatingActionButtonTheme: const FloatingActionButtonThemeData(
-        backgroundColor: BJJColors.gold,
-        foregroundColor: BJJColors.navy,
+        backgroundColor: BJJColors.greenBright,
+        foregroundColor: BJJColors.onGreenGrad,
       ),
       textTheme: const TextTheme(
         headlineLarge: TextStyle(
           fontSize: 32,
           fontWeight: FontWeight.bold,
-          color: BJJColors.white,
+          color: Color(0xFFE8EEF7),
         ),
         headlineMedium: TextStyle(
           fontSize: 24,
           fontWeight: FontWeight.bold,
-          color: BJJColors.white,
+          color: Color(0xFFE8EEF7),
         ),
         headlineSmall: TextStyle(
           fontSize: 20,
           fontWeight: FontWeight.w600,
-          color: BJJColors.white,
+          color: Color(0xFFE8EEF7),
         ),
         titleLarge: TextStyle(
           fontSize: 18,
           fontWeight: FontWeight.w600,
-          color: BJJColors.white,
+          color: Color(0xFFE8EEF7),
         ),
-        bodyLarge: TextStyle(fontSize: 16, color: BJJColors.white),
-        bodyMedium: TextStyle(fontSize: 14, color: BJJColors.greyLight),
+        bodyLarge: TextStyle(fontSize: 16, color: Color(0xFFE8EEF7)),
+        bodyMedium: TextStyle(fontSize: 14, color: Color(0xB3E8EEF7)),
         labelLarge: TextStyle(
           fontSize: 14,
           fontWeight: FontWeight.w600,
-          color: BJJColors.green,
+          color: BJJColors.greenBright,
         ),
       ),
     );
@@ -174,7 +387,8 @@ class AppTheme {
     return ThemeData(
       useMaterial3: true,
       brightness: Brightness.light,
-      scaffoldBackgroundColor: BJJColors.offWhite,
+      scaffoldBackgroundColor: const Color(0xFFF3F5F8),
+      extensions: const [ChokeTokens.light],
       colorScheme: const ColorScheme.light(
         primary: BJJColors.green,
         onPrimary: BJJColors.white,
@@ -186,7 +400,7 @@ class AppTheme {
         onError: BJJColors.white,
       ),
       appBarTheme: const AppBarTheme(
-        backgroundColor: BJJColors.white,
+        backgroundColor: Color(0xFFF3F5F8),
         foregroundColor: BJJColors.navy,
         elevation: 0,
         centerTitle: true,
@@ -196,7 +410,8 @@ class AppTheme {
           backgroundColor: BJJColors.green,
           foregroundColor: BJJColors.white,
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
@@ -204,7 +419,8 @@ class AppTheme {
           foregroundColor: BJJColors.green,
           side: const BorderSide(color: BJJColors.green, width: 2),
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
       ),
       textButtonTheme: TextButtonThemeData(
@@ -212,26 +428,29 @@ class AppTheme {
       ),
       cardTheme: CardThemeData(
         color: BJJColors.white,
-        elevation: 2,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(15),
+          side: const BorderSide(color: Color(0x14121A2E)),
+        ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: BJJColors.offWhite,
+        fillColor: const Color(0xFFEDF1F6),
         border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: const BorderSide(color: BJJColors.greyLight),
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: Color(0x1F121A2E)),
         ),
         enabledBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
-          borderSide: const BorderSide(color: BJJColors.greyLight),
+          borderRadius: BorderRadius.circular(11),
+          borderSide: const BorderSide(color: Color(0x1F121A2E)),
         ),
         focusedBorder: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(11),
           borderSide: const BorderSide(color: BJJColors.green, width: 2),
         ),
         labelStyle: const TextStyle(color: BJJColors.grey),
-        hintStyle: const TextStyle(color: BJJColors.greyLight),
+        hintStyle: const TextStyle(color: Color(0x66121A2E)),
       ),
       bottomNavigationBarTheme: const BottomNavigationBarThemeData(
         backgroundColor: BJJColors.white,
@@ -240,8 +459,8 @@ class AppTheme {
         type: BottomNavigationBarType.fixed,
       ),
       floatingActionButtonTheme: const FloatingActionButtonThemeData(
-        backgroundColor: BJJColors.gold,
-        foregroundColor: BJJColors.navy,
+        backgroundColor: BJJColors.green,
+        foregroundColor: BJJColors.white,
       ),
       textTheme: const TextTheme(
         headlineLarge: TextStyle(
@@ -265,11 +484,11 @@ class AppTheme {
           color: BJJColors.navy,
         ),
         bodyLarge: TextStyle(fontSize: 16, color: BJJColors.navy),
-        bodyMedium: TextStyle(fontSize: 14, color: BJJColors.greyDark),
+        bodyMedium: TextStyle(fontSize: 14, color: Color(0xB3121A2E)),
         labelLarge: TextStyle(
           fontSize: 14,
           fontWeight: FontWeight.w600,
-          color: BJJColors.green,
+          color: Color(0xFF148746),
         ),
       ),
     );


### PR DESCRIPTION
## Resumen

Aplica el rediseño **turn 2** del proyecto de diseño *Anotación BJJ* a las 4 pantallas principales (Inicio 2a, Nuevo combate 2c, Cuenta 2e, Ajustes 2g), manteniendo **toda** la funcionalidad existente y el soporte de **tema claro y oscuro**.

## Cambios

### Tema (`app_theme.dart`)
- Nueva extensión `ChokeTokens` (ThemeExtension) con los tokens del diseño — tarjeta, campo interior, bordes sutiles, textos muted/faint, acento verde, gradiente de botones, chips de estado Finalizado/Cancelado, dorado y rojo — **con variantes calibradas para claro y oscuro**.
- Dark ColorScheme refrescado: fondo ink `#090E1A`, tarjetas `#111A2C`, verde brillante `#2FD46C` con texto oscuro sobre gradiente.
- `ChokeTokens.of` cae por brillo cuando la extensión no está registrada (mantiene compatibles los widget tests con temas planos).

### Pantallas
- **Inicio (2a)** — header con marca, chips de filtro con conteo por estado (multi-select conservado), tarjetas rediseñadas: en curso resaltada con gradiente+borde verde, canceladas atenuadas, puntaje líder en acento, badges A:/P: junto al nombre; FAB gradiente con glow.
- **Nuevo combate (2c)** — tarjeta por luchador (nombre + puntos de color 26px, borde en el color elegido), círculo VS entre ambas, duración en una fila desplazable, CTA fija abajo con gradiente. Validación intacta.
- **Cuenta (2e)** — cabecera de identidad, NPUB (mono acento + Copiar/Mostrar QR lado a lado) y NSEC (tarjeta de peligro, campo oculto con ojo) diferenciados, consejos con tiles de iconos de colores. Import/QR/copy intactos.
- **Ajustes (2g)** — títulos de sección teñidos, filas con tile de icono + chevron, y **selector de tema reconstruido: 3 segmentos que siempre caben en una línea** (arregla el SegmentedButton que se envolvía). Footer "Built by Pana" intacto.

## Pruebas y verificación

- `flutter test`: **62/62 en verde** (incluye el test existente del footer de Ajustes).
- `flutter analyze`: sin issues nuevos (solo infos `withOpacity` consistentes con el codebase).
- **Verificación visual real en ambos temas**: build web release servida estática y capturada con Chromium headless vía CDP emulando `prefers-color-scheme` dark/light — las 4 pantallas renderizan correctamente en oscuro y en claro (contraste OK, selector de tema en una línea, sin overflows).

## Test plan

- [ ] Inicio: chips filtran y muestran conteos; tarjeta "En curso" resaltada
- [ ] Nuevo combate: crear con nombres/colores/duración funciona igual que antes
- [ ] Cuenta: copiar npub, QR, revelar nsec e importar clave funcionan
- [ ] Ajustes: cambiar tema (Sistema/Oscuro/Claro) — el selector no se rompe en ningún idioma
- [ ] Revisar todas las pantallas en tema claro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed account, home, match creation, and settings screens with a more consistent visual design.
  * Improved match cards with clearer status indicators, fighter colors, scores, and match statistics.
  * Added match status counts and redesigned filtering controls.
  * Streamlined match creation with fighter cards, color selectors, duration options, and a prominent create action.
  * Updated account key actions, security tips, and private-key reveal styling.
  * Reworked settings navigation, appearance selection, language, match, and about sections.
  * Refined light and dark themes with updated colors, gradients, controls, and layout styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->