### PR TITLE
refactor(nostr): Phase 2 — a NostrCrypto seam between the app and its crypto library

### DIFF
--- a/docs/specs/nostr-sdk-migration.md
+++ b/docs/specs/nostr-sdk-migration.md
@@ -1,12 +1,12 @@
 # Migration Spec: `nostr_tools` (Dart) → `nostr-sdk` (Rust) via `flutter_rust_bridge`
 
-**Status:** APPROVED — Phases 0-1 complete, Phase 2 next
+**Status:** APPROVED — Phases 0-2 complete, Phase 3 next
 **Author:** prepared with Claude Code
 **Date:** 2026-07-13
 **Decisions locked (2026-07-13):** web target frozen (§5, W1) · own thin Rust
 crate over official Flutter bindings (§9.2) · manual QA on Android (§9.3)
 
-**Progress:** Phase 0 ✅ · Phase 1 ✅ · Phases 2–8 pending
+**Progress:** Phases 0 ✅ 1 ✅ 2 ✅ · Phases 3–8 pending
 
 ---
 
@@ -109,8 +109,8 @@ These are pinned by the existing test suite (105 tests) and must never regress:
 | I4 | A relay that never answers OK is treated as dead and recycled; connections recycled on app resume | zombie detection tests (PR #78) |
 | I5 | Pending state publishes the moment a relay reconnects (no backoff wait) | reconnect recovery tests (PR #78) |
 | I6 | Incoming NIP-40 expired events ignored; addressable replacement keeps newest `(kind, pubkey, d)` | `_handleIncomingEvent` behavior |
-| I7 | Keys: same nsec always derives the same npub; import/export round-trips | key manager tests |
-| I8 | Event ids/signatures are valid NIP-01 (verifiable by any compliant relay) | differential tests (new, Phase 3) |
+| I7 | Keys: same nsec always derives the same npub; import/export round-trips | key manager tests (added in Phase 2 — see §2.2) |
+| I8 | Event ids/signatures are valid NIP-01: the id hashes the event **and** the signature is the pubkey's (verifiable by any compliant relay) | `NostrCrypto` contract (Phase 2) + differential tests (Phase 3) — see §2.1 |
 
 ## 5. Platform support & the web question
 
@@ -249,7 +249,7 @@ release APK growth stays inside the ≤6 MB budget (measured: +2.1 MB — see th
 
 ---
 
-### Phase 2 — Crypto seam in Dart *(PR: pure refactor)*
+### Phase 2 — Crypto seam in Dart — ✅ **DONE (2026-07-13)** *(PR: pure refactor)*
 
 **Goal:** one interface both crypto implementations can stand behind.
 
@@ -279,9 +279,44 @@ Steps:
    against a hand-computed NIP-01 vector, sign→verify). Runs against
    `NostrToolsCrypto` in this PR.
 
-**Tests:** existing 105 + contract suite. Zero behavior change.
-**Acceptance:** `nostr_tools` imports exist **only** inside `NostrToolsCrypto`.
-**Rollback:** revert; pure refactor.
+#### 2.1 What the contract turned up: `nostr_tools` under-verifies events
+
+Writing the contract first surfaced a real flaw in the incumbent library.
+`EventApi.verifySignature` checks the signature **against the event id, but
+never checks that the id describes the event**. Per NIP-01 the id *is* the hash
+of the event's fields, so an event whose content is rewritten after signing —
+keeping the original id and signature — is forged. `nostr_tools` calls it valid.
+The Rust `nostr` crate rejects it (Phase 1's tampering test already proved this),
+so the two implementations would not have been interchangeable.
+
+`NostrToolsCrypto.verifyEvent` therefore also recomputes the id (via
+`getEventHash`) and rejects a mismatch. This is a **deliberate, small hardening**
+rather than a pure move: it is what makes the contract satisfiable by both
+backends, and it cannot regress the app, whose only use of verification is a
+self-check on events it just signed itself (where the id always matches).
+
+Two consequences:
+- **I8 gets stronger**: event verification now means *id integrity + signature*,
+  in both implementations.
+- **Phase 8 gains urgency**: the app is currently shipping a signature check
+  that the library alone would have gotten wrong. Nothing else in the app calls
+  it, so exposure is nil — but it is exactly the class of bug that motivated
+  this migration.
+
+#### 2.2 I7 was not actually pinned
+
+The spec claimed invariant I7 (same nsec ⇒ same npub; import round-trips) was
+"pinned by key manager tests" — there were none. Phase 2 adds
+`test/services/key_management/key_manager_test.dart` (in-memory secure storage),
+covering first launch, reopening, npub/nsec round-trips, nsec import (valid and
+malformed), and the repair path for a stored pubkey that disagrees with its
+private key. Phase 4 swaps the crypto backend underneath exactly this code, so
+the invariant needed teeth before then, not after.
+
+**Tests:** 136 passing (110 existing + 19 contract + 7 key manager).
+**Acceptance:** `package:nostr_tools` is imported in **exactly one file**,
+`nostr_tools_crypto.dart`. ✅
+**Rollback:** revert; behavior-preserving apart from §2.1.
 
 ---
 

--- a/lib/features/match/models/match.dart
+++ b/lib/features/match/models/match.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:math';
-import 'package:nostr_tools/nostr_tools.dart' as nostr;
 import '../../../services/nostr/nostr_service.dart';
 
 /// Sentinel value for distinguishing "not provided" from "null" in copyWith

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,13 +13,20 @@ import 'features/account/account_screen.dart';
 import 'features/settings/settings_screen.dart';
 import 'features/settings/providers/relay_config_provider.dart';
 import 'services/key_management/key_manager.dart';
+import 'services/nostr/crypto/nostr_crypto.dart';
+import 'services/nostr/crypto/nostr_tools_crypto.dart';
 import 'services/nostr/nostr_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  // The one place the crypto implementation is chosen. Everything downstream
+  // takes it as a NostrCrypto, so swapping the backend (Phase 4) is a change
+  // to this line alone. See docs/specs/nostr-sdk-migration.md.
+  final NostrCrypto crypto = NostrToolsCrypto();
+
   // Initialize KeyManager
-  final keyManager = KeyManager();
+  final keyManager = KeyManager(crypto: crypto);
   try {
     await keyManager.initialize();
   } catch (e, st) {
@@ -36,7 +43,7 @@ void main() async {
   }
 
   // Initialize NostrService with configured relays
-  final nostrService = NostrService(keyManager);
+  final nostrService = NostrService(keyManager, crypto: crypto);
   try {
     final enabledRelayUrls =
         relayConfigs.where((r) => r.isEnabled).map((r) => r.url).toList();
@@ -60,6 +67,7 @@ void main() async {
   runApp(
     ProviderScope(
       overrides: [
+        nostrCryptoProvider.overrideWithValue(crypto),
         keyManagerProvider.overrideWithValue(keyManager),
         nostrServiceProvider.overrideWithValue(nostrService),
         relayConfigServiceProvider.overrideWithValue(relayConfigService),

--- a/lib/services/key_management/key_manager.dart
+++ b/lib/services/key_management/key_manager.dart
@@ -122,8 +122,11 @@ class KeyManager {
 
       debugPrint('KeyManager: Keypair imported successfully');
       return true;
-    } catch (e) {
-      debugPrint('KeyManager: Error importing nsec: $e');
+    } catch (_) {
+      // Not logged: everything inside this try handles the private key the
+      // user is importing, so the exception's message can carry it into the
+      // device log.
+      debugPrint('KeyManager: Error importing nsec');
       return false;
     }
   }
@@ -152,8 +155,12 @@ class KeyManager {
   String _derivePublicKeyHex(String privateKeyHex) {
     try {
       return _crypto.getPublicKey(privateKeyHex);
-    } catch (e) {
-      debugPrint('KeyManager: Error deriving public key: $e');
+    } catch (_) {
+      // The exception is not logged: it was raised while handling the private
+      // key, so its message can carry the key itself into the device log —
+      // and debugPrint is not stripped from release builds. The throw still
+      // propagates, so no error is swallowed.
+      debugPrint('KeyManager: Error deriving public key');
       rethrow;
     }
   }
@@ -172,8 +179,10 @@ class KeyManager {
   String _encodeNsec(String hexPrivateKey) {
     try {
       return _crypto.nsecEncode(hexPrivateKey);
-    } catch (e) {
-      debugPrint('KeyManager: Error encoding nsec: $e');
+    } catch (_) {
+      // Same reasoning as _derivePublicKeyHex: the input is the private key,
+      // so the exception's message must not reach the log.
+      debugPrint('KeyManager: Error encoding nsec');
       rethrow;
     }
   }

--- a/lib/services/key_management/key_manager.dart
+++ b/lib/services/key_management/key_manager.dart
@@ -1,20 +1,28 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:nostr_tools/nostr_tools.dart';
+
+import '../nostr/crypto/nostr_crypto.dart';
+import '../nostr/crypto/nostr_tools_crypto.dart';
 
 /// Service for managing Nostr keypairs
 /// Handles generation, storage, and recovery of keys
+///
+/// All cryptography goes through [NostrCrypto] rather than through a library
+/// of its own, so the implementation can be swapped without touching this
+/// class. See docs/specs/nostr-sdk-migration.md.
 class KeyManager {
   static const String _privateKeyKey = 'nostr_private_key';
   static const String _publicKeyKey = 'nostr_public_key';
 
   final FlutterSecureStorage _secureStorage;
+  final NostrCrypto _crypto;
   String? _cachedPrivateKey;
   String? _cachedPublicKey;
 
-  KeyManager({FlutterSecureStorage? secureStorage})
-      : _secureStorage = secureStorage ??
+  KeyManager({FlutterSecureStorage? secureStorage, NostrCrypto? crypto})
+      : _crypto = crypto ?? NostrToolsCrypto(),
+        _secureStorage = secureStorage ??
             const FlutterSecureStorage(
               aOptions: AndroidOptions(encryptedSharedPreferences: true),
               iOptions: IOSOptions(
@@ -48,15 +56,9 @@ class KeyManager {
   }
 
   /// Generate a new secp256k1 keypair and store it securely.
-  /// Uses nostr_tools KeyApi to guarantee a valid private key.
   Future<void> _generateAndStoreKeypair() async {
-    final keyApi = KeyApi();
-
-    // Generate a valid secp256k1 private key via nostr_tools
-    final privateKeyHex = keyApi.generatePrivateKey();
-
-    // Derive public key from private key
-    final publicKeyHex = keyApi.getPublicKey(privateKeyHex);
+    final privateKeyHex = _crypto.generatePrivateKey();
+    final publicKeyHex = _crypto.getPublicKey(privateKeyHex);
 
     // Store securely
     await _secureStorage.write(key: _privateKeyKey, value: privateKeyHex);
@@ -146,24 +148,20 @@ class KeyManager {
     debugPrint('KeyManager: All keys deleted');
   }
 
-  /// Derive secp256k1 public key from private key using nostr_tools.
+  /// Derive secp256k1 public key from private key.
   String _derivePublicKeyHex(String privateKeyHex) {
     try {
-      final keyApi = KeyApi();
-      return keyApi.getPublicKey(privateKeyHex);
+      return _crypto.getPublicKey(privateKeyHex);
     } catch (e) {
       debugPrint('KeyManager: Error deriving public key: $e');
       rethrow;
     }
   }
 
-  // NIP-19 Encoding/Decoding using nostr_tools
-
   /// Encode hex public key to npub (NIP-19 bech32)
   String _encodeNpub(String hexPublicKey) {
     try {
-      final nip19 = Nip19();
-      return nip19.npubEncode(hexPublicKey);
+      return _crypto.npubEncode(hexPublicKey);
     } catch (e) {
       debugPrint('KeyManager: Error encoding npub: $e');
       rethrow;
@@ -173,30 +171,15 @@ class KeyManager {
   /// Encode hex private key to nsec (NIP-19 bech32)
   String _encodeNsec(String hexPrivateKey) {
     try {
-      final nip19 = Nip19();
-      return nip19.nsecEncode(hexPrivateKey);
+      return _crypto.nsecEncode(hexPrivateKey);
     } catch (e) {
       debugPrint('KeyManager: Error encoding nsec: $e');
       rethrow;
     }
   }
 
-  /// Decode nsec to hex private key
-  String? _decodeNsec(String nsec) {
-    try {
-      final nip19 = Nip19();
-      final decoded = nip19.decode(nsec);
-
-      // Validate type is 'nsec'
-      if (decoded['type'] != 'nsec') return null;
-
-      // Return the hex data
-      return decoded['data'] as String?;
-    } catch (e) {
-      debugPrint('KeyManager: nsec decode error: $e');
-      return null;
-    }
-  }
+  /// Decode nsec to hex private key, or null if it is not a valid nsec.
+  String? _decodeNsec(String nsec) => _crypto.nsecDecode(nsec);
 }
 
 /// Provider for KeyManager

--- a/lib/services/nostr/crypto/nostr_crypto.dart
+++ b/lib/services/nostr/crypto/nostr_crypto.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../nostr_service.dart' show NostrEvent;
+
+/// A Nostr event that has been assembled but not yet signed: it has no id
+/// and no signature, because both are derived from these fields.
+class UnsignedNostrEvent {
+  final String pubkey;
+  final int createdAt;
+  final int kind;
+  final List<List<String>> tags;
+  final String content;
+
+  const UnsignedNostrEvent({
+    required this.pubkey,
+    required this.createdAt,
+    required this.kind,
+    required this.tags,
+    required this.content,
+  });
+}
+
+/// Every cryptographic operation the app performs.
+///
+/// This is the seam the migration turns on: the app talks to this interface,
+/// never to a crypto library directly, so the implementation underneath can
+/// be swapped (Dart `nostr_tools` → Rust `nostr`) without a single call site
+/// changing. See docs/specs/nostr-sdk-migration.md.
+///
+/// Implementations must be interchangeable: the same private key always
+/// yields the same public key, npub and nsec, and the same unsigned event
+/// always yields the same event id. Only signatures may differ between
+/// implementations (Schnorr signing uses a random nonce), and each must
+/// verify the other's. `nostr_crypto_contract.dart` pins all of this.
+abstract class NostrCrypto {
+  /// A fresh, valid secp256k1 private key, as lowercase hex.
+  String generatePrivateKey();
+
+  /// The public key belonging to [privateKeyHex], as lowercase hex.
+  String getPublicKey(String privateKeyHex);
+
+  /// NIP-19 bech32 encoding of a hex public key (`npub1…`).
+  String npubEncode(String publicKeyHex);
+
+  /// NIP-19 bech32 encoding of a hex private key (`nsec1…`).
+  String nsecEncode(String privateKeyHex);
+
+  /// The hex private key inside [nsec], or null if it is not a valid nsec.
+  ///
+  /// Returns null rather than throwing: a malformed nsec is something a user
+  /// can type, not a programming error.
+  String? nsecDecode(String nsec);
+
+  /// Compute [event]'s id and sign it with [privateKeyHex].
+  NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex);
+
+  /// Whether [event]'s id matches its contents and its signature is valid.
+  bool verifyEvent(NostrEvent event);
+}
+
+/// The crypto implementation the app runs on.
+///
+/// Overridden in `main.dart` with the selected backend. Phase 2 ships only
+/// the legacy Dart implementation; Phase 3 adds the Rust one behind a flag.
+final nostrCryptoProvider = Provider<NostrCrypto>((ref) {
+  throw UnimplementedError(
+    'nostrCryptoProvider must be overridden with a NostrCrypto implementation',
+  );
+});

--- a/lib/services/nostr/crypto/nostr_tools_crypto.dart
+++ b/lib/services/nostr/crypto/nostr_tools_crypto.dart
@@ -41,8 +41,11 @@ class NostrToolsCrypto implements NostrCrypto {
       // be a catastrophic confusion, so the type has to match.
       if (decoded['type'] != 'nsec') return null;
       return decoded['data'] as String?;
-    } catch (e) {
-      debugPrint('NostrToolsCrypto: nsec decode error: $e');
+    } catch (_) {
+      // The exception itself is deliberately not logged: it was raised while
+      // parsing an nsec, so its message can carry the private key into the
+      // device log — and debugPrint is not stripped from release builds.
+      debugPrint('NostrToolsCrypto: nsec could not be decoded');
       return null;
     }
   }

--- a/lib/services/nostr/crypto/nostr_tools_crypto.dart
+++ b/lib/services/nostr/crypto/nostr_tools_crypto.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/foundation.dart';
+import 'package:nostr_tools/nostr_tools.dart' as nostr;
+
+import '../nostr_service.dart' show NostrEvent;
+import 'nostr_crypto.dart';
+
+/// [NostrCrypto] backed by the `nostr_tools` Dart package.
+///
+/// This is the only place in the app allowed to import `nostr_tools`. It is
+/// the incumbent implementation, kept for one release cycle after the Rust
+/// backend takes over — as an instant rollback — and deleted in Phase 8.
+/// See docs/specs/nostr-sdk-migration.md.
+class NostrToolsCrypto implements NostrCrypto {
+  final nostr.KeyApi _keyApi;
+  final nostr.EventApi _eventApi;
+  final nostr.Nip19 _nip19;
+
+  NostrToolsCrypto()
+      : _keyApi = nostr.KeyApi(),
+        _eventApi = nostr.EventApi(),
+        _nip19 = nostr.Nip19();
+
+  @override
+  String generatePrivateKey() => _keyApi.generatePrivateKey();
+
+  @override
+  String getPublicKey(String privateKeyHex) =>
+      _keyApi.getPublicKey(privateKeyHex);
+
+  @override
+  String npubEncode(String publicKeyHex) => _nip19.npubEncode(publicKeyHex);
+
+  @override
+  String nsecEncode(String privateKeyHex) => _nip19.nsecEncode(privateKeyHex);
+
+  @override
+  String? nsecDecode(String nsec) {
+    try {
+      final decoded = _nip19.decode(nsec);
+      // An npub decodes cleanly too — taking its data as a private key would
+      // be a catastrophic confusion, so the type has to match.
+      if (decoded['type'] != 'nsec') return null;
+      return decoded['data'] as String?;
+    } catch (e) {
+      debugPrint('NostrToolsCrypto: nsec decode error: $e');
+      return null;
+    }
+  }
+
+  @override
+  NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex) {
+    final unsigned = nostr.Event(
+      kind: event.kind,
+      tags: event.tags,
+      content: event.content,
+      created_at: event.createdAt,
+      pubkey: event.pubkey,
+    );
+
+    // finishEvent computes both the id and the Schnorr signature.
+    final signed = _eventApi.finishEvent(unsigned, privateKeyHex);
+    return _fromToolsEvent(signed);
+  }
+
+  @override
+  bool verifyEvent(NostrEvent event) {
+    final toolsEvent = _toToolsEvent(event);
+
+    // `nostr_tools` only checks the signature against the id, never that the
+    // id actually describes the event — so on its own it calls an event whose
+    // content was rewritten after signing valid. Per NIP-01 the id *is* the
+    // hash of the event, so recompute it: an event whose id does not match
+    // its own contents is forged, whatever its signature says. The Rust
+    // implementation checks both, and the two must agree.
+    if (_eventApi.getEventHash(toolsEvent) != event.id) return false;
+
+    return _eventApi.verifySignature(toolsEvent);
+  }
+
+  // Translating to and from `nostr_tools`' own event type is this class's
+  // private business — it is what keeps the type out of the rest of the app.
+
+  nostr.Event _toToolsEvent(NostrEvent event) {
+    return nostr.Event(
+      id: event.id,
+      pubkey: event.pubkey,
+      created_at: event.createdAt,
+      kind: event.kind,
+      tags: event.tags,
+      content: event.content,
+      sig: event.sig,
+    );
+  }
+
+  NostrEvent _fromToolsEvent(nostr.Event event) {
+    return NostrEvent(
+      id: event.id,
+      pubkey: event.pubkey,
+      createdAt: event.created_at,
+      kind: event.kind,
+      tags: event.tags,
+      content: event.content,
+      sig: event.sig,
+    );
+  }
+}

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -3,10 +3,15 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:nostr_tools/nostr_tools.dart' as nostr;
 import '../key_management/key_manager.dart';
+import 'crypto/nostr_crypto.dart';
+import 'crypto/nostr_tools_crypto.dart';
 
-/// Nostr Event model (wrapper around nostr_tools Event)
+/// A signed Nostr event.
+///
+/// Deliberately free of any crypto library's types: translating to and from
+/// those is [NostrCrypto]'s business, which is what lets the backend change
+/// without the rest of the app noticing.
 class NostrEvent {
   final String id;
   final String pubkey;
@@ -52,31 +57,6 @@ class NostrEvent {
     };
   }
 
-  /// Convert to nostr_tools Event
-  nostr.Event toNostrToolsEvent() {
-    return nostr.Event(
-      id: id,
-      pubkey: pubkey,
-      created_at: createdAt,
-      kind: kind,
-      tags: tags,
-      content: content,
-      sig: sig,
-    );
-  }
-
-  /// Create NostrEvent from nostr_tools Event
-  factory NostrEvent.fromNostrToolsEvent(nostr.Event event) {
-    return NostrEvent(
-      id: event.id,
-      pubkey: event.pubkey,
-      createdAt: event.created_at,
-      kind: event.kind,
-      tags: event.tags,
-      content: event.content,
-      sig: event.sig,
-    );
-  }
 }
 
 /// Filter for Nostr subscriptions
@@ -396,12 +376,18 @@ class NostrService {
   final WebSocketChannelFactory? _channelFactory;
   final Duration _okTimeout;
 
+  /// Signs and verifies the events this service publishes. Injected so the
+  /// crypto backend can be swapped without touching the relay layer.
+  final NostrCrypto _crypto;
+
   NostrService(
     this._keyManager, {
+    NostrCrypto? crypto,
     WebSocketChannelFactory? channelFactory,
     Duration okTimeout = const Duration(seconds: 10),
     this.resendInterval = const Duration(seconds: 5),
-  })  : _channelFactory = channelFactory,
+  })  : _crypto = crypto ?? NostrToolsCrypto(),
+        _channelFactory = channelFactory,
         _okTimeout = okTimeout;
 
   Stream<NostrEvent> get eventStream => _eventController.stream;
@@ -688,31 +674,24 @@ class NostrService {
 
     final createdAt = nextCreatedAt(dTag);
 
-    // Build nostr_tools Event
-    final nostrEvent = nostr.Event(
-      kind: 31415,
-      tags: tags,
-      content: content,
-      created_at: createdAt,
-      pubkey: publicKey,
+    // Sign the event: this computes both its id and its signature.
+    final event = _crypto.finishEvent(
+      UnsignedNostrEvent(
+        kind: 31415,
+        tags: tags,
+        content: content,
+        createdAt: createdAt,
+        pubkey: publicKey,
+      ),
+      privateKey,
     );
+    debugPrint('NostrService: event id: ${event.id}');
 
-    // Sign event using nostr_tools (calculates id + signature)
-    final eventApi = nostr.EventApi();
-    final finishedEvent = eventApi.finishEvent(nostrEvent, privateKey);
-    debugPrint('NostrService: event id: ${finishedEvent.id}');
-    debugPrint(
-        'NostrService: event sig: ${finishedEvent.sig.substring(0, 16)}...');
-    debugPrint('NostrService: event pubkey: ${finishedEvent.pubkey}');
-
-    // Verify the signature before publishing
-    final isValid = eventApi.verifySignature(finishedEvent);
-    debugPrint('NostrService: signature valid: $isValid');
-    if (!isValid) {
+    // Self-check before it goes out: a relay would reject a bad event anyway,
+    // and a silently malformed one is worse than a loud failure here.
+    if (!_crypto.verifyEvent(event)) {
       throw Exception('Event signature verification failed');
     }
-
-    final event = NostrEvent.fromNostrToolsEvent(finishedEvent);
 
     await publishEvent(event);
   }

--- a/test/services/key_management/key_manager_test.dart
+++ b/test/services/key_management/key_manager_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_tools_crypto.dart';
+
+/// Pins the identity guarantees the crypto migration must not break: the key
+/// in secure storage *is* the user's identity, and swapping the crypto
+/// implementation underneath it (Phase 4) must leave the npub it derives
+/// untouched. See docs/specs/nostr-sdk-migration.md (I7).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // In-memory stand-in for the platform keystore.
+  late Map<String, String> storage;
+
+  setUp(() {
+    storage = {};
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+      (call) async {
+        final args = (call.arguments as Map?)?.cast<String, dynamic>() ?? {};
+        final key = args['key'] as String?;
+        switch (call.method) {
+          case 'write':
+            storage[key!] = args['value'] as String;
+            return null;
+          case 'read':
+            return storage[key];
+          case 'delete':
+            storage.remove(key);
+            return null;
+          case 'readAll':
+            return storage;
+          case 'deleteAll':
+            storage.clear();
+            return null;
+          case 'containsKey':
+            return storage.containsKey(key);
+          default:
+            return null;
+        }
+      },
+    );
+  });
+
+  KeyManager subject() => KeyManager(
+        secureStorage: const FlutterSecureStorage(),
+        crypto: NostrToolsCrypto(),
+      );
+
+  group('first launch', () {
+    test('generates and stores a keypair', () async {
+      // Arrange
+      final manager = subject();
+
+      // Act
+      await manager.initialize();
+
+      // Assert
+      expect(await manager.hasKeys(), isTrue);
+      expect(await manager.getPrivateKeyHex(), hasLength(64));
+      expect(await manager.getNpub(), startsWith('npub1'));
+      expect(await manager.getNsec(), startsWith('nsec1'));
+    });
+
+    test('the stored public key belongs to the stored private key', () async {
+      // Arrange
+      final manager = subject();
+
+      // Act
+      await manager.initialize();
+
+      // Assert — the npub the user shows the world must be the one their nsec
+      // actually signs with
+      final privateKey = (await manager.getPrivateKeyHex())!;
+      final derived = NostrToolsCrypto().getPublicKey(privateKey);
+      expect(await manager.getPublicKeyHex(), derived);
+    });
+  });
+
+  group('reopening the app', () {
+    test('keeps the identity it already had', () async {
+      // Arrange — a first run generates the keys
+      await subject().initialize();
+      final npubBefore = await subject().getNpub();
+
+      // Act — a later run reads them back
+      final reopened = subject();
+      await reopened.initialize();
+
+      // Assert — the invariant Phase 4 must not break: the key lives in secure
+      // storage, so changing the crypto backend may change *how* the npub is
+      // derived but never *what* it is.
+      expect(await reopened.getNpub(), npubBefore);
+    });
+
+    test('repairs a stored public key that does not match the private key',
+        () async {
+      // Arrange — a corrupted install whose npub lies about its nsec
+      await subject().initialize();
+      final privateKey = storage['nostr_private_key']!;
+      storage['nostr_public_key'] = 'deadbeef' * 8;
+
+      // Act
+      final manager = subject();
+      await manager.initialize();
+
+      // Assert — always re-derived from the private key, never trusted
+      expect(
+        await manager.getPublicKeyHex(),
+        NostrToolsCrypto().getPublicKey(privateKey),
+      );
+    });
+  });
+
+  group('importing an nsec', () {
+    // The NIP-19 spec's own test vector.
+    const nsec =
+        'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
+    const privateKeyHex =
+        '67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa';
+
+    test('replaces the identity with the imported one', () async {
+      // Arrange
+      final manager = subject();
+      await manager.initialize();
+
+      // Act
+      final imported = await manager.importFromNsec(nsec);
+
+      // Assert
+      expect(imported, isTrue);
+      expect(await manager.getPrivateKeyHex(), privateKeyHex);
+      expect(await manager.getNsec(), nsec);
+      expect(
+        await manager.getPublicKeyHex(),
+        NostrToolsCrypto().getPublicKey(privateKeyHex),
+      );
+    });
+
+    test('rejects a malformed nsec without disturbing the current keys',
+        () async {
+      // Arrange
+      final manager = subject();
+      await manager.initialize();
+      final npubBefore = await manager.getNpub();
+
+      // Act
+      final imported = await manager.importFromNsec('nsec1nonsense');
+
+      // Assert — a typo in the import field must not cost the user their
+      // identity
+      expect(imported, isFalse);
+      expect(await manager.getNpub(), npubBefore);
+    });
+  });
+
+  test('deleting keys leaves nothing behind', () async {
+    // Arrange
+    final manager = subject();
+    await manager.initialize();
+
+    // Act
+    await manager.deleteKeys();
+
+    // Assert
+    expect(await manager.hasKeys(), isFalse);
+    expect(await manager.getPrivateKeyHex(), isNull);
+  });
+}

--- a/test/services/nostr/crypto/nostr_crypto_contract.dart
+++ b/test/services/nostr/crypto/nostr_crypto_contract.dart
@@ -1,0 +1,311 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+
+/// The behavior every [NostrCrypto] implementation must exhibit, written once
+/// against the interface.
+///
+/// This is what makes the migration safe: the Rust implementation (Phase 3)
+/// is held to this same suite without editing a line of it, so "the new
+/// backend behaves like the old one" stops being a claim and becomes a test
+/// result. See docs/specs/nostr-sdk-migration.md (I7, I8).
+void runNostrCryptoContract(String name, NostrCrypto Function() create) {
+  group('$name — NostrCrypto contract', () {
+    late NostrCrypto crypto;
+
+    setUp(() => crypto = create());
+
+    // The NIP-19 test vector published in the NIP itself. An implementation
+    // that disagrees with this disagrees with the protocol.
+    const nip19PrivateKey =
+        '67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa';
+    const nip19Nsec =
+        'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
+
+    group('keys', () {
+      test('generates a usable 32-byte private key', () {
+        // Act
+        final privateKey = crypto.generatePrivateKey();
+
+        // Assert — 32 bytes of lowercase hex, and a key the rest of the API
+        // actually accepts
+        expect(privateKey, matches(RegExp(r'^[0-9a-f]{64}$')));
+        expect(crypto.getPublicKey(privateKey), hasLength(64));
+      });
+
+      test('generates a different key every time', () {
+        // Arrange & Act — a generator that repeated itself would hand two
+        // referees the same identity
+        final keys = List.generate(10, (_) => crypto.generatePrivateKey());
+
+        // Assert
+        expect(keys.toSet(), hasLength(10));
+      });
+
+      test('derives the same public key from the same private key', () {
+        // Arrange
+        final privateKey = crypto.generatePrivateKey();
+
+        // Act
+        final first = crypto.getPublicKey(privateKey);
+        final second = crypto.getPublicKey(privateKey);
+
+        // Assert — the user's identity must not drift between calls
+        expect(first, second);
+        expect(first, matches(RegExp(r'^[0-9a-f]{64}$')));
+      });
+
+      test('derives different public keys from different private keys', () {
+        // Arrange & Act
+        final a = crypto.getPublicKey(crypto.generatePrivateKey());
+        final b = crypto.getPublicKey(crypto.generatePrivateKey());
+
+        // Assert
+        expect(a, isNot(b));
+      });
+    });
+
+    group('NIP-19', () {
+      test('encodes the NIP-19 spec vector to its published nsec', () {
+        // Act
+        final nsec = crypto.nsecEncode(nip19PrivateKey);
+
+        // Assert
+        expect(nsec, nip19Nsec);
+      });
+
+      test('decodes the NIP-19 spec vector back to its hex key', () {
+        // Act
+        final hex = crypto.nsecDecode(nip19Nsec);
+
+        // Assert
+        expect(hex, nip19PrivateKey);
+      });
+
+      test('round-trips a generated key through nsec', () {
+        // Arrange
+        final privateKey = crypto.generatePrivateKey();
+
+        // Act
+        final decoded = crypto.nsecDecode(crypto.nsecEncode(privateKey));
+
+        // Assert
+        expect(decoded, privateKey);
+      });
+
+      test('encodes a public key as an npub', () {
+        // Arrange
+        final publicKey = crypto.getPublicKey(nip19PrivateKey);
+
+        // Act
+        final npub = crypto.npubEncode(publicKey);
+
+        // Assert
+        expect(npub, startsWith('npub1'));
+      });
+
+      test('gives the same npub for the same key every time', () {
+        // Arrange — the npub is the user's public identity; it cannot wobble
+        final publicKey = crypto.getPublicKey(nip19PrivateKey);
+
+        // Act & Assert
+        expect(crypto.npubEncode(publicKey), crypto.npubEncode(publicKey));
+      });
+
+      test('returns null for an nsec that is not one', () {
+        // Act & Assert — a user can type any of these into the import field
+        expect(crypto.nsecDecode('not an nsec'), isNull);
+        expect(crypto.nsecDecode(''), isNull);
+        expect(crypto.nsecDecode(nip19PrivateKey), isNull, reason: 'raw hex');
+      });
+
+      test('returns null for an npub given where an nsec is expected', () {
+        // Arrange — same bech32 family, wrong prefix: decoding this as a
+        // private key would be a catastrophic confusion
+        final npub = crypto.npubEncode(crypto.getPublicKey(nip19PrivateKey));
+
+        // Act & Assert
+        expect(crypto.nsecDecode(npub), isNull);
+      });
+    });
+
+    group('signing', () {
+      UnsignedNostrEvent unsigned(String pubkey, {String content = 'choke'}) {
+        return UnsignedNostrEvent(
+          pubkey: pubkey,
+          createdAt: 1700000000,
+          kind: 31415,
+          tags: const [
+            ['d', 'abcd'],
+            ['expiration', '1900000000'],
+          ],
+          content: content,
+        );
+      }
+
+      test('produces an event that verifies', () {
+        // Arrange
+        final privateKey = crypto.generatePrivateKey();
+        final publicKey = crypto.getPublicKey(privateKey);
+
+        // Act
+        final event = crypto.finishEvent(unsigned(publicKey), privateKey);
+
+        // Assert
+        expect(crypto.verifyEvent(event), isTrue);
+      });
+
+      test('preserves every field it was given', () {
+        // Arrange
+        final privateKey = crypto.generatePrivateKey();
+        final publicKey = crypto.getPublicKey(privateKey);
+        final input = unsigned(publicKey);
+
+        // Act
+        final event = crypto.finishEvent(input, privateKey);
+
+        // Assert — a signer that quietly reordered tags or rewrote created_at
+        // would break the match schema and NIP-01 replacement alike
+        expect(event.pubkey, input.pubkey);
+        expect(event.createdAt, input.createdAt);
+        expect(event.kind, input.kind);
+        expect(event.tags, input.tags);
+        expect(event.content, input.content);
+      });
+
+      test('fills in a well-formed id and signature', () {
+        // Arrange
+        final privateKey = crypto.generatePrivateKey();
+        final publicKey = crypto.getPublicKey(privateKey);
+
+        // Act
+        final event = crypto.finishEvent(unsigned(publicKey), privateKey);
+
+        // Assert
+        expect(event.id, matches(RegExp(r'^[0-9a-f]{64}$')));
+        expect(event.sig, matches(RegExp(r'^[0-9a-f]{128}$')));
+      });
+
+      test('derives the id from the event, not from chance', () {
+        // Arrange — the id is a hash of the event's fields, so signing the
+        // same event twice must produce the same id (NIP-01). This is what
+        // lets Phase 3 compare the two implementations byte for byte.
+        final privateKey = crypto.generatePrivateKey();
+        final publicKey = crypto.getPublicKey(privateKey);
+        final input = unsigned(publicKey);
+
+        // Act
+        final first = crypto.finishEvent(input, privateKey);
+        final second = crypto.finishEvent(input, privateKey);
+
+        // Assert
+        expect(first.id, second.id);
+      });
+
+      test('gives different content a different id', () {
+        // Arrange
+        final privateKey = crypto.generatePrivateKey();
+        final publicKey = crypto.getPublicKey(privateKey);
+
+        // Act
+        final a = crypto.finishEvent(unsigned(publicKey), privateKey);
+        final b = crypto.finishEvent(
+          unsigned(publicKey, content: 'choked'),
+          privateKey,
+        );
+
+        // Assert
+        expect(a.id, isNot(b.id));
+      });
+
+      test('signs content that is not plain ASCII', () {
+        // Arrange — fighter names carry accents and the app is localized into
+        // Japanese; a signer that mangled UTF-8 would emit events every relay
+        // rejects. Quotes and newlines probe JSON escaping too.
+        final privateKey = crypto.generatePrivateKey();
+        final publicKey = crypto.getPublicKey(privateKey);
+        final input = unsigned(
+          publicKey,
+          content: '{"f1":"Gonçalves 🥋","f2":"田中","n":"a \\"quote\\"\nnewline"}',
+        );
+
+        // Act
+        final event = crypto.finishEvent(input, privateKey);
+
+        // Assert
+        expect(crypto.verifyEvent(event), isTrue);
+        expect(event.content, input.content);
+      });
+    });
+
+    group('verification', () {
+      test('rejects an event whose content was changed after signing', () {
+        // Arrange
+        final privateKey = crypto.generatePrivateKey();
+        final publicKey = crypto.getPublicKey(privateKey);
+        final event = crypto.finishEvent(
+          UnsignedNostrEvent(
+            pubkey: publicKey,
+            createdAt: 1700000000,
+            kind: 31415,
+            tags: const [
+              ['d', 'abcd']
+            ],
+            content: 'f1 wins',
+          ),
+          privateKey,
+        );
+
+        // Act — someone rewrites the result, keeping the original signature
+        final forged = NostrEvent(
+          id: event.id,
+          pubkey: event.pubkey,
+          createdAt: event.createdAt,
+          kind: event.kind,
+          tags: event.tags,
+          content: 'f2 wins',
+          sig: event.sig,
+        );
+
+        // Assert
+        expect(crypto.verifyEvent(forged), isFalse);
+      });
+
+      test('rejects an event signed by someone else', () {
+        // Arrange — two referees; one's signature is pasted onto an event
+        // claiming to come from the other
+        final keyA = crypto.generatePrivateKey();
+        final keyB = crypto.generatePrivateKey();
+        final pubA = crypto.getPublicKey(keyA);
+        final pubB = crypto.getPublicKey(keyB);
+
+        final byA = crypto.finishEvent(
+          UnsignedNostrEvent(
+            pubkey: pubA,
+            createdAt: 1700000000,
+            kind: 31415,
+            tags: const [
+              ['d', 'abcd']
+            ],
+            content: 'choke',
+          ),
+          keyA,
+        );
+
+        // Act
+        final impersonated = NostrEvent(
+          id: byA.id,
+          pubkey: pubB,
+          createdAt: byA.createdAt,
+          kind: byA.kind,
+          tags: byA.tags,
+          content: byA.content,
+          sig: byA.sig,
+        );
+
+        // Assert
+        expect(crypto.verifyEvent(impersonated), isFalse);
+      });
+    });
+  });
+}

--- a/test/services/nostr/crypto/nostr_tools_crypto_test.dart
+++ b/test/services/nostr/crypto/nostr_tools_crypto_test.dart
@@ -1,0 +1,9 @@
+import 'package:choke/services/nostr/crypto/nostr_tools_crypto.dart';
+
+import 'nostr_crypto_contract.dart';
+
+/// The incumbent Dart implementation, held to the shared contract. Phase 3
+/// runs the identical contract against the Rust implementation.
+void main() {
+  runNostrCryptoContract('NostrToolsCrypto', NostrToolsCrypto.new);
+}


### PR DESCRIPTION
Phase 2 of [the migration spec](docs/specs/nostr-sdk-migration.md). The app no longer talks to a crypto library — it talks to a `NostrCrypto` interface. Swapping the implementation in Phase 4 becomes a change to **one line of `main.dart`**.

## What's here

- **`NostrCrypto`** (+ `UnsignedNostrEvent`), and **`NostrToolsCrypto`** implementing it over `nostr_tools`. `KeyManager` and `NostrService` take it by constructor; `main.dart` is the single place that picks the implementation.
- **`package:nostr_tools` is now imported in exactly one file.** `NostrEvent`'s `toNostrToolsEvent`/`fromNostrToolsEvent` converters moved *inside* `NostrToolsCrypto` — the event model is now free of any crypto library's types, which is what the acceptance criterion actually requires.
- The dead `nostr_tools` import in `match.dart` is gone.
- **A contract test suite written against the interface, not the implementation.** Phase 3 will hold the Rust backend to these same 19 tests without editing a line of them, so "the new backend behaves like the old one" stops being a claim and becomes a test result.

## Two things the work turned up

### 1. `nostr_tools` under-verifies events — a real flaw (§2.1)

Writing the contract first paid for itself immediately. `EventApi.verifySignature` checks the signature **against the event id, but never checks that the id describes the event**. Per NIP-01 the id *is* the hash of the event's fields — so an event whose content is rewritten after signing, keeping the original id and signature, is forged. **`nostr_tools` calls it valid.** The Rust `nostr` crate rejects it (Phase 1's tampering test already proved that), so the two implementations were not actually interchangeable.

`NostrToolsCrypto.verifyEvent` now recomputes the id (`getEventHash`) and rejects a mismatch. This is a deliberate, small hardening rather than a pure move — it's what makes the contract satisfiable by both backends. **It cannot regress the app**, whose only use of verification is a self-check on events it has just signed itself (where the id always matches by construction). Exposure was nil, but it is precisely the class of bug that motivated this migration in the first place.

### 2. Invariant I7 was never actually pinned (§2.2)

The spec claimed I7 ("same nsec always derives the same npub; import round-trips") was *"pinned by key manager tests"*. **There were no key manager tests.** Since Phase 4 swaps the crypto backend underneath exactly that code, the invariant needed teeth *before* then, not after. Added: first launch, reopening the app, npub/nsec round-trips, nsec import (valid and malformed), and the repair path for a stored pubkey that disagrees with its private key — all against an in-memory secure storage.

## Test plan

- [x] `flutter test` — **136 passing** (110 existing + 19 contract + 7 key manager)
- [x] `flutter analyze` — 51 issues, one *fewer* than `main` (the dead import); zero introduced
- [x] Android APK builds with the seam in place
- [x] `grep -rn "package:nostr_tools" lib/` returns exactly one file
- [x] Behavior-preserving apart from the verification hardening in §2.1

## Rollback

Revert the PR. Nothing changes shape for the caller: `KeyManager()` and `NostrService(keyManager)` still work with no arguments, defaulting to `NostrToolsCrypto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD1yHCBE9EBjjafUz8N1Gg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated cryptography layer for key generation, NIP-19 encoding/decoding, event signing, and verification.
  - Added stronger protection against tampered or forged events.
  - Key management now supports reliable identity recovery, import, validation, and repair.

- **Refactor**
  - Decoupled application Nostr functionality from its underlying cryptography implementation.

- **Tests**
  - Added comprehensive coverage for key persistence, imports, round-trips, event signing, and signature validation.

- **Documentation**
  - Updated migration progress, contract findings, invariants, and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->