### PR TITLE
fix: every relay converges to the latest match state

### DIFF
--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -74,12 +74,24 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   bool _sending = false;
   Timer? _retryTimer;
   int _retryAttempt = 0;
+  StreamSubscription<String>? _relayConnectedSub;
 
   MatchControlNotifier(Match match, this._nostrService, [this._feedNotifier])
       : super(MatchControlState(
           match: match,
           remainingSeconds: _calculateRemaining(match),
         )) {
+    // A relay that just (re)connected can take the pending state right now —
+    // waiting out a backoff scheduled against its dead predecessor would
+    // leave the remote board stale for up to 30 extra seconds.
+    _relayConnectedSub = _nostrService.onRelayConnected.listen((_) {
+      if (_outbox == null) return;
+      _retryTimer?.cancel();
+      _retryTimer = null;
+      _retryAttempt = 0;
+      _drainOutbox();
+    });
+
     if (match.status == MatchStatus.inProgress) {
       if (match.pausedAt != null) {
         // A paused clock stays paused, however long the app was away.
@@ -393,6 +405,7 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   void dispose() {
     _timer?.cancel();
     _retryTimer?.cancel();
+    _relayConnectedSub?.cancel();
     super.dispose();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,11 +76,41 @@ void main() async {
 /// Watches [localeProvider] and [themeModeProvider] to configure the app's
 /// locale and theme mode. Provides both light and dark themes, with the
 /// active mode determined by user preference or system setting.
-class ChokeApp extends ConsumerWidget {
+///
+/// Also watches the app lifecycle: relay sockets rarely survive
+/// backgrounding — the OS kills them without a close frame, leaving
+/// connections that look open but drop every event — so on resume all
+/// relay connections are recycled before the operator's next action.
+class ChokeApp extends ConsumerStatefulWidget {
   const ChokeApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ChokeApp> createState() => _ChokeAppState();
+}
+
+class _ChokeAppState extends ConsumerState<ChokeApp>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      ref.read(nostrServiceProvider).reconnectAll();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final locale = ref.watch(localeProvider);
     final themeMode = ref.watch(themeModeProvider);
 

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -112,26 +112,42 @@ class Filter {
   }
 }
 
+/// Creates the WebSocket for a relay connection; injectable for tests.
+typedef WebSocketChannelFactory = WebSocketChannel Function(Uri uri);
+
 /// Represents a Nostr relay connection
 class RelayConnection {
   final String url;
   bool isConnected = false;
   WebSocketChannel? _channel;
+  final WebSocketChannelFactory _channelFactory;
+
+  /// How long to wait for a relay's OK before declaring the socket dead.
+  final Duration okTimeout;
+
   final _messageController = StreamController<NostrEvent>.broadcast();
   final _connectionController = StreamController<bool>.broadcast();
   final _okController = StreamController<List<dynamic>>.broadcast();
   Timer? _reconnectTimer;
   final Set<String> _activeSubscriptions = {};
   final Map<String, Filter> _subscriptionFilters = {};
+  final Set<String> _awaitingOk = {};
 
-  RelayConnection(this.url);
+  /// Whether a publish of this event is already in flight on this relay.
+  bool isAwaitingOk(String eventId) => _awaitingOk.contains(eventId);
+
+  RelayConnection(
+    this.url, {
+    WebSocketChannelFactory? channelFactory,
+    this.okTimeout = const Duration(seconds: 10),
+  }) : _channelFactory = channelFactory ?? WebSocketChannel.connect;
 
   Stream<NostrEvent> get messageStream => _messageController.stream;
   Stream<bool> get connectionStream => _connectionController.stream;
 
   Future<void> connect() async {
     try {
-      _channel = WebSocketChannel.connect(Uri.parse(url));
+      _channel = _channelFactory(Uri.parse(url));
 
       // Wait for WebSocket handshake to complete with timeout
       await _channel!.ready.timeout(
@@ -261,20 +277,27 @@ class RelayConnection {
       if (!completer.isCompleted) completer.complete(msg);
     });
 
-    final timer = Timer(const Duration(seconds: 10), () {
+    final timer = Timer(okTimeout, () {
       if (!completer.isCompleted) {
         completer.completeError(
           TimeoutException('No OK response from $url for event ${event.id}'),
         );
+        // A relay that says nothing for this long is not slow — the socket
+        // died without a close frame (phone slept, network switched) and
+        // every write goes into a void while isConnected still reads true.
+        // Recycle the connection instead of feeding more events into it.
+        _handleDisconnect();
       }
     });
 
+    _awaitingOk.add(event.id);
     channel.sink.add(message);
 
     List<dynamic> okMsg;
     try {
       okMsg = await completer.future;
     } finally {
+      _awaitingOk.remove(event.id);
       timer.cancel();
       await subscription.cancel();
     }
@@ -284,6 +307,23 @@ class RelayConnection {
       debugPrint('NostrService: [$url] rejected event ${event.id}: $reason');
     }
     return accepted;
+  }
+
+  /// Tear down the socket — dead or alive — and connect a fresh one now.
+  ///
+  /// A socket killed while the app was backgrounded produces no close
+  /// event, so [isConnected] can lie until TCP gives up minutes later.
+  /// Callers that know the transport is suspect (app just resumed) use
+  /// this to skip that wait; subscriptions are re-established on connect.
+  Future<void> reconnectNow() async {
+    _reconnectTimer?.cancel();
+    if (isConnected) {
+      isConnected = false;
+      _connectionController.add(false);
+    }
+    _channel?.sink.close();
+    _channel = null;
+    await connect();
   }
 
   void disconnect() {
@@ -307,13 +347,41 @@ class NostrService {
   final KeyManager _keyManager;
   final Map<String, RelayConnection> _relays = {};
   final Map<String, StreamSubscription<NostrEvent>> _relaySubscriptions = {};
+  final Map<String, StreamSubscription<bool>> _connectionSubscriptions = {};
   final _eventController = StreamController<NostrEvent>.broadcast();
+  final _relayConnectedController = StreamController<String>.broadcast();
   final Map<String, NostrEvent> _addressableEvents = {};
   final Map<String, int> _lastCreatedAt = {};
 
-  NostrService(this._keyManager);
+  /// Latest signed event per d-tag that some relay has not accepted yet,
+  /// and the relay urls that already did. "One relay accepted" is enough
+  /// for the caller, but every configured relay must converge to the
+  /// latest state — stragglers are resent on reconnect and by [_resendTimer].
+  final Map<String, NostrEvent> _pendingLatest = {};
+  final Map<String, Set<String>> _pendingAcks = {};
+  Timer? _resendTimer;
+
+  /// How often relays that are connected but still missing the latest
+  /// event (e.g. they rejected it) are retried.
+  final Duration resendInterval;
+
+  final WebSocketChannelFactory? _channelFactory;
+  final Duration _okTimeout;
+
+  NostrService(
+    this._keyManager, {
+    WebSocketChannelFactory? channelFactory,
+    Duration okTimeout = const Duration(seconds: 10),
+    this.resendInterval = const Duration(seconds: 5),
+  })  : _channelFactory = channelFactory,
+        _okTimeout = okTimeout;
 
   Stream<NostrEvent> get eventStream => _eventController.stream;
+
+  /// Fires with the relay URL each time a relay (re)connects. Publishers
+  /// holding unconfirmed state listen to this to retry immediately instead
+  /// of waiting out a backoff against a relay that just came back.
+  Stream<String> get onRelayConnected => _relayConnectedController.stream;
 
   /// Connect to configured relays on app start
   Future<void> initialize({List<String>? relayUrls}) async {
@@ -334,7 +402,11 @@ class NostrService {
       return;
     }
 
-    final relay = RelayConnection(url);
+    final relay = RelayConnection(
+      url,
+      channelFactory: _channelFactory,
+      okTimeout: _okTimeout,
+    );
     _relays[url] = relay;
 
     // Listen to events from this relay and store subscription
@@ -343,17 +415,35 @@ class NostrService {
     });
     _relaySubscriptions[url] = subscription;
 
+    _connectionSubscriptions[url] = relay.connectionStream.listen((connected) {
+      if (!connected) return;
+      _relayConnectedController.add(url);
+      // A fresh socket may belong to a relay that missed events while it
+      // was down — bring it up to date right away.
+      _resendPendingTo(relay);
+    });
+
     await relay.connect();
   }
 
   /// Remove a relay
   void removeRelay(String url) {
-    // Cancel stream subscription to prevent memory leak
+    // Cancel stream subscriptions to prevent memory leaks
     final subscription = _relaySubscriptions.remove(url);
     subscription?.cancel();
+    final connectionSubscription = _connectionSubscriptions.remove(url);
+    connectionSubscription?.cancel();
 
     final relay = _relays.remove(url);
     relay?.dispose();
+  }
+
+  /// Recycle every relay connection with a fresh socket.
+  ///
+  /// Meant for app resume: the OS kills sockets in the background without a
+  /// close frame, so connections can look open while dropping every event.
+  Future<void> reconnectAll() async {
+    await Future.wait(_relays.values.map((relay) => relay.reconnectNow()));
   }
 
   /// Subscribe to kind 31415 events for the current user
@@ -441,13 +531,27 @@ class NostrService {
 
   /// Publish a signed event to all connected relays.
   /// Waits for OK confirmation from each relay.
+  ///
+  /// Succeeds when at least one relay accepts, but keeps working after
+  /// returning: relays that were down, timed out, or rejected the event are
+  /// resent the latest state per d-tag until every configured relay has it.
   Future<void> publishEvent(NostrEvent event) async {
+    final dTag = _dTagOf(event);
+    if (dTag != null) {
+      // This event supersedes whatever was pending for the match: relays
+      // that missed older states only ever need the newest one.
+      _pendingLatest[dTag] = event;
+      _pendingAcks[dTag] = <String>{};
+    }
+
     final connectedRelays = _relays.values.where((r) => r.isConnected).toList();
 
     debugPrint(
         'NostrService: publishing event ${event.id} (kind ${event.kind}, content ${event.content.length} chars) to ${connectedRelays.length} relays');
 
     if (connectedRelays.isEmpty) {
+      // Pending state stays registered: the reconnect listener delivers it
+      // as soon as any relay comes back.
       throw Exception('No connected relays');
     }
 
@@ -457,6 +561,7 @@ class NostrService {
         try {
           final accepted = await relay.publish(event);
           debugPrint('NostrService: [${relay.url}] accepted=$accepted');
+          if (accepted) _markAccepted(dTag, event, relay.url);
           return accepted;
         } catch (e) {
           debugPrint('NostrService: [${relay.url}] publish error: $e');
@@ -469,9 +574,70 @@ class NostrService {
     debugPrint(
         'NostrService: published to $successCount/${connectedRelays.length} relays');
 
+    _scheduleResendSweep();
+
     if (successCount == 0) {
       throw Exception('Event rejected by all relays');
     }
+  }
+
+  static String? _dTagOf(NostrEvent event) {
+    for (final tag in event.tags) {
+      if (tag.length >= 2 && tag[0] == 'd') return tag[1];
+    }
+    return null;
+  }
+
+  /// Record that [url] accepted [event]; forget the d-tag once every
+  /// configured relay has the latest state.
+  void _markAccepted(String? dTag, NostrEvent event, String url) {
+    if (dTag == null) return;
+    // A newer state may have superseded this event mid-flight; an ack for
+    // the old one says nothing about the state the relays must converge to.
+    if (!identical(_pendingLatest[dTag], event)) return;
+    final acked = _pendingAcks[dTag];
+    if (acked == null) return;
+    acked.add(url);
+    if (_relays.keys.every(acked.contains)) {
+      _pendingLatest.remove(dTag);
+      _pendingAcks.remove(dTag);
+    }
+  }
+
+  /// Send every pending latest event this relay has not accepted yet.
+  Future<void> _resendPendingTo(RelayConnection relay) async {
+    for (final dTag in _pendingLatest.keys.toList()) {
+      final event = _pendingLatest[dTag];
+      if (event == null) continue;
+      final acked = _pendingAcks[dTag];
+      if (acked == null || acked.contains(relay.url)) continue;
+      // The original publish may still be waiting on this relay's OK —
+      // don't race it with a duplicate frame for the same event.
+      if (relay.isAwaitingOk(event.id)) continue;
+      try {
+        final accepted = await relay.publish(event);
+        debugPrint(
+            'NostrService: resent ${event.id} to ${relay.url}, accepted=$accepted');
+        if (accepted) _markAccepted(dTag, event, relay.url);
+      } catch (e) {
+        debugPrint('NostrService: resend to ${relay.url} failed: $e');
+      }
+    }
+    _scheduleResendSweep();
+  }
+
+  /// While any relay is missing the latest state, keep a slow retry loop
+  /// alive for relays that are connected but rejected it (rate limits and
+  /// the like). Disconnected relays are handled by the reconnect listener.
+  void _scheduleResendSweep() {
+    if (_pendingLatest.isEmpty) return;
+    _resendTimer ??= Timer(resendInterval, () async {
+      _resendTimer = null;
+      for (final relay in _relays.values.where((r) => r.isConnected)) {
+        await _resendPendingTo(relay);
+      }
+      _scheduleResendSweep();
+    });
   }
 
   /// Create and publish a kind 31415 addressable event
@@ -563,9 +729,15 @@ class NostrService {
       subscription.cancel();
     }
     _relaySubscriptions.clear();
+    for (final subscription in _connectionSubscriptions.values) {
+      subscription.cancel();
+    }
+    _connectionSubscriptions.clear();
+    _resendTimer?.cancel();
 
     disconnect();
     _eventController.close();
+    _relayConnectedController.close();
   }
 }
 

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -131,10 +131,18 @@ class RelayConnection {
   Timer? _reconnectTimer;
   final Set<String> _activeSubscriptions = {};
   final Map<String, Filter> _subscriptionFilters = {};
-  final Set<String> _awaitingOk = {};
+
+  /// Publishes waiting for an OK on the *current* socket, by event id. A
+  /// socket swap fails them: the OK they wait for can never arrive.
+  final Map<String, Completer<List<dynamic>>> _inFlight = {};
+
+  /// Listener on the current socket. Held so it can be cancelled before a
+  /// new socket is installed — a stale `onDone` from the old one would
+  /// otherwise tear down its replacement.
+  StreamSubscription<dynamic>? _channelSub;
 
   /// Whether a publish of this event is already in flight on this relay.
-  bool isAwaitingOk(String eventId) => _awaitingOk.contains(eventId);
+  bool isAwaitingOk(String eventId) => _inFlight.containsKey(eventId);
 
   RelayConnection(
     this.url, {
@@ -161,7 +169,7 @@ class RelayConnection {
       _connectionController.add(true);
       debugPrint('NostrService: Connected to $url');
 
-      _channel!.stream.listen(
+      _channelSub = _channel!.stream.listen(
         (data) => _handleMessage(data),
         onError: (error) {
           debugPrint('NostrService: Error on $url: $error');
@@ -218,9 +226,28 @@ class RelayConnection {
     if (!isConnected) return;
     isConnected = false;
     _connectionController.add(false);
+    _teardownChannel();
+    _scheduleReconnect();
+  }
+
+  /// Detach from the current socket for good: stop listening (so its late
+  /// `onDone` cannot tear down whatever replaces it), close it, and fail
+  /// every publish still waiting on an OK it can no longer receive.
+  void _teardownChannel() {
+    _channelSub?.cancel();
+    _channelSub = null;
     _channel?.sink.close();
     _channel = null;
-    _scheduleReconnect();
+
+    final orphaned = List.of(_inFlight.values);
+    _inFlight.clear();
+    for (final completer in orphaned) {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          Exception('Connection to $url closed before the relay answered'),
+        );
+      }
+    }
   }
 
   void _scheduleReconnect() {
@@ -290,14 +317,16 @@ class RelayConnection {
       }
     });
 
-    _awaitingOk.add(event.id);
+    _inFlight[event.id] = completer;
     channel.sink.add(message);
 
     List<dynamic> okMsg;
     try {
       okMsg = await completer.future;
     } finally {
-      _awaitingOk.remove(event.id);
+      // A socket swap may already have dropped (and failed) this entry —
+      // only clear it if it is still the one this publish registered.
+      if (identical(_inFlight[event.id], completer)) _inFlight.remove(event.id);
       timer.cancel();
       await subscription.cancel();
     }
@@ -321,15 +350,14 @@ class RelayConnection {
       isConnected = false;
       _connectionController.add(false);
     }
-    _channel?.sink.close();
-    _channel = null;
+    _teardownChannel();
     await connect();
   }
 
   void disconnect() {
     _reconnectTimer?.cancel();
-    _channel?.sink.close();
     isConnected = false;
+    _teardownChannel();
   }
 
   void dispose() {

--- a/test/features/match/providers/match_control_provider_test.dart
+++ b/test/features/match/providers/match_control_provider_test.dart
@@ -18,6 +18,12 @@ class _FakeNostrService extends NostrService {
   int failuresRemaining = 0;
   Completer<void>? gate;
 
+  /// Lets tests simulate a relay (re)connecting.
+  final relayConnected = StreamController<String>.broadcast();
+
+  @override
+  Stream<String> get onRelayConnected => relayConnected.stream;
+
   Match get lastPublishedMatch =>
       Match.fromJsonString(publishedContents.last);
 
@@ -529,6 +535,41 @@ void main() {
 
       // Assert — publishes immediately with the combined state
       expect(nostr.lastPublishedMatch.f1Score, 5);
+    });
+
+    test('a pending state is published the moment a relay reconnects',
+        () async {
+      // Arrange — the relay is unreachable: the advantage fails to publish
+      // and sits in the outbox behind a backoff timer
+      nostr = _FakeNostrService()..failuresRemaining = 1;
+      notifier = MatchControlNotifier(_runningMatch(), nostr);
+      notifier.scoreAdv(1);
+      await Future<void>.delayed(Duration.zero);
+      expect(nostr.publishCount, 0, reason: 'publish must have failed');
+
+      // Act — the relay comes back before the backoff runs out
+      nostr.relayConnected.add('wss://relay.test');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Assert — the advantage lands right away, not seconds later
+      expect(nostr.publishCount, greaterThan(0));
+      expect(nostr.lastPublishedMatch.f1Adv, 1);
+    });
+
+    test('a reconnect with nothing pending publishes nothing', () async {
+      // Arrange — everything already confirmed
+      nostr = _FakeNostrService();
+      notifier = MatchControlNotifier(_runningMatch(), nostr);
+      notifier.scoreAdv(1);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      final publishesBefore = nostr.publishCount;
+
+      // Act
+      nostr.relayConnected.add('wss://relay.test');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Assert
+      expect(nostr.publishCount, publishesBefore);
     });
   });
 }

--- a/test/services/nostr/nostr_service_test.dart
+++ b/test/services/nostr/nostr_service_test.dart
@@ -104,14 +104,23 @@ void main() {
   });
 
   group('RelayConnection zombie detection', () {
-    late _FakeWebSocketChannel channel;
+    // Every connect() gets a brand-new socket, as it does in production —
+    // reusing one fake would let a reconnect silently listen to the old
+    // (single-subscription) stream and never exercise the reconnect path.
+    late List<_FakeWebSocketChannel> channels;
     late RelayConnection relay;
 
+    _FakeWebSocketChannel current() => channels.last;
+
     setUp(() async {
-      channel = _FakeWebSocketChannel();
+      channels = [];
       relay = RelayConnection(
         'wss://relay.test',
-        channelFactory: (_) => channel,
+        channelFactory: (_) {
+          final channel = _FakeWebSocketChannel();
+          channels.add(channel);
+          return channel;
+        },
         okTimeout: const Duration(milliseconds: 100),
       );
       await relay.connect();
@@ -126,12 +135,12 @@ void main() {
 
       // Act — the relay confirms the event
       final publishing = relay.publish(event);
-      channel.incoming.add(jsonEncode(['OK', 'e1', true, '']));
+      current().incoming.add(jsonEncode(['OK', 'e1', true, '']));
 
       // Assert
       expect(await publishing, isTrue);
       expect(relay.isConnected, isTrue);
-      expect(channel.sent, hasLength(1));
+      expect(current().sent, hasLength(1));
     });
 
     test('publish drops the connection when the relay never answers',
@@ -155,11 +164,48 @@ void main() {
         () async {
       // Arrange — the current socket may be a zombie after app resume
       expect(relay.isConnected, isTrue);
+      final old = current();
 
       // Act
       await relay.reconnectNow();
 
-      // Assert
+      // Assert — a genuinely new socket, and the connection is live on it
+      expect(channels, hasLength(2));
+      expect(current(), isNot(same(old)));
+      expect(relay.isConnected, isTrue);
+    });
+
+    test('a late close from the old socket does not kill the new connection',
+        () async {
+      // Arrange — the OS closes the backgrounded socket, but the close
+      // notification only lands after the app already reconnected
+      final old = current();
+      await relay.reconnectNow();
+      expect(relay.isConnected, isTrue);
+
+      // Act — the stale socket finally reports it is done
+      await old.incoming.close();
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert — the fresh socket must survive its predecessor's funeral
+      expect(relay.isConnected, isTrue);
+    });
+
+    test('reconnecting frees a publish that was in flight on the old socket',
+        () async {
+      // Arrange — a publish is waiting for an OK the dead socket can never
+      // deliver when the app resumes and swaps the connection
+      final event = _event('e1');
+      final publishing = relay.publish(event);
+      expect(relay.isAwaitingOk('e1'), isTrue);
+
+      // Act
+      await relay.reconnectNow();
+      await expectLater(publishing, throwsA(isA<Exception>()));
+
+      // Assert — the event is no longer considered in flight, so the
+      // resend to the fresh socket is not suppressed as a duplicate
+      expect(relay.isAwaitingOk('e1'), isFalse);
       expect(relay.isConnected, isTrue);
     });
   });

--- a/test/services/nostr/nostr_service_test.dart
+++ b/test/services/nostr/nostr_service_test.dart
@@ -1,6 +1,59 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:choke/services/key_management/key_manager.dart';
 import 'package:choke/services/nostr/nostr_service.dart';
+
+/// In-memory WebSocket standing in for a relay: the test scripts what the
+/// "relay" sends back through [incoming] and inspects what the client wrote
+/// through [sent].
+class _FakeWebSocketChannel implements WebSocketChannel {
+  final incoming = StreamController<dynamic>();
+  final sent = <String>[];
+  late final _FakeWebSocketSink _sink = _FakeWebSocketSink(this);
+
+  @override
+  Stream<dynamic> get stream => incoming.stream;
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeWebSocketSink implements WebSocketSink {
+  final _FakeWebSocketChannel _channel;
+  _FakeWebSocketSink(this._channel);
+
+  @override
+  void add(dynamic message) => _channel.sent.add(message as String);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+NostrEvent _event(String id) {
+  return NostrEvent(
+    id: id,
+    pubkey: 'f' * 64,
+    createdAt: 1,
+    kind: 31415,
+    tags: const [
+      ['d', 'abcd']
+    ],
+    content: '{}',
+    sig: 'f' * 128,
+  );
+}
 
 void main() {
   group('nextCreatedAt', () {
@@ -47,6 +100,189 @@ void main() {
 
       // Assert — the fresh match starts at the wall clock, not at aaaa's +5
       expect(other, lessThanOrEqualTo(now + 1));
+    });
+  });
+
+  group('RelayConnection zombie detection', () {
+    late _FakeWebSocketChannel channel;
+    late RelayConnection relay;
+
+    setUp(() async {
+      channel = _FakeWebSocketChannel();
+      relay = RelayConnection(
+        'wss://relay.test',
+        channelFactory: (_) => channel,
+        okTimeout: const Duration(milliseconds: 100),
+      );
+      await relay.connect();
+    });
+
+    tearDown(() => relay.dispose());
+
+    test('publish succeeds and stays connected when the relay sends OK',
+        () async {
+      // Arrange
+      final event = _event('e1');
+
+      // Act — the relay confirms the event
+      final publishing = relay.publish(event);
+      channel.incoming.add(jsonEncode(['OK', 'e1', true, '']));
+
+      // Assert
+      expect(await publishing, isTrue);
+      expect(relay.isConnected, isTrue);
+      expect(channel.sent, hasLength(1));
+    });
+
+    test('publish drops the connection when the relay never answers',
+        () async {
+      // Arrange — the socket died without a close frame (phone slept,
+      // network switched): writes go nowhere and no OK ever arrives
+      final event = _event('e1');
+
+      // Act
+      await expectLater(
+        relay.publish(event),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      // Assert — the connection must be recycled, not trusted again: a
+      // zombie socket that stays "connected" swallows every later publish
+      expect(relay.isConnected, isFalse);
+    });
+
+    test('reconnectNow tears down the socket and connects a fresh one',
+        () async {
+      // Arrange — the current socket may be a zombie after app resume
+      expect(relay.isConnected, isTrue);
+
+      // Act
+      await relay.reconnectNow();
+
+      // Assert
+      expect(relay.isConnected, isTrue);
+    });
+  });
+
+  group('per-relay convergence', () {
+    test('a relay that missed an event receives it after reconnecting',
+        () async {
+      // Arrange — two relays; B's socket is dead and never answers, so the
+      // event only lands on A. "One relay accepted" must not mean "done":
+      // whoever watches relay B still deserves the latest match state.
+      final chanA1 = _FakeWebSocketChannel();
+      final chanA2 = _FakeWebSocketChannel();
+      final chanB1 = _FakeWebSocketChannel();
+      final chanB2 = _FakeWebSocketChannel();
+      final channels = {
+        'a.test': [chanA1, chanA2],
+        'b.test': [chanB1, chanB2],
+      };
+      final service = NostrService(
+        KeyManager(),
+        channelFactory: (uri) => channels[uri.host]!.removeAt(0),
+        okTimeout: const Duration(milliseconds: 100),
+        resendInterval: const Duration(milliseconds: 100),
+      );
+      await service.addRelay('wss://a.test');
+      await service.addRelay('wss://b.test');
+
+      // Act — A confirms, B stays silent (publish still succeeds via A)
+      final publishing = service.publishEvent(_event('e1'));
+      chanA1.incoming.add(jsonEncode(['OK', 'e1', true, '']));
+      await publishing;
+      expect(chanB2.sent, isEmpty);
+
+      // B comes back with a fresh socket
+      await service.reconnectAll();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Assert — the missed event reaches B without any new user action
+      expect(chanB2.sent.where((m) => m.contains('"e1"')), isNotEmpty);
+      chanB2.incoming.add(jsonEncode(['OK', 'e1', true, '']));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      service.dispose();
+    });
+
+    test('a relay that rejects an event gets it resent until accepted',
+        () async {
+      // Arrange — B is connected but refuses the event (e.g. rate limiting
+      // rapid-fire scoring), while A accepts it
+      final chanA = _FakeWebSocketChannel();
+      final chanB = _FakeWebSocketChannel();
+      final channels = {
+        'a.test': [chanA],
+        'b.test': [chanB],
+      };
+      final service = NostrService(
+        KeyManager(),
+        channelFactory: (uri) => channels[uri.host]!.removeAt(0),
+        okTimeout: const Duration(milliseconds: 200),
+        resendInterval: const Duration(milliseconds: 100),
+      );
+      await service.addRelay('wss://a.test');
+      await service.addRelay('wss://b.test');
+
+      // Act — first attempt: A accepts, B rejects
+      final publishing = service.publishEvent(_event('e1'));
+      chanA.incoming.add(jsonEncode(['OK', 'e1', true, '']));
+      chanB.incoming.add(
+          jsonEncode(['OK', 'e1', false, 'rate-limited: slow down']));
+      await publishing;
+      expect(chanB.sent, hasLength(1));
+
+      // The resend sweep retries B on its own; this time B accepts
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(chanB.sent, hasLength(2),
+          reason: 'rejected relay must be retried');
+      chanB.incoming.add(jsonEncode(['OK', 'e1', true, '']));
+
+      // Assert — once accepted everywhere, no more resends
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(chanB.sent, hasLength(2));
+      service.dispose();
+    });
+
+    test('only the newest state is resent when updates supersede each other',
+        () async {
+      // Arrange — B misses two updates in a row; on recovery it must get
+      // only the latest one (addressable events: old states are noise)
+      final chanA = _FakeWebSocketChannel();
+      final chanB = _FakeWebSocketChannel();
+      final channels = {
+        'a.test': [chanA],
+        'b.test': [chanB],
+      };
+      final service = NostrService(
+        KeyManager(),
+        channelFactory: (uri) => channels[uri.host]!.removeAt(0),
+        okTimeout: const Duration(milliseconds: 100),
+        resendInterval: const Duration(milliseconds: 100),
+      );
+      await service.addRelay('wss://a.test');
+      await service.addRelay('wss://b.test');
+
+      // Act — two publishes; A accepts both, B rejects both
+      final first = service.publishEvent(_event('e1'));
+      chanA.incoming.add(jsonEncode(['OK', 'e1', true, '']));
+      chanB.incoming.add(jsonEncode(['OK', 'e1', false, 'rate-limited']));
+      await first;
+      final second = service.publishEvent(_event('e2'));
+      chanA.incoming.add(jsonEncode(['OK', 'e2', true, '']));
+      chanB.incoming.add(jsonEncode(['OK', 'e2', false, 'rate-limited']));
+      await second;
+      final sentBefore = chanB.sent.length;
+
+      // The sweep retries B; it accepts now
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      final resent = chanB.sent.sublist(sentBefore);
+      chanB.incoming.add(jsonEncode(['OK', 'e2', true, '']));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Assert — only e2 (the latest state) went out again
+      expect(resent, hasLength(1));
+      expect(resent.single, contains('"e2"'));
+      service.dispose();
     });
   });
 }


### PR DESCRIPTION
## Problem

While refereeing, updates would sometimes never reach the relay being monitored. It happened rarely when adding points, but often when adding advantages or penalties in quick succession — three advantages could go by with nothing published, and only some later action would eventually carry the accumulated state across.

## Root cause

`publishEvent` fans out to all connected relays but treats **"at least one relay accepted"** as success. Once any relay sends OK, the outbox is cleared and that state is **never resent to the other relays**.

So if the relay you watch rejects the event (rate-limiting a burst of rapid taps — advantages and penalties get hit in rapid succession far more often than points) or is disconnected at that moment, while the other relay accepts, the app considers the publish done and that relay keeps serving a stale scoreboard. A later action, landing when the connection is calm, reaches both relays and drags the accumulated state along — which is exactly the "occasionally a future event catches up" behavior observed.

## Fix

`NostrService` now guarantees **every configured relay** converges to the latest state of each match:

- **Per-relay tracking** (`_pendingLatest` / `_pendingAcks`): on publish, the latest signed event per match (d-tag) is registered along with which relays OK'd it. Publish still resolves on the first OK so the UI never stalls — but the work doesn't stop there.
- **Resend on reconnect**: when a relay (re)connects, it immediately receives the latest event it's missing.
- **Resend sweep** (every 5s while any relay is behind): connected relays that rejected the event get it again until they accept.
- **Only the newest state travels**: if three updates happened while a relay was behind, only the last one is resent — addressable events supersede their predecessors, so intermediate states are noise. An in-flight guard prevents duplicating a frame already awaiting OK on the same relay.

Transport hardening underneath:

- A relay that never answers OK is treated as a **dead socket** and recycled, instead of being trusted for every subsequent publish. (Backgrounding/network switches kill sockets without a close frame, so `isConnected` can lie for minutes.)
- All relay connections are recycled **on app resume**.
- A pending match state is published **the moment a relay reconnects**, instead of waiting out a backoff scheduled against a socket that's already dead.

## Test plan

- [x] `a relay that missed an event receives it after reconnecting`
- [x] `a relay that rejects an event gets it resent until accepted` (fails on `main` — this is the reported bug)
- [x] `only the newest state is resent when updates supersede each other`
- [x] `publish drops the connection when the relay never answers`
- [x] `reconnectNow tears down the socket and connects a fresh one`
- [x] `a pending state is published the moment a relay reconnects`
- [x] `a reconnect with nothing pending publishes nothing`
- [x] Full suite green: 105 tests
- [x] `flutter analyze`: no new issues
- [ ] Manual: create a match, hammer the advantage button, confirm every press lands on the monitored relay in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD1yHCBE9EBjjafUz8N1Gg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay reliability by detecting stalled connections and automatically reconnecting.
  * Ensured the latest match state is retried and synchronized across relays after reconnections or temporary failures.
  * Pending updates now publish promptly when connectivity is restored.

* **Improvements**
  * The app automatically reconnects to relays when returning to the foreground.
  * Prevented updates from continuing after related components are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->