### PR TITLE
feat(rust): Phase 3 — Rust crypto implementation, proven equivalent by differential tests

### DIFF
--- a/docs/specs/nostr-sdk-migration.md
+++ b/docs/specs/nostr-sdk-migration.md
@@ -1,12 +1,12 @@
 # Migration Spec: `nostr_tools` (Dart) → `nostr-sdk` (Rust) via `flutter_rust_bridge`
 
-**Status:** APPROVED — Phases 0-2 complete, Phase 3 next
+**Status:** APPROVED — Phases 0-3 complete, Phase 4 next
 **Author:** prepared with Claude Code
 **Date:** 2026-07-13
 **Decisions locked (2026-07-13):** web target frozen (§5, W1) · own thin Rust
 crate over official Flutter bindings (§9.2) · manual QA on Android (§9.3)
 
-**Progress:** Phases 0 ✅ 1 ✅ 2 ✅ · Phases 3–8 pending
+**Progress:** Phases 0 ✅ 1 ✅ 2 ✅ 3 ✅ · Phases 4–8 pending
 
 ---
 
@@ -320,7 +320,7 @@ the invariant needed teeth before then, not after.
 
 ---
 
-### Phase 3 — Rust crypto implementation + differential tests *(PR: additive)*
+### Phase 3 — Rust crypto implementation + differential tests — ✅ **DONE (2026-07-13)** *(PR: additive)*
 
 **Goal:** a fully verified Rust implementation, not yet default.
 
@@ -342,9 +342,49 @@ Steps:
 5. Wire the backend selector: `nostrCryptoProvider` reads
    `String.fromEnvironment('NOSTR_BACKEND', defaultValue: 'legacy')`.
 
-**Tests:** contract ×2 + differential suite (tagged `rust`, run in the CI job that
-has the native lib).
-**Acceptance:** both impls pass identical contracts; differential suite green.
+#### 3.1 Events cross the bridge as structs, not JSON
+
+The event id is a hash of the event's canonical serialization. Passing events
+over FFI as JSON would have put a **second** serializer in the path (Dart's
+`jsonEncode` on one side, `serde` on the other) — a silent canonicalization the
+differential tests could only have caught by luck. The bridge therefore carries
+the *fields* (`UnsignedEventData` / `SignedEventData`), and the `nostr` crate
+performs the only serialization that counts.
+
+#### 3.2 Results
+
+Both implementations pass the **identical** Phase 2 contract — 19 tests, not a
+line of it changed — plus 10 differential tests. `nostr_tools` and the Rust
+crate agree on:
+
+- the public key, npub and nsec derived from the same private key (20 random
+  keys per run), and each accepts the other's generated keys;
+- **the event id**, for every hostile content vector tried — empty, accented,
+  CJK, emoji, embedded quotes, newlines, tabs, back- and forward-slashes, and
+  raw match JSON — and for tag sets from empty to unicode d-tags. Identical ids
+  mean both libraries serialize to identical canonical bytes;
+- `created_at` preserved exactly across the FFI boundary (0 → 4102444800),
+  which matters because NIP-01 replacement ordering turns on it (I1);
+- rejecting a post-signing tamper, keeping §2.1's divergence closed.
+
+Signatures are *not* compared byte for byte — Schnorr signing uses a random
+nonce, so they legitimately differ. What is asserted instead is the property
+that actually matters: **each library verifies the other's signatures**, which
+is what a relay and every other Nostr client will do.
+
+**Size, re-measured** (§0.3 asked Phase 3 not to assume headroom): release APK
+`43.9 MB` (baseline `41.7`, so +2.2 MB); `librust_lib_choke.so` = 2.09 MB. The
+seven new crypto functions cost ~0.08 MB — the bulk was already paid for by
+secp256k1 in Phase 1. Comfortably inside the ≤6 MB budget.
+
+**Backend selector:** `--dart-define=NOSTR_BACKEND=rust|legacy`, defaulting to
+`legacy`. `main.dart` initializes `RustLib` only when Rust is selected. Both
+APKs build.
+
+**Tests:** contract ×2 + differential suite (tagged `rust`; CI's `bridge` job
+already runs `flutter test --tags rust`, so it picks them up with no workflow
+change). 165 Dart tests + 10 Rust unit tests.
+**Acceptance:** both impls pass identical contracts; differential suite green. ✅
 **Rollback:** revert; default is still `legacy`.
 
 ---

--- a/docs/specs/nostr-sdk-migration.md
+++ b/docs/specs/nostr-sdk-migration.md
@@ -326,9 +326,13 @@ the invariant needed teeth before then, not after.
 
 Steps:
 1. Extend the crate: `generate_secret_key`, `public_key_from_secret`,
-   `npub_encode`, `nsec_encode`, `nsec_decode`, `finish_event(unsigned_json, sk)`,
-   `verify_event(json)` — thin wrappers over `nostr::Keys`, `nostr::nips::nip19`,
-   `nostr::EventBuilder`/`UnsignedEvent`.
+   `npub_encode`, `nsec_encode`, `nsec_decode`, plus — over **typed** FFI
+   structs rather than JSON, for the reason in §3.1 —
+   `finish_event(UnsignedEventData, secret_hex) -> SignedEventData` and
+   `verify_event_data(SignedEventData) -> bool`. Thin wrappers over
+   `nostr::Keys`, `nostr::nips::nip19` and `nostr::UnsignedEvent`.
+   (`verify_event(json)` from Phase 1 stays, unused by the app but handy as a
+   smoke test of the bridge.)
 2. `RustNostrCrypto implements NostrCrypto` over the generated bindings.
 3. Run the Phase 2 contract suite against `RustNostrCrypto`.
 4. **Differential tests** (the heart of this phase): for a corpus of fixed vectors

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,15 +15,42 @@ import 'features/settings/providers/relay_config_provider.dart';
 import 'services/key_management/key_manager.dart';
 import 'services/nostr/crypto/nostr_crypto.dart';
 import 'services/nostr/crypto/nostr_tools_crypto.dart';
+import 'services/nostr/crypto/rust_nostr_crypto.dart';
 import 'services/nostr/nostr_service.dart';
+import 'src/rust/frb_generated.dart';
+
+/// Which crypto implementation the app runs on.
+///
+/// `legacy` is the Dart `nostr_tools` package; `rust` is the maintained Rust
+/// `nostr` crate. Phase 3 ships both and still defaults to `legacy`; Phase 4
+/// flips this default — which is why it is a flag rather than an edit, and why
+/// rolling back needs no code change:
+///
+///   flutter run --dart-define=NOSTR_BACKEND=rust
+///
+/// See docs/specs/nostr-sdk-migration.md.
+const _nostrBackend = String.fromEnvironment(
+  'NOSTR_BACKEND',
+  defaultValue: 'legacy',
+);
+
+/// Build the selected crypto backend, initializing whatever it needs.
+Future<NostrCrypto> _buildCrypto() async {
+  if (_nostrBackend != 'rust') return NostrToolsCrypto();
+
+  // Loads the native library. Failing loudly here beats limping on: without it
+  // nothing can be signed, and every match would silently go unpublished.
+  await RustLib.init();
+  debugPrint('Nostr crypto backend: rust');
+  return const RustNostrCrypto();
+}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // The one place the crypto implementation is chosen. Everything downstream
-  // takes it as a NostrCrypto, so swapping the backend (Phase 4) is a change
-  // to this line alone. See docs/specs/nostr-sdk-migration.md.
-  final NostrCrypto crypto = NostrToolsCrypto();
+  // takes it as a NostrCrypto, so the backend swap never reaches a call site.
+  final NostrCrypto crypto = await _buildCrypto();
 
   // Initialize KeyManager
   final keyManager = KeyManager(crypto: crypto);

--- a/lib/services/nostr/crypto/rust_nostr_crypto.dart
+++ b/lib/services/nostr/crypto/rust_nostr_crypto.dart
@@ -1,0 +1,73 @@
+import '../../../src/rust/api/crypto.dart' as rust;
+import '../nostr_service.dart' show NostrEvent;
+import 'nostr_crypto.dart';
+
+/// [NostrCrypto] backed by the Rust `nostr` crate, reached over
+/// flutter_rust_bridge.
+///
+/// Requires `RustLib` to have been initialized first — `main.dart` does that
+/// when the Rust backend is selected. Every call is synchronous: these are
+/// microsecond-scale operations, so hopping to a worker isolate would cost
+/// more than it saves.
+///
+/// See docs/specs/nostr-sdk-migration.md.
+class RustNostrCrypto implements NostrCrypto {
+  const RustNostrCrypto();
+
+  @override
+  String generatePrivateKey() => rust.generateSecretKey();
+
+  @override
+  String getPublicKey(String privateKeyHex) =>
+      rust.publicKeyFromSecret(secretHex: privateKeyHex);
+
+  @override
+  String npubEncode(String publicKeyHex) =>
+      rust.npubEncode(publicKeyHex: publicKeyHex);
+
+  @override
+  String nsecEncode(String privateKeyHex) =>
+      rust.nsecEncode(secretHex: privateKeyHex);
+
+  @override
+  String? nsecDecode(String nsec) => rust.nsecDecode(nsec: nsec);
+
+  @override
+  NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex) {
+    final signed = rust.finishEvent(
+      event: rust.UnsignedEventData(
+        pubkey: event.pubkey,
+        createdAt: event.createdAt,
+        kind: event.kind,
+        tags: event.tags,
+        content: event.content,
+      ),
+      secretHex: privateKeyHex,
+    );
+
+    return NostrEvent(
+      id: signed.id,
+      pubkey: signed.pubkey,
+      createdAt: signed.createdAt,
+      kind: signed.kind,
+      tags: signed.tags,
+      content: signed.content,
+      sig: signed.sig,
+    );
+  }
+
+  @override
+  bool verifyEvent(NostrEvent event) {
+    return rust.verifyEventData(
+      event: rust.SignedEventData(
+        id: event.id,
+        pubkey: event.pubkey,
+        createdAt: event.createdAt,
+        kind: event.kind,
+        tags: event.tags,
+        content: event.content,
+        sig: event.sig,
+      ),
+    );
+  }
+}

--- a/lib/src/rust/api/crypto.dart
+++ b/lib/src/rust/api/crypto.dart
@@ -6,6 +6,44 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
+// These functions are ignored because they are not marked as `pub`: `parse_tags`, `to_event`, `to_signed_data`
+
+/// A fresh secp256k1 private key, as lowercase hex.
+String generateSecretKey() =>
+    RustLib.instance.api.crateApiCryptoGenerateSecretKey();
+
+/// The public key belonging to `secret_hex`, as lowercase hex.
+String publicKeyFromSecret({required String secretHex}) => RustLib.instance.api
+    .crateApiCryptoPublicKeyFromSecret(secretHex: secretHex);
+
+/// NIP-19 bech32 encoding of a hex public key (`npub1…`).
+String npubEncode({required String publicKeyHex}) =>
+    RustLib.instance.api.crateApiCryptoNpubEncode(publicKeyHex: publicKeyHex);
+
+/// NIP-19 bech32 encoding of a hex private key (`nsec1…`).
+String nsecEncode({required String secretHex}) =>
+    RustLib.instance.api.crateApiCryptoNsecEncode(secretHex: secretHex);
+
+/// The hex private key inside `nsec`, or `None` if it is not a valid nsec.
+///
+/// `None` rather than an error: a malformed nsec is something a user can type,
+/// not a bug. An npub is rejected here too — it is bech32 of the same family,
+/// and reading one as a private key would be a catastrophic confusion.
+String? nsecDecode({required String nsec}) =>
+    RustLib.instance.api.crateApiCryptoNsecDecode(nsec: nsec);
+
+/// Compute `event`'s id and sign it with `secret_hex`.
+SignedEventData finishEvent(
+        {required UnsignedEventData event, required String secretHex}) =>
+    RustLib.instance.api
+        .crateApiCryptoFinishEvent(event: event, secretHex: secretHex);
+
+/// Whether `event`'s id hashes its own contents *and* its signature is the one
+/// its pubkey would produce. Both must hold: an event whose content was
+/// rewritten after signing still carries a valid signature over a now-wrong id.
+bool verifyEventData({required SignedEventData event}) =>
+    RustLib.instance.api.crateApiCryptoVerifyEventData(event: event);
+
 /// Whether `event_json` is a well-formed Nostr event whose id and Schnorr
 /// signature both check out.
 ///
@@ -13,3 +51,84 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 /// that parses but fails verification is `Ok(false)`.
 bool verifyEvent({required String eventJson}) =>
     RustLib.instance.api.crateApiCryptoVerifyEvent(eventJson: eventJson);
+
+/// A signed event, exactly as it goes to a relay.
+class SignedEventData {
+  final String id;
+  final String pubkey;
+  final PlatformInt64 createdAt;
+  final int kind;
+  final List<List<String>> tags;
+  final String content;
+  final String sig;
+
+  const SignedEventData({
+    required this.id,
+    required this.pubkey,
+    required this.createdAt,
+    required this.kind,
+    required this.tags,
+    required this.content,
+    required this.sig,
+  });
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      pubkey.hashCode ^
+      createdAt.hashCode ^
+      kind.hashCode ^
+      tags.hashCode ^
+      content.hashCode ^
+      sig.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SignedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          pubkey == other.pubkey &&
+          createdAt == other.createdAt &&
+          kind == other.kind &&
+          tags == other.tags &&
+          content == other.content &&
+          sig == other.sig;
+}
+
+/// An event assembled but not yet signed: no id and no signature, because
+/// both are derived from these fields.
+class UnsignedEventData {
+  final String pubkey;
+  final PlatformInt64 createdAt;
+  final int kind;
+  final List<List<String>> tags;
+  final String content;
+
+  const UnsignedEventData({
+    required this.pubkey,
+    required this.createdAt,
+    required this.kind,
+    required this.tags,
+    required this.content,
+  });
+
+  @override
+  int get hashCode =>
+      pubkey.hashCode ^
+      createdAt.hashCode ^
+      kind.hashCode ^
+      tags.hashCode ^
+      content.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnsignedEventData &&
+          runtimeType == other.runtimeType &&
+          pubkey == other.pubkey &&
+          createdAt == other.createdAt &&
+          kind == other.kind &&
+          tags == other.tags &&
+          content == other.content;
+}

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 1623134185;
+  int get rustContentHash => 141708053;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -82,9 +82,24 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 }
 
 abstract class RustLibApi extends BaseApi {
+  SignedEventData crateApiCryptoFinishEvent(
+      {required UnsignedEventData event, required String secretHex});
+
+  String crateApiCryptoGenerateSecretKey();
+
   Future<void> crateApiCryptoInitApp();
 
+  String crateApiCryptoNpubEncode({required String publicKeyHex});
+
+  String? crateApiCryptoNsecDecode({required String nsec});
+
+  String crateApiCryptoNsecEncode({required String secretHex});
+
+  String crateApiCryptoPublicKeyFromSecret({required String secretHex});
+
   bool crateApiCryptoVerifyEvent({required String eventJson});
+
+  bool crateApiCryptoVerifyEventData({required SignedEventData event});
 }
 
 class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
@@ -96,12 +111,60 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   });
 
   @override
+  SignedEventData crateApiCryptoFinishEvent(
+      {required UnsignedEventData event, required String secretHex}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_unsigned_event_data(event, serializer);
+        sse_encode_String(secretHex, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_signed_event_data,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiCryptoFinishEventConstMeta,
+      argValues: [event, secretHex],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoFinishEventConstMeta => const TaskConstMeta(
+        debugName: "finish_event",
+        argNames: ["event", "secretHex"],
+      );
+
+  @override
+  String crateApiCryptoGenerateSecretKey() {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiCryptoGenerateSecretKeyConstMeta,
+      argValues: [],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoGenerateSecretKeyConstMeta =>
+      const TaskConstMeta(
+        debugName: "generate_secret_key",
+        argNames: [],
+      );
+
+  @override
   Future<void> crateApiCryptoInitApp() {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 1, port: port_);
+            funcId: 3, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -119,12 +182,105 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  String crateApiCryptoNpubEncode({required String publicKeyHex}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(publicKeyHex, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiCryptoNpubEncodeConstMeta,
+      argValues: [publicKeyHex],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoNpubEncodeConstMeta => const TaskConstMeta(
+        debugName: "npub_encode",
+        argNames: ["publicKeyHex"],
+      );
+
+  @override
+  String? crateApiCryptoNsecDecode({required String nsec}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(nsec, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_opt_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiCryptoNsecDecodeConstMeta,
+      argValues: [nsec],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoNsecDecodeConstMeta => const TaskConstMeta(
+        debugName: "nsec_decode",
+        argNames: ["nsec"],
+      );
+
+  @override
+  String crateApiCryptoNsecEncode({required String secretHex}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(secretHex, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiCryptoNsecEncodeConstMeta,
+      argValues: [secretHex],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoNsecEncodeConstMeta => const TaskConstMeta(
+        debugName: "nsec_encode",
+        argNames: ["secretHex"],
+      );
+
+  @override
+  String crateApiCryptoPublicKeyFromSecret({required String secretHex}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(secretHex, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_String,
+        decodeErrorData: sse_decode_String,
+      ),
+      constMeta: kCrateApiCryptoPublicKeyFromSecretConstMeta,
+      argValues: [secretHex],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoPublicKeyFromSecretConstMeta =>
+      const TaskConstMeta(
+        debugName: "public_key_from_secret",
+        argNames: ["secretHex"],
+      );
+
+  @override
   bool crateApiCryptoVerifyEvent({required String eventJson}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(eventJson, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -141,6 +297,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         argNames: ["eventJson"],
       );
 
+  @override
+  bool crateApiCryptoVerifyEventData({required SignedEventData event}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_box_autoadd_signed_event_data(event, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_bool,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiCryptoVerifyEventDataConstMeta,
+      argValues: [event],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoVerifyEventDataConstMeta =>
+      const TaskConstMeta(
+        debugName: "verify_event_data",
+        argNames: ["event"],
+      );
+
   @protected
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -154,9 +334,68 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SignedEventData dco_decode_box_autoadd_signed_event_data(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_signed_event_data(raw);
+  }
+
+  @protected
+  UnsignedEventData dco_decode_box_autoadd_unsigned_event_data(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dco_decode_unsigned_event_data(raw);
+  }
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return dcoDecodeI64(raw);
+  }
+
+  @protected
+  List<String> dco_decode_list_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_String).toList();
+  }
+
+  @protected
+  List<List<String>> dco_decode_list_list_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_list_String).toList();
+  }
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as Uint8List;
+  }
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_String(raw);
+  }
+
+  @protected
+  SignedEventData dco_decode_signed_event_data(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    return SignedEventData(
+      id: dco_decode_String(arr[0]),
+      pubkey: dco_decode_String(arr[1]),
+      createdAt: dco_decode_i_64(arr[2]),
+      kind: dco_decode_u_16(arr[3]),
+      tags: dco_decode_list_list_String(arr[4]),
+      content: dco_decode_String(arr[5]),
+      sig: dco_decode_String(arr[6]),
+    );
+  }
+
+  @protected
+  int dco_decode_u_16(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as int;
   }
 
   @protected
@@ -169,6 +408,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void dco_decode_unit(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return;
+  }
+
+  @protected
+  UnsignedEventData dco_decode_unsigned_event_data(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return UnsignedEventData(
+      pubkey: dco_decode_String(arr[0]),
+      createdAt: dco_decode_i_64(arr[1]),
+      kind: dco_decode_u_16(arr[2]),
+      tags: dco_decode_list_list_String(arr[3]),
+      content: dco_decode_String(arr[4]),
+    );
   }
 
   @protected
@@ -185,10 +439,91 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SignedEventData sse_decode_box_autoadd_signed_event_data(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_signed_event_data(deserializer));
+  }
+
+  @protected
+  UnsignedEventData sse_decode_box_autoadd_unsigned_event_data(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_unsigned_event_data(deserializer));
+  }
+
+  @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getPlatformInt64();
+  }
+
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <String>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<List<String>> sse_decode_list_list_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <List<String>>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_list_String(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var len_ = sse_decode_i_32(deserializer);
     return deserializer.buffer.getUint8List(len_);
+  }
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_String(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  SignedEventData sse_decode_signed_event_data(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_id = sse_decode_String(deserializer);
+    var var_pubkey = sse_decode_String(deserializer);
+    var var_createdAt = sse_decode_i_64(deserializer);
+    var var_kind = sse_decode_u_16(deserializer);
+    var var_tags = sse_decode_list_list_String(deserializer);
+    var var_content = sse_decode_String(deserializer);
+    var var_sig = sse_decode_String(deserializer);
+    return SignedEventData(
+        id: var_id,
+        pubkey: var_pubkey,
+        createdAt: var_createdAt,
+        kind: var_kind,
+        tags: var_tags,
+        content: var_content,
+        sig: var_sig);
+  }
+
+  @protected
+  int sse_decode_u_16(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return deserializer.buffer.getUint16();
   }
 
   @protected
@@ -200,6 +535,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_decode_unit(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+
+  @protected
+  UnsignedEventData sse_decode_unsigned_event_data(
+      SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_pubkey = sse_decode_String(deserializer);
+    var var_createdAt = sse_decode_i_64(deserializer);
+    var var_kind = sse_decode_u_16(deserializer);
+    var var_tags = sse_decode_list_list_String(deserializer);
+    var var_content = sse_decode_String(deserializer);
+    return UnsignedEventData(
+        pubkey: var_pubkey,
+        createdAt: var_createdAt,
+        kind: var_kind,
+        tags: var_tags,
+        content: var_content);
   }
 
   @protected
@@ -221,11 +573,79 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_box_autoadd_signed_event_data(
+      SignedEventData self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_signed_event_data(self, serializer);
+  }
+
+  @protected
+  void sse_encode_box_autoadd_unsigned_event_data(
+      UnsignedEventData self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_unsigned_event_data(self, serializer);
+  }
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putPlatformInt64(self);
+  }
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_String(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_list_String(
+      List<List<String>> self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_list_String(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
       Uint8List self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_i_32(self.length, serializer);
     serializer.buffer.putUint8List(self);
+  }
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_String(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_signed_event_data(
+      SignedEventData self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.id, serializer);
+    sse_encode_String(self.pubkey, serializer);
+    sse_encode_i_64(self.createdAt, serializer);
+    sse_encode_u_16(self.kind, serializer);
+    sse_encode_list_list_String(self.tags, serializer);
+    sse_encode_String(self.content, serializer);
+    sse_encode_String(self.sig, serializer);
+  }
+
+  @protected
+  void sse_encode_u_16(int self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    serializer.buffer.putUint16(self);
   }
 
   @protected
@@ -237,6 +657,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_unit(void self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+
+  @protected
+  void sse_encode_unsigned_event_data(
+      UnsignedEventData self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.pubkey, serializer);
+    sse_encode_i_64(self.createdAt, serializer);
+    sse_encode_u_16(self.kind, serializer);
+    sse_encode_list_list_String(self.tags, serializer);
+    sse_encode_String(self.content, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -25,7 +25,31 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   bool dco_decode_bool(dynamic raw);
 
   @protected
+  SignedEventData dco_decode_box_autoadd_signed_event_data(dynamic raw);
+
+  @protected
+  UnsignedEventData dco_decode_box_autoadd_unsigned_event_data(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw);
+
+  @protected
+  List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<List<String>> dco_decode_list_list_String(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
+  SignedEventData dco_decode_signed_event_data(dynamic raw);
+
+  @protected
+  int dco_decode_u_16(dynamic raw);
 
   @protected
   int dco_decode_u_8(dynamic raw);
@@ -34,19 +58,52 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void dco_decode_unit(dynamic raw);
 
   @protected
+  UnsignedEventData dco_decode_unsigned_event_data(dynamic raw);
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
+  SignedEventData sse_decode_box_autoadd_signed_event_data(
+      SseDeserializer deserializer);
+
+  @protected
+  UnsignedEventData sse_decode_box_autoadd_unsigned_event_data(
+      SseDeserializer deserializer);
+
+  @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<List<String>> sse_decode_list_list_String(SseDeserializer deserializer);
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
+  SignedEventData sse_decode_signed_event_data(SseDeserializer deserializer);
+
+  @protected
+  int sse_decode_u_16(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_8(SseDeserializer deserializer);
 
   @protected
   void sse_decode_unit(SseDeserializer deserializer);
+
+  @protected
+  UnsignedEventData sse_decode_unsigned_event_data(
+      SseDeserializer deserializer);
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -58,14 +115,46 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_signed_event_data(
+      SignedEventData self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_unsigned_event_data(
+      UnsignedEventData self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_list_String(
+      List<List<String>> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
       Uint8List self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_signed_event_data(
+      SignedEventData self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_16(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_8(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_unsigned_event_data(
+      UnsignedEventData self, SseSerializer serializer);
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -27,7 +27,31 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   bool dco_decode_bool(dynamic raw);
 
   @protected
+  SignedEventData dco_decode_box_autoadd_signed_event_data(dynamic raw);
+
+  @protected
+  UnsignedEventData dco_decode_box_autoadd_unsigned_event_data(dynamic raw);
+
+  @protected
+  PlatformInt64 dco_decode_i_64(dynamic raw);
+
+  @protected
+  List<String> dco_decode_list_String(dynamic raw);
+
+  @protected
+  List<List<String>> dco_decode_list_list_String(dynamic raw);
+
+  @protected
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
+  SignedEventData dco_decode_signed_event_data(dynamic raw);
+
+  @protected
+  int dco_decode_u_16(dynamic raw);
 
   @protected
   int dco_decode_u_8(dynamic raw);
@@ -36,19 +60,52 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void dco_decode_unit(dynamic raw);
 
   @protected
+  UnsignedEventData dco_decode_unsigned_event_data(dynamic raw);
+
+  @protected
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
+  SignedEventData sse_decode_box_autoadd_signed_event_data(
+      SseDeserializer deserializer);
+
+  @protected
+  UnsignedEventData sse_decode_box_autoadd_unsigned_event_data(
+      SseDeserializer deserializer);
+
+  @protected
+  PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
+  List<String> sse_decode_list_String(SseDeserializer deserializer);
+
+  @protected
+  List<List<String>> sse_decode_list_list_String(SseDeserializer deserializer);
+
+  @protected
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
+  SignedEventData sse_decode_signed_event_data(SseDeserializer deserializer);
+
+  @protected
+  int sse_decode_u_16(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_8(SseDeserializer deserializer);
 
   @protected
   void sse_decode_unit(SseDeserializer deserializer);
+
+  @protected
+  UnsignedEventData sse_decode_unsigned_event_data(
+      SseDeserializer deserializer);
 
   @protected
   int sse_decode_i_32(SseDeserializer deserializer);
@@ -60,14 +117,46 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_signed_event_data(
+      SignedEventData self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_box_autoadd_unsigned_event_data(
+      UnsignedEventData self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_String(List<String> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_list_String(
+      List<List<String>> self, SseSerializer serializer);
+
+  @protected
   void sse_encode_list_prim_u_8_strict(
       Uint8List self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_signed_event_data(
+      SignedEventData self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_u_16(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_8(int self, SseSerializer serializer);
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_unsigned_event_data(
+      UnsignedEventData self, SseSerializer serializer);
 
   @protected
   void sse_encode_i_32(int self, SseSerializer serializer);

--- a/rust/src/api/crypto.rs
+++ b/rust/src/api/crypto.rs
@@ -5,10 +5,113 @@
 //! it bounds the binary, and an upstream API change lands in one file
 //! instead of across the Dart codebase.
 //!
-//! Phase 1 exposes only [`verify_event`], enough to prove the toolchain
-//! links and runs. Keys, NIP-19 and signing arrive in Phase 3.
+//! Events cross the bridge as structs, not as JSON. The event id is a hash of
+//! the event's canonical serialization, so letting each side serialize its own
+//! JSON would put a second, silent canonicalization in the path — exactly the
+//! divergence the differential tests exist to catch. Instead the fields travel,
+//! and the `nostr` crate performs the only serialization that matters.
+
+use std::str::FromStr;
 
 use nostr::prelude::*;
+
+/// An event assembled but not yet signed: no id and no signature, because
+/// both are derived from these fields.
+pub struct UnsignedEventData {
+    pub pubkey: String,
+    pub created_at: i64,
+    pub kind: u16,
+    pub tags: Vec<Vec<String>>,
+    pub content: String,
+}
+
+/// A signed event, exactly as it goes to a relay.
+pub struct SignedEventData {
+    pub id: String,
+    pub pubkey: String,
+    pub created_at: i64,
+    pub kind: u16,
+    pub tags: Vec<Vec<String>>,
+    pub content: String,
+    pub sig: String,
+}
+
+/// A fresh secp256k1 private key, as lowercase hex.
+#[flutter_rust_bridge::frb(sync)]
+pub fn generate_secret_key() -> String {
+    Keys::generate().secret_key().to_secret_hex()
+}
+
+/// The public key belonging to `secret_hex`, as lowercase hex.
+#[flutter_rust_bridge::frb(sync)]
+pub fn public_key_from_secret(secret_hex: String) -> Result<String, String> {
+    let keys = Keys::parse(&secret_hex).map_err(|e| e.to_string())?;
+    Ok(keys.public_key().to_hex())
+}
+
+/// NIP-19 bech32 encoding of a hex public key (`npub1…`).
+#[flutter_rust_bridge::frb(sync)]
+pub fn npub_encode(public_key_hex: String) -> Result<String, String> {
+    let public_key = PublicKey::parse(&public_key_hex).map_err(|e| e.to_string())?;
+    public_key.to_bech32().map_err(|e| e.to_string())
+}
+
+/// NIP-19 bech32 encoding of a hex private key (`nsec1…`).
+#[flutter_rust_bridge::frb(sync)]
+pub fn nsec_encode(secret_hex: String) -> Result<String, String> {
+    let secret_key = SecretKey::parse(&secret_hex).map_err(|e| e.to_string())?;
+    secret_key.to_bech32().map_err(|e| e.to_string())
+}
+
+/// The hex private key inside `nsec`, or `None` if it is not a valid nsec.
+///
+/// `None` rather than an error: a malformed nsec is something a user can type,
+/// not a bug. An npub is rejected here too — it is bech32 of the same family,
+/// and reading one as a private key would be a catastrophic confusion.
+#[flutter_rust_bridge::frb(sync)]
+pub fn nsec_decode(nsec: String) -> Option<String> {
+    SecretKey::from_bech32(&nsec)
+        .ok()
+        .map(|secret_key| secret_key.to_secret_hex())
+}
+
+/// Compute `event`'s id and sign it with `secret_hex`.
+#[flutter_rust_bridge::frb(sync)]
+pub fn finish_event(
+    event: UnsignedEventData,
+    secret_hex: String,
+) -> Result<SignedEventData, String> {
+    let keys = Keys::parse(&secret_hex).map_err(|e| e.to_string())?;
+    let public_key = PublicKey::parse(&event.pubkey).map_err(|e| e.to_string())?;
+    let tags = parse_tags(&event.tags)?;
+
+    let created_at = u64::try_from(event.created_at)
+        .map_err(|_| format!("created_at cannot be negative: {}", event.created_at))?;
+
+    let unsigned = UnsignedEvent::new(
+        public_key,
+        Timestamp::from(created_at),
+        Kind::from(event.kind),
+        tags,
+        event.content,
+    );
+
+    let signed = unsigned.sign_with_keys(&keys).map_err(|e| e.to_string())?;
+    Ok(to_signed_data(&signed))
+}
+
+/// Whether `event`'s id hashes its own contents *and* its signature is the one
+/// its pubkey would produce. Both must hold: an event whose content was
+/// rewritten after signing still carries a valid signature over a now-wrong id.
+#[flutter_rust_bridge::frb(sync)]
+pub fn verify_event_data(event: SignedEventData) -> bool {
+    match to_event(&event) {
+        Ok(event) => event.verify().is_ok(),
+        // Unparseable fields (a malformed pubkey, bad signature hex) mean this
+        // is not a valid event — which is exactly what `false` says.
+        Err(_) => false,
+    }
+}
 
 /// Whether `event_json` is a well-formed Nostr event whose id and Schnorr
 /// signature both check out.
@@ -26,9 +129,52 @@ pub fn init_app() {
     flutter_rust_bridge::setup_default_user_utils();
 }
 
+fn parse_tags(tags: &[Vec<String>]) -> Result<Vec<Tag>, String> {
+    tags.iter()
+        .map(|tag| Tag::parse(tag.clone()).map_err(|e| e.to_string()))
+        .collect()
+}
+
+fn to_signed_data(event: &Event) -> SignedEventData {
+    SignedEventData {
+        id: event.id.to_hex(),
+        pubkey: event.pubkey.to_hex(),
+        created_at: event.created_at.as_secs() as i64,
+        kind: event.kind.as_u16(),
+        tags: event.tags.iter().map(|tag| tag.clone().to_vec()).collect(),
+        content: event.content.clone(),
+        sig: event.sig.to_string(),
+    }
+}
+
+fn to_event(data: &SignedEventData) -> Result<Event, String> {
+    let created_at =
+        u64::try_from(data.created_at).map_err(|_| "negative created_at".to_string())?;
+
+    Ok(Event::new(
+        EventId::from_hex(&data.id).map_err(|e| e.to_string())?,
+        PublicKey::parse(&data.pubkey).map_err(|e| e.to_string())?,
+        Timestamp::from(created_at),
+        Kind::from(data.kind),
+        parse_tags(&data.tags)?,
+        data.content.clone(),
+        Signature::from_str(&data.sig).map_err(|e| e.to_string())?,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn unsigned(pubkey: &str) -> UnsignedEventData {
+        UnsignedEventData {
+            pubkey: pubkey.to_string(),
+            created_at: 1_700_000_000,
+            kind: 31415,
+            tags: vec![vec!["d".to_string(), "abcd".to_string()]],
+            content: "choke".to_string(),
+        }
+    }
 
     /// A real signed event: the id and signature must both hold.
     fn signed_event() -> String {
@@ -54,5 +200,71 @@ mod tests {
     #[test]
     fn errors_on_input_that_is_not_an_event() {
         assert!(verify_event("{\"not\":\"an event\"}".to_string()).is_err());
+    }
+
+    #[test]
+    fn signs_an_event_that_verifies() {
+        let secret = generate_secret_key();
+        let pubkey = public_key_from_secret(secret.clone()).unwrap();
+
+        let event = finish_event(unsigned(&pubkey), secret).unwrap();
+
+        assert!(verify_event_data(event));
+    }
+
+    #[test]
+    fn signing_the_same_event_twice_gives_the_same_id() {
+        // The id hashes the event, not the signing nonce.
+        let secret = generate_secret_key();
+        let pubkey = public_key_from_secret(secret.clone()).unwrap();
+
+        let first = finish_event(unsigned(&pubkey), secret.clone()).unwrap();
+        let second = finish_event(unsigned(&pubkey), secret).unwrap();
+
+        assert_eq!(first.id, second.id);
+    }
+
+    #[test]
+    fn rejects_an_event_whose_content_changed_after_signing() {
+        let secret = generate_secret_key();
+        let pubkey = public_key_from_secret(secret.clone()).unwrap();
+        let mut event = finish_event(unsigned(&pubkey), secret).unwrap();
+
+        event.content = "choked".to_string();
+
+        assert!(!verify_event_data(event));
+    }
+
+    #[test]
+    fn nsec_round_trips() {
+        let secret = generate_secret_key();
+
+        let nsec = nsec_encode(secret.clone()).unwrap();
+
+        assert_eq!(nsec_decode(nsec), Some(secret));
+    }
+
+    #[test]
+    fn nsec_decode_rejects_an_npub() {
+        let secret = generate_secret_key();
+        let pubkey = public_key_from_secret(secret).unwrap();
+        let npub = npub_encode(pubkey).unwrap();
+
+        assert_eq!(nsec_decode(npub), None);
+    }
+
+    #[test]
+    fn nsec_decode_rejects_nonsense() {
+        assert_eq!(nsec_decode("not an nsec".to_string()), None);
+    }
+
+    /// The vector published in NIP-19 itself.
+    #[test]
+    fn matches_the_nip19_test_vector() {
+        const SECRET: &str = "67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa";
+        const NSEC: &str = "nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5";
+
+        assert_eq!(nsec_encode(SECRET.to_string()).unwrap(), NSEC);
+        assert_eq!(nsec_decode(NSEC.to_string()), Some(SECRET.to_string()));
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1623134185;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 141708053;
 
 // Section: executor
 
@@ -46,6 +46,66 @@ flutter_rust_bridge::frb_generated_default_handler!();
 
 // Section: wire_funcs
 
+fn wire__crate__api__crypto__finish_event_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "finish_event",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_event = <crate::api::crypto::UnsignedEventData>::sse_decode(&mut deserializer);
+            let api_secret_hex = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::crypto::finish_event(api_event, api_secret_hex)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__crypto__generate_secret_key_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_secret_key",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::crypto::generate_secret_key())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__crypto__init_app_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -80,6 +140,126 @@ fn wire__crate__api__crypto__init_app_impl(
         },
     )
 }
+fn wire__crate__api__crypto__npub_encode_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "npub_encode",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_public_key_hex = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::crypto::npub_encode(api_public_key_hex)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__crypto__nsec_decode_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "nsec_decode",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_nsec = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::crypto::nsec_decode(api_nsec))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__crypto__nsec_encode_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "nsec_encode",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_secret_hex = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::crypto::nsec_encode(api_secret_hex)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
+fn wire__crate__api__crypto__public_key_from_secret_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "public_key_from_secret",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_secret_hex = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::crypto::public_key_from_secret(api_secret_hex)?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__crypto__verify_event_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -110,6 +290,37 @@ fn wire__crate__api__crypto__verify_event_impl(
         },
     )
 }
+fn wire__crate__api__crypto__verify_event_data_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "verify_event_data",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_event = <crate::api::crypto::SignedEventData>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok =
+                    Result::<_, ()>::Ok(crate::api::crypto::verify_event_data(api_event))?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 
 // Section: dart2rust
 
@@ -128,6 +339,37 @@ impl SseDecode for bool {
     }
 }
 
+impl SseDecode for i64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_i64::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for Vec<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<String>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<Vec<String>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = Vec::with_capacity(len_ as usize);
+        for idx_ in 0..len_ {
+            ans_.push(<Vec<String>>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -137,6 +379,46 @@ impl SseDecode for Vec<u8> {
             ans_.push(<u8>::sse_decode(deserializer));
         }
         return ans_;
+    }
+}
+
+impl SseDecode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<String>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for crate::api::crypto::SignedEventData {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_id = <String>::sse_decode(deserializer);
+        let mut var_pubkey = <String>::sse_decode(deserializer);
+        let mut var_createdAt = <i64>::sse_decode(deserializer);
+        let mut var_kind = <u16>::sse_decode(deserializer);
+        let mut var_tags = <Vec<Vec<String>>>::sse_decode(deserializer);
+        let mut var_content = <String>::sse_decode(deserializer);
+        let mut var_sig = <String>::sse_decode(deserializer);
+        return crate::api::crypto::SignedEventData {
+            id: var_id,
+            pubkey: var_pubkey,
+            created_at: var_createdAt,
+            kind: var_kind,
+            tags: var_tags,
+            content: var_content,
+            sig: var_sig,
+        };
+    }
+}
+
+impl SseDecode for u16 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        deserializer.cursor.read_u16::<NativeEndian>().unwrap()
     }
 }
 
@@ -150,6 +432,24 @@ impl SseDecode for u8 {
 impl SseDecode for () {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {}
+}
+
+impl SseDecode for crate::api::crypto::UnsignedEventData {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pubkey = <String>::sse_decode(deserializer);
+        let mut var_createdAt = <i64>::sse_decode(deserializer);
+        let mut var_kind = <u16>::sse_decode(deserializer);
+        let mut var_tags = <Vec<Vec<String>>>::sse_decode(deserializer);
+        let mut var_content = <String>::sse_decode(deserializer);
+        return crate::api::crypto::UnsignedEventData {
+            pubkey: var_pubkey,
+            created_at: var_createdAt,
+            kind: var_kind,
+            tags: var_tags,
+            content: var_content,
+        };
+    }
 }
 
 impl SseDecode for i32 {
@@ -168,7 +468,7 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        1 => wire__crate__api__crypto__init_app_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__crypto__init_app_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -181,12 +481,70 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        2 => wire__crate__api__crypto__verify_event_impl(ptr, rust_vec_len, data_len),
+        1 => wire__crate__api__crypto__finish_event_impl(ptr, rust_vec_len, data_len),
+        2 => wire__crate__api__crypto__generate_secret_key_impl(ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__crypto__npub_encode_impl(ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__crypto__nsec_decode_impl(ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__crypto__nsec_encode_impl(ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__crypto__public_key_from_secret_impl(ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__crypto__verify_event_impl(ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__crypto__verify_event_data_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
 
 // Section: rust2dart
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::crypto::SignedEventData {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.id.into_into_dart().into_dart(),
+            self.pubkey.into_into_dart().into_dart(),
+            self.created_at.into_into_dart().into_dart(),
+            self.kind.into_into_dart().into_dart(),
+            self.tags.into_into_dart().into_dart(),
+            self.content.into_into_dart().into_dart(),
+            self.sig.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::crypto::SignedEventData
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::crypto::SignedEventData>
+    for crate::api::crypto::SignedEventData
+{
+    fn into_into_dart(self) -> crate::api::crypto::SignedEventData {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::crypto::UnsignedEventData {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.pubkey.into_into_dart().into_dart(),
+            self.created_at.into_into_dart().into_dart(),
+            self.kind.into_into_dart().into_dart(),
+            self.tags.into_into_dart().into_dart(),
+            self.content.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::crypto::UnsignedEventData
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::crypto::UnsignedEventData>
+    for crate::api::crypto::UnsignedEventData
+{
+    fn into_into_dart(self) -> crate::api::crypto::UnsignedEventData {
+        self
+    }
+}
 
 impl SseEncode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -202,6 +560,33 @@ impl SseEncode for bool {
     }
 }
 
+impl SseEncode for i64 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_i64::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for Vec<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <String>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<Vec<String>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <Vec<String>>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<u8> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -209,6 +594,36 @@ impl SseEncode for Vec<u8> {
         for item in self {
             <u8>::sse_encode(item, serializer);
         }
+    }
+}
+
+impl SseEncode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <String>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for crate::api::crypto::SignedEventData {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.id, serializer);
+        <String>::sse_encode(self.pubkey, serializer);
+        <i64>::sse_encode(self.created_at, serializer);
+        <u16>::sse_encode(self.kind, serializer);
+        <Vec<Vec<String>>>::sse_encode(self.tags, serializer);
+        <String>::sse_encode(self.content, serializer);
+        <String>::sse_encode(self.sig, serializer);
+    }
+}
+
+impl SseEncode for u16 {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        serializer.cursor.write_u16::<NativeEndian>(self).unwrap();
     }
 }
 
@@ -222,6 +637,17 @@ impl SseEncode for u8 {
 impl SseEncode for () {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {}
+}
+
+impl SseEncode for crate::api::crypto::UnsignedEventData {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.pubkey, serializer);
+        <i64>::sse_encode(self.created_at, serializer);
+        <u16>::sse_encode(self.kind, serializer);
+        <Vec<Vec<String>>>::sse_encode(self.tags, serializer);
+        <String>::sse_encode(self.content, serializer);
+    }
 }
 
 impl SseEncode for i32 {

--- a/test/services/nostr/crypto/rust_nostr_crypto_test.dart
+++ b/test/services/nostr/crypto/rust_nostr_crypto_test.dart
@@ -206,12 +206,19 @@ void _differentialTests() {
           content: 'choke',
         );
 
-        // Act & Assert
-        expect(
-          rust.finishEvent(unsigned, privateKey).id,
-          dart.finishEvent(unsigned, privateKey).id,
-          reason: 'event id differs for tags: $tags',
-        );
+        // Act
+        final byRust = rust.finishEvent(unsigned, privateKey);
+        final byDart = dart.finishEvent(unsigned, privateKey);
+
+        // Assert — matching ids prove Rust hashed the tags correctly *inside*
+        // Rust; they say nothing about the return leg, where the struct could
+        // still mangle them on the way back to Dart. So check the tags that
+        // actually came back, and that each library accepts the other's event.
+        expect(byRust.id, byDart.id, reason: 'event id differs for: $tags');
+        expect(byRust.tags, tags, reason: 'tags mangled crossing back: $tags');
+        expect(byDart.tags, tags);
+        expect(dart.verifyEvent(byRust), isTrue);
+        expect(rust.verifyEvent(byDart), isTrue);
       }
     });
 
@@ -314,8 +321,17 @@ String _describe(String content) =>
     content.replaceAll('\n', r'\n').replaceAll('\t', r'\t');
 
 /// Where `cargo build` leaves the crate, or null if it has not been built.
+///
+/// The filename follows the host: these tests run on a developer's machine and
+/// on CI, not on a device, so a hardcoded `.so` would silently skip the whole
+/// suite on macOS or Windows.
 String? _findNativeLibrary() {
-  const name = 'librust_lib_choke.so';
+  final name = Platform.isMacOS
+      ? 'librust_lib_choke.dylib'
+      : Platform.isWindows
+          ? 'rust_lib_choke.dll'
+          : 'librust_lib_choke.so';
+
   for (final profile in ['debug', 'release']) {
     final path = 'rust/target/$profile/$name';
     if (File(path).existsSync()) return path;

--- a/test/services/nostr/crypto/rust_nostr_crypto_test.dart
+++ b/test/services/nostr/crypto/rust_nostr_crypto_test.dart
@@ -1,0 +1,324 @@
+@Tags(['rust'])
+library;
+
+import 'dart:io';
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/crypto/nostr_tools_crypto.dart';
+import 'package:choke/services/nostr/crypto/rust_nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+import 'package:choke/src/rust/frb_generated.dart';
+
+import 'nostr_crypto_contract.dart';
+
+/// Holds the Rust implementation to the same contract the Dart one passes,
+/// then puts the two side by side.
+///
+/// The differential group is the point of this phase. The contract proves each
+/// implementation is internally consistent; only comparing them proves they are
+/// *interchangeable* — which is what Phase 4 bets the users' identities on.
+///
+/// Needs the native library, so it skips itself when the crate has not been
+/// built:
+///
+///   cargo build --manifest-path rust/Cargo.toml
+///   flutter test --tags rust
+void main() {
+  final libraryPath = _findNativeLibrary();
+  final skip = libraryPath == null
+      ? 'native library not built — run: cargo build --manifest-path rust/Cargo.toml'
+      : null;
+
+  group('Rust crypto', skip: skip, () {
+    setUpAll(() async {
+      await RustLib.init(externalLibrary: ExternalLibrary.open(libraryPath!));
+    });
+
+    tearDownAll(() => RustLib.dispose());
+
+    // The identical suite NostrToolsCrypto passes, not one line changed.
+    runNostrCryptoContract('RustNostrCrypto', RustNostrCrypto.new);
+
+    _differentialTests();
+  });
+}
+
+/// Both implementations, fed the same inputs, must agree.
+void _differentialTests() {
+  group('differential (Rust vs nostr_tools)', () {
+    late NostrCrypto rust;
+    late NostrCrypto dart;
+
+    setUp(() {
+      rust = const RustNostrCrypto();
+      dart = NostrToolsCrypto();
+    });
+
+    // Content that has historically broken hand-rolled serializers. The id is
+    // a hash of the event's canonical JSON, so any disagreement about escaping
+    // — UTF-8, emoji, quotes, newlines, tabs, slashes — surfaces here as a
+    // different id, and the app would be publishing events relays reject.
+    const contents = [
+      'choke',
+      '',
+      'Gonçalves',
+      '田中太郎',
+      '🥋⚡',
+      'a "quoted" string',
+      'line\nbreak',
+      'tab\tseparated',
+      'back\\slash',
+      'forward/slash',
+      '{"f1_name":"José","f2_pt2":3}',
+    ];
+
+    test('derive the same public key from the same private key', () {
+      // Arrange & Act & Assert — a mismatch here would change users' identities
+      for (var i = 0; i < 20; i++) {
+        final privateKey = rust.generatePrivateKey();
+
+        expect(
+          rust.getPublicKey(privateKey),
+          dart.getPublicKey(privateKey),
+          reason: 'public key differs for a generated key',
+        );
+      }
+    });
+
+    test('accept each other’s generated private keys', () {
+      // Arrange & Act — a key from either generator must be usable by both
+      final fromDart = dart.generatePrivateKey();
+      final fromRust = rust.generatePrivateKey();
+
+      // Assert
+      expect(rust.getPublicKey(fromDart), dart.getPublicKey(fromDart));
+      expect(dart.getPublicKey(fromRust), rust.getPublicKey(fromRust));
+    });
+
+    test('produce the same npub and nsec', () {
+      for (var i = 0; i < 20; i++) {
+        // Arrange
+        final privateKey = rust.generatePrivateKey();
+        final publicKey = rust.getPublicKey(privateKey);
+
+        // Act & Assert — the npub is what the user reads off the Account screen
+        // and what a dashboard subscribes to; it cannot change under them
+        expect(rust.npubEncode(publicKey), dart.npubEncode(publicKey));
+        expect(rust.nsecEncode(privateKey), dart.nsecEncode(privateKey));
+      }
+    });
+
+    test('decode each other’s nsec back to the same key', () {
+      // Arrange
+      final privateKey = rust.generatePrivateKey();
+
+      // Act
+      final rustNsec = rust.nsecEncode(privateKey);
+      final dartNsec = dart.nsecEncode(privateKey);
+
+      // Assert
+      expect(dart.nsecDecode(rustNsec), privateKey);
+      expect(rust.nsecDecode(dartNsec), privateKey);
+    });
+
+    test('agree that a malformed nsec is malformed', () {
+      // Arrange — what a user might actually paste into the import field
+      final npub =
+          rust.npubEncode(rust.getPublicKey(rust.generatePrivateKey()));
+      final inputs = ['', 'not an nsec', 'nsec1nonsense', npub];
+
+      // Act & Assert
+      for (final input in inputs) {
+        expect(
+          rust.nsecDecode(input),
+          dart.nsecDecode(input),
+          reason: 'disagreed about "$input"',
+        );
+        expect(rust.nsecDecode(input), isNull);
+      }
+    });
+
+    test('compute the same event id for the same unsigned event', () {
+      // Arrange — the id is deterministic (the signature is not), so this is
+      // the strongest equivalence available: identical ids mean both libraries
+      // serialize the event to identical canonical bytes.
+      final privateKey = rust.generatePrivateKey();
+      final publicKey = rust.getPublicKey(privateKey);
+
+      for (final content in contents) {
+        final unsigned = UnsignedNostrEvent(
+          pubkey: publicKey,
+          createdAt: 1700000000,
+          kind: 31415,
+          tags: const [
+            ['d', 'abcd'],
+            ['expiration', '1900000000'],
+          ],
+          content: content,
+        );
+
+        // Act
+        final byRust = rust.finishEvent(unsigned, privateKey);
+        final byDart = dart.finishEvent(unsigned, privateKey);
+
+        // Assert
+        expect(
+          byRust.id,
+          byDart.id,
+          reason: 'event id differs for content: ${_describe(content)}',
+        );
+      }
+    });
+
+    test('compute the same event id whatever the tags look like', () {
+      // Arrange — tags carry the d-tag identifying the match and the expiration
+      // that stops relays hoarding it; both must survive the crossing
+      final privateKey = rust.generatePrivateKey();
+      final publicKey = rust.getPublicKey(privateKey);
+
+      const tagSets = [
+        <List<String>>[],
+        [
+          ['d', 'abcd']
+        ],
+        [
+          ['d', 'abcd'],
+          ['expiration', '1900000000'],
+        ],
+        [
+          ['d', 'abcd'],
+          ['t', 'bjj'],
+          ['t', 'gi'],
+        ],
+        [
+          ['d', 'ünïcødé 🥋']
+        ],
+      ];
+
+      for (final tags in tagSets) {
+        final unsigned = UnsignedNostrEvent(
+          pubkey: publicKey,
+          createdAt: 1700000000,
+          kind: 31415,
+          tags: tags,
+          content: 'choke',
+        );
+
+        // Act & Assert
+        expect(
+          rust.finishEvent(unsigned, privateKey).id,
+          dart.finishEvent(unsigned, privateKey).id,
+          reason: 'event id differs for tags: $tags',
+        );
+      }
+    });
+
+    test('each verifies an event the other signed', () {
+      // Arrange — signatures legitimately differ (Schnorr uses a random nonce),
+      // so they cannot be compared byte for byte. What must hold is that each
+      // library accepts the other's work — which is what a relay, and every
+      // other Nostr client, will do.
+      final privateKey = rust.generatePrivateKey();
+      final publicKey = rust.getPublicKey(privateKey);
+
+      for (final content in contents) {
+        final unsigned = UnsignedNostrEvent(
+          pubkey: publicKey,
+          createdAt: 1700000000,
+          kind: 31415,
+          tags: const [
+            ['d', 'abcd']
+          ],
+          content: content,
+        );
+
+        // Act
+        final byRust = rust.finishEvent(unsigned, privateKey);
+        final byDart = dart.finishEvent(unsigned, privateKey);
+
+        // Assert
+        expect(dart.verifyEvent(byRust), isTrue,
+            reason: 'nostr_tools rejected a Rust signature');
+        expect(rust.verifyEvent(byDart), isTrue,
+            reason: 'Rust rejected a nostr_tools signature');
+      }
+    });
+
+    test('both reject an event tampered with after signing', () {
+      // Arrange
+      final privateKey = rust.generatePrivateKey();
+      final publicKey = rust.getPublicKey(privateKey);
+      final event = rust.finishEvent(
+        UnsignedNostrEvent(
+          pubkey: publicKey,
+          createdAt: 1700000000,
+          kind: 31415,
+          tags: const [
+            ['d', 'abcd']
+          ],
+          content: 'f1 wins',
+        ),
+        privateKey,
+      );
+
+      // Act — the score is rewritten, the signature left in place
+      final forged = NostrEvent(
+        id: event.id,
+        pubkey: event.pubkey,
+        createdAt: event.createdAt,
+        kind: event.kind,
+        tags: event.tags,
+        content: 'f2 wins',
+        sig: event.sig,
+      );
+
+      // Assert — the divergence found in Phase 2 (2.1) stays closed
+      expect(rust.verifyEvent(forged), isFalse);
+      expect(dart.verifyEvent(forged), isFalse);
+    });
+
+    test('preserve created_at exactly across the bridge', () {
+      // Arrange — created_at is a 64-bit timestamp crossing an FFI boundary,
+      // and NIP-01 replacement turns on it: a value mangled in transit would
+      // silently break the ordering that keeps relays showing the latest score
+      final privateKey = rust.generatePrivateKey();
+      final publicKey = rust.getPublicKey(privateKey);
+      const timestamps = [0, 1, 1700000000, 2147483647, 4102444800];
+
+      for (final createdAt in timestamps) {
+        final unsigned = UnsignedNostrEvent(
+          pubkey: publicKey,
+          createdAt: createdAt,
+          kind: 31415,
+          tags: const [
+            ['d', 'abcd']
+          ],
+          content: 'choke',
+        );
+
+        // Act
+        final byRust = rust.finishEvent(unsigned, privateKey);
+
+        // Assert
+        expect(byRust.createdAt, createdAt);
+        expect(byRust.id, dart.finishEvent(unsigned, privateKey).id);
+      }
+    });
+  });
+}
+
+/// Renders control characters visibly, so a failure message stays readable.
+String _describe(String content) =>
+    content.replaceAll('\n', r'\n').replaceAll('\t', r'\t');
+
+/// Where `cargo build` leaves the crate, or null if it has not been built.
+String? _findNativeLibrary() {
+  const name = 'librust_lib_choke.so';
+  for (final profile in ['debug', 'release']) {
+    final path = 'rust/target/$profile/$name';
+    if (File(path).existsSync()) return path;
+  }
+  return null;
+}

--- a/test/services/nostr_rust/rust_bindings_test.dart
+++ b/test/services/nostr_rust/rust_bindings_test.dart
@@ -90,8 +90,17 @@ void _bridgeTests(String? libraryPath) {
 
 /// Where `cargo build` leaves the crate, or null if it has not been built.
 /// Debug first: that is what a contributor (and CI) has just produced.
+///
+/// The filename follows the host — these tests run on a developer's machine,
+/// not on a device, so a hardcoded `.so` would silently skip them on macOS or
+/// Windows.
 String? _findNativeLibrary() {
-  const name = 'librust_lib_choke.so';
+  final name = Platform.isMacOS
+      ? 'librust_lib_choke.dylib'
+      : Platform.isWindows
+          ? 'rust_lib_choke.dll'
+          : 'librust_lib_choke.so';
+
   for (final profile in ['debug', 'release']) {
     final path = 'rust/target/$profile/$name';
     if (File(path).existsSync()) return path;


### PR DESCRIPTION
Phase 3 of [the migration spec](docs/specs/nostr-sdk-migration.md). Both crypto backends now exist side by side. **The default is still `nostr_tools`** — Phase 4 flips it. This PR's job is to earn that flip.

## What's here

- **The crate gains keys, NIP-19 and signing**: `generate_secret_key`, `public_key_from_secret`, `npub_encode`, `nsec_encode`, `nsec_decode`, `finish_event`, `verify_event_data`. Ten Rust unit tests, including the NIP-19 spec vector.
- **`RustNostrCrypto`** implements the Phase 2 `NostrCrypto` interface over the generated bindings.
- **Backend selector**: `--dart-define=NOSTR_BACKEND=rust|legacy`, default `legacy`. `main.dart` initializes `RustLib` only when Rust is selected — so rolling back Phase 4 will need no code change at all.

## A design decision worth flagging: structs, not JSON, across the bridge (§3.1)

The event id is a **hash of the event's canonical serialization**. Shipping events over FFI as JSON would have put a *second* serializer in the path — Dart's `jsonEncode` on one side, `serde` on the other. That's a silent canonicalization the differential tests could only have caught by luck. So the bridge carries the **fields** (`UnsignedEventData` / `SignedEventData`), and the `nostr` crate performs the only serialization that counts.

## The proof (§3.2)

The Rust implementation passes the **identical Phase 2 contract — 19 tests, not a line changed** — plus 10 differential tests. The two libraries agree on:

- **public key, npub and nsec** from the same private key (20 random keys per run), and each accepts the other's generated keys;
- **the event id**, for every hostile content vector tried — empty, accented (`Gonçalves`), CJK (`田中太郎`), emoji (`🥋⚡`), embedded quotes, newlines, tabs, back- and forward-slashes, raw match JSON — and for tag sets from empty to unicode d-tags. **Identical ids mean both libraries serialize to identical canonical bytes**, which is the whole ballgame;
- **`created_at`** preserved exactly across the FFI boundary (0 → 4102444800) — this matters because NIP-01 replacement ordering turns on it (I1), and a timestamp mangled in transit would silently break the convergence work from #78;
- **rejecting a post-signing tamper**, keeping the divergence found in §2.1 closed.

Signatures are deliberately **not** compared byte for byte — Schnorr signing uses a random nonce, so they legitimately differ every time. What's asserted instead is the property that actually matters: **each library verifies the other's signatures**, which is exactly what a relay and every other Nostr client will do.

## Size, re-measured

§0.3 asked Phase 3 not to assume headroom, so:

| Release APK (arm64) | Size |
|---|---|
| Baseline (`main` before Phase 1) | 41.7 MB |
| This PR | 43.9 MB |
| **Delta** | **+2.2 MB** |

The seven new crypto functions cost only ~0.08 MB on top of Phase 1 — secp256k1 was already paid for. Budget is ≤6 MB.

## Test plan

- [x] `cargo test` — 10 passing; `cargo clippy -D warnings` and `cargo fmt --check` clean
- [x] `flutter test` — **165 passing**
- [x] `flutter test --tags rust` — 29 passing (19 contract + 10 differential)
- [x] `flutter analyze` — 51 issues, unchanged from `main`
- [x] APK builds on **both** backends (default, and `--dart-define=NOSTR_BACKEND=rust`)
- [ ] Manual QA on Android with the Rust backend — deferred to Phase 4, where it becomes the default and the checklist (same npub after upgrade, nsec import, full match lifecycle against a real relay) is the acceptance gate

## Rollback

Revert the PR, or simply don't pass the flag: the default path is untouched `nostr_tools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD1yHCBE9EBjjafUz8N1Gg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Rust-powered Nostr crypto backend, selectable at app startup.
  * Added key generation, public/private key conversion, NIP-19 encoding and decoding, event signing, and signature verification.
  * Enabled typed event data exchange between the app and native crypto layer.

* **Tests**
  * Added cross-backend validation for keys, encodings, event IDs, signatures, tampering detection, and timestamp preservation.

* **Documentation**
  * Updated migration progress through Phase 3 and documented interoperability results and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->