### PR TITLE
fix: finalizar la lucha automáticamente cuando el reloj llega a cero

### DIFF
--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -67,9 +67,14 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
           match: match,
           remainingSeconds: _calculateRemaining(match),
         )) {
-    // If match is already in progress, resume timer
     if (match.status == MatchStatus.inProgress) {
-      _startTimer();
+      // The clock may have run out while the app was closed — a match is
+      // never left in progress past its own duration.
+      if (state.remainingSeconds <= 0) {
+        _finish();
+      } else {
+        _startTimer();
+      }
     }
   }
 
@@ -216,7 +221,9 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   }
 
   /// Finish the match
-  void finishMatch() {
+  void finishMatch() => _finish();
+
+  void _finish() {
     if (state.isFinished) return;
 
     _timer?.cancel();
@@ -241,8 +248,9 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
       final remaining = _calculateRemaining(state.match);
       state = state.copyWith(remainingSeconds: remaining);
 
+      // Regulation time is over: the match finishes on its own.
       if (remaining <= 0) {
-        _timer?.cancel();
+        _finish();
       }
     });
   }

--- a/test/features/match/providers/match_control_provider_test.dart
+++ b/test/features/match/providers/match_control_provider_test.dart
@@ -179,4 +179,77 @@ void main() {
       expect(nostr.publishCount, greaterThan(publishesBefore));
     });
   });
+
+  group('time expiry', () {
+    test('match finishes when the timer reaches zero', () async {
+      // Arrange — a running match with one second left on the clock
+      nostr = _FakeNostrService();
+      final almostOver = _runningMatch().copyWith(
+        duration: 1,
+        startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      notifier = MatchControlNotifier(almostOver, nostr);
+      expect(notifier.state.match.status, MatchStatus.inProgress);
+
+      // Act — let the clock run out
+      await Future<void>.delayed(const Duration(milliseconds: 1600));
+
+      // Assert
+      expect(notifier.state.remainingSeconds, 0);
+      expect(notifier.state.match.status, MatchStatus.finished);
+      expect(notifier.state.isRunning, isFalse);
+    });
+
+    test('reopening a match whose time already elapsed finishes it', () {
+      // Arrange — started 10 minutes ago with a 5 minute duration
+      nostr = _FakeNostrService();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final expired = _runningMatch().copyWith(
+        duration: 300,
+        startAt: now - 600,
+      );
+
+      // Act
+      notifier = MatchControlNotifier(expired, nostr);
+
+      // Assert
+      expect(notifier.state.remainingSeconds, 0);
+      expect(notifier.state.match.status, MatchStatus.finished);
+    });
+
+    test('expiring the clock publishes the finished match', () async {
+      // Arrange
+      nostr = _FakeNostrService();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final expired = _runningMatch().copyWith(
+        duration: 300,
+        startAt: now - 600,
+      );
+
+      // Act
+      notifier = MatchControlNotifier(expired, nostr);
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(nostr.publishCount, greaterThan(0));
+    });
+
+    test('a match finished by the clock keeps its score', () async {
+      // Arrange
+      nostr = _FakeNostrService();
+      final almostOver = _runningMatch().copyWith(
+        duration: 1,
+        startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      notifier = MatchControlNotifier(almostOver, nostr);
+      notifier.scorePt4(1);
+
+      // Act
+      await Future<void>.delayed(const Duration(milliseconds: 1600));
+
+      // Assert
+      expect(notifier.state.match.status, MatchStatus.finished);
+      expect(notifier.state.match.f1Score, 4);
+    });
+  });
 }


### PR DESCRIPTION
## Problema

Una lucha en curso seguía apareciendo como **En curso** después de que su temporizador llegara a 00:00. El timer periódico solo se cancelaba a sí mismo al llegar a cero (`match_control_provider.dart`) y nunca cambiaba el estado a `finished`, así que la lucha quedaba viva indefinidamente, con el reloj en cero.

## Solución

- Al agotarse el tiempo reglamentario, la lucha se finaliza por el mismo camino que la acción manual de mantener pulsado "Finalizar": el estado pasa a `finished` y se **publica a Nostr**, de modo que la tarjeta en Inicio pasa a "Finalizado" sola, sin interacción.
- Se extrae un `_finish()` privado que comparten el fin manual y el fin por tiempo, para que ambos hagan exactamente lo mismo.
- Al **reabrir** una lucha cuyo tiempo ya venció (la app se cerró a mitad del combate), el provider la finaliza al construirse en vez de reanudar un temporizador muerto.
- El marcador se conserva íntegro al finalizar por tiempo.

## Tests

Cuatro tests de regresión nuevos en el grupo `time expiry`, escritos primero y confirmados en rojo antes del fix:

- la lucha se finaliza cuando el temporizador llega a cero
- reabrir una lucha cuyo tiempo ya venció la finaliza
- la expiración del reloj publica la lucha finalizada
- una lucha finalizada por el reloj conserva su marcador

## Plan de prueba

- [x] `flutter test` — 66/66 pasan (62 previos + 4 nuevos)
- [x] `flutter analyze` — sin errores nuevos
- [ ] Prueba manual: crear una lucha de 03:00, iniciarla y dejar correr el reloj hasta cero; verificar que pasa a "Finalizado" tanto en la pantalla de combate como en la lista de Inicio

## Limitación conocida

Si una lucha vence mientras la app está **cerrada**, la lista de Inicio la seguirá mostrando "En curso" hasta que se abra (ahí se auto-finaliza y se publica). Corregirlo requeriría que la pantalla de Inicio evalúe el reloj de cada lucha al cargar la lista; queda fuera del alcance de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xix4mqtxTXHaTXgwtxDbsn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matches that have already reached their time limit now finish immediately.
  * Running matches transition reliably to finished when the timer expires.
  * Existing scores are preserved when a match ends due to time expiration.
  * Match completion updates are published when the timer reaches zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->