### PR TITLE
Vista de solo lectura para luchas finalizadas o canceladas

### DIFF
--- a/lib/features/match/match_control_screen.dart
+++ b/lib/features/match/match_control_screen.dart
@@ -111,8 +111,6 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
                     ),
                   ),
                   if (state.isWaiting) _buildWaitingOverlay(context, notifier),
-                  if (state.isFinished)
-                    _buildFinishedOverlay(context, state, f1Color, f2Color),
                 ],
               );
             },
@@ -485,6 +483,10 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
     final l10n = AppLocalizations.of(context);
     final colors = Theme.of(context).colorScheme;
 
+    // A finished or canceled match is read-only: replace the scoring controls
+    // with a status indicator instead of showing disabled buttons.
+    if (state.isFinished) return _buildReadOnlyFooter(context, state);
+
     return SizedBox(
       height: 44,
       child: Row(
@@ -590,50 +592,46 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
     );
   }
 
-  Widget _buildFinishedOverlay(
-    BuildContext context,
-    MatchControlState state,
-    Color f1Color,
-    Color f2Color,
-  ) {
+  /// Read-only footer shown in place of the scoring controls once a match is
+  /// finished or canceled. The match detail stays fully visible above it.
+  Widget _buildReadOnlyFooter(BuildContext context, MatchControlState state) {
     final l10n = AppLocalizations.of(context);
-    final colors = Theme.of(context).colorScheme;
-    final match = state.match;
+    final finished = state.match.status == MatchStatus.finished;
+    final accent = finished ? BJJColors.info : BJJColors.error;
+    final label = finished ? l10n.matchFinished : l10n.matchCanceled;
 
-    return _overlay(
-      context,
-      children: [
-        Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
+    return SizedBox(
+      height: 44,
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: accent.withOpacity(.12),
+            borderRadius: BorderRadius.circular(99),
+            border: Border.all(color: accent.withOpacity(.4)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                match.status == MatchStatus.finished
-                    ? l10n.matchFinished
-                    : l10n.matchCanceled,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
-                ),
+              Icon(
+                finished ? Icons.emoji_events_outlined : Icons.cancel_outlined,
+                size: 16,
+                color: accent,
               ),
-              const SizedBox(height: 10),
+              const SizedBox(width: 8),
               Text(
-                '${match.f1Name} ${match.f1Score} — '
-                '${match.f2Score} ${match.f2Name}',
+                '$label · ${l10n.matchReadOnly}',
                 style: TextStyle(
-                  fontSize: 14,
-                  color: colors.onSurface.withOpacity(.6),
+                  color: accent,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: .5,
                 ),
-              ),
-              const SizedBox(height: 18),
-              OutlinedButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: Text(l10n.goBack),
               ),
             ],
           ),
         ),
-      ],
+      ),
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -314,6 +314,10 @@
   "@matchCanceled": {
     "description": "Status text when match is canceled"
   },
+  "matchReadOnly": "View only",
+  "@matchReadOnly": {
+    "description": "Read-only indicator shown when viewing a finished or canceled match"
+  },
   "finishMatchQuestion": "Finish Match?",
   "@finishMatchQuestion": {
     "description": "Finish match dialog title"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -76,6 +76,7 @@
   "holdHint": "mantener",
   "matchFinished": "Lucha finalizada",
   "matchCanceled": "Lucha cancelada",
+  "matchReadOnly": "Solo lectura",
   "finishMatchQuestion": "¿Finalizar lucha?",
   "finishMatchDescription": "Esto finalizará la lucha y publicará el puntaje final.",
   "cancelMatchQuestion": "¿Cancelar lucha?",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -76,6 +76,7 @@
   "holdHint": "長押し",
   "matchFinished": "試合終了",
   "matchCanceled": "試合キャンセル",
+  "matchReadOnly": "閲覧のみ",
   "finishMatchQuestion": "試合を終了しますか？",
   "finishMatchDescription": "試合が終了し、最終スコアが公開されます。",
   "cancelMatchQuestion": "試合をキャンセルしますか？",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -76,6 +76,7 @@
   "holdHint": "segurar",
   "matchFinished": "Luta finalizada",
   "matchCanceled": "Luta cancelada",
+  "matchReadOnly": "Somente leitura",
   "finishMatchQuestion": "Finalizar luta?",
   "finishMatchDescription": "Isso encerrará a luta e publicará a pontuação final.",
   "cancelMatchQuestion": "Cancelar luta?",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -558,6 +558,12 @@ abstract class AppLocalizations {
   /// **'Match Canceled'**
   String get matchCanceled;
 
+  /// Read-only indicator shown when viewing a finished or canceled match
+  ///
+  /// In en, this message translates to:
+  /// **'View only'**
+  String get matchReadOnly;
+
   /// Finish match dialog title
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -249,6 +249,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get matchCanceled => 'Match Canceled';
 
   @override
+  String get matchReadOnly => 'View only';
+
+  @override
   String get finishMatchQuestion => 'Finish Match?';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -251,6 +251,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get matchCanceled => 'Lucha cancelada';
 
   @override
+  String get matchReadOnly => 'Solo lectura';
+
+  @override
   String get finishMatchQuestion => '¿Finalizar lucha?';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -241,6 +241,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get matchCanceled => '試合キャンセル';
 
   @override
+  String get matchReadOnly => '閲覧のみ';
+
+  @override
   String get finishMatchQuestion => '試合を終了しますか？';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -250,6 +250,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get matchCanceled => 'Luta cancelada';
 
   @override
+  String get matchReadOnly => 'Somente leitura';
+
+  @override
   String get finishMatchQuestion => 'Finalizar luta?';
 
   @override

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -122,7 +122,10 @@ void main() {
 
     // Assert
     expect(notifier.state.match.status, MatchStatus.finished);
-    expect(find.text(l10n.matchFinished), findsOneWidget);
+    expect(
+      find.text('${l10n.matchFinished} · ${l10n.matchReadOnly}'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('waiting match shows start overlay', (tester) async {


### PR DESCRIPTION
## Problema

Al abrir una lucha ya **finalizada** (o **cancelada**), la app navegaba a la pantalla de la lucha pero dibujaba encima un overlay casi opaco (88%) que ocupaba toda la pantalla, tapando por completo el detalle (marcador, ventajas, penalidades).

## Cambios

- **Se elimina el overlay de pantalla completa** para luchas finalizadas/canceladas: el detalle queda totalmente visible.
- **Solo lectura garantizada**: los controles de puntuación ya estaban deshabilitados cuando la lucha no está en curso (`enabled: state.isRunning`, y el provider ignora cualquier acción si no está `inProgress`), así que no se puede modificar nada.
- **Footer de solo lectura**: en lugar de mostrar los botones deshabilitados (deshacer/finalizar/cancelar), el footer muestra una píldora indicadora — 🏆 *"Lucha finalizada · Solo lectura"* o ✕ *"Lucha cancelada · Solo lectura"* — con el color de estado correspondiente.
- El badge de estado en la cabecera (FINALIZADO/CANCELADO) y la flecha de volver siguen funcionando igual.
- Se añade la cadena localizada `matchReadOnly` ("Solo lectura") en los 4 idiomas (es/en/pt/ja), en los `.arb` fuente y en los archivos generados.

## Notas de verificación

En el entorno no había Flutter/Dart disponible, por lo que no se pudo ejecutar `flutter analyze` ni compilar. El cambio se revisó cuidadosamente a mano; conviene una compilación local antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oDf3WfqwVCLVboeDxftd4

---
_Generated by [Claude Code](https://claude.ai/code/session_018oDf3WfqwVCLVboeDxftd4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Finished or canceled matches now display a clear read-only status indicator.
  * Interactive match controls are replaced with a view-only footer after completion.
  * Added localized “View only” text in English, Spanish, Japanese, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->