### PR TITLE
ci: ship an arm64-only release APK (86 MB → 36 MB)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,8 +220,16 @@ jobs:
           echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> android/key.properties
           echo "storeFile=choke-upload-key.jks" >> android/key.properties
 
+      # arm64 only. A plain `flutter build apk` packs native code for three ABIs
+      # into one file — and since the Nostr stack became a Rust library, that is
+      # three copies of it. Every 64-bit Android phone made in the last decade
+      # runs arm64-v8a; armeabi-v7a and x86_64 were costing ~40 MB to serve
+      # 32-bit hardware nobody referees on, and emulators.
+      #
+      # Deliberately NOT --split-per-abi: that renames the output to
+      # app-arm64-v8a-release.apk and would break the step below.
       - name: Build APK
-        run: flutter build apk --release
+        run: flutter build apk --release --target-platform android-arm64
 
       - name: Rename APK
         run: |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,6 +16,16 @@ if (keystorePropertiesFile.exists()) {
 val releaseKeystoreFile =
     keystoreProperties["storeFile"]?.toString()?.let { file(it) }
 
+// Strip every ABI but arm64 — but only when building a release artifact.
+//
+// Every 64-bit Android phone of the last decade is arm64-v8a, so nothing a
+// referee holds is affected, and it halves the download. Debug builds keep all
+// ABIs on purpose: filtering them would break an x86_64 emulator at runtime,
+// with an UnsatisfiedLinkError and no hint as to why.
+val releaseOnlyArm64 = gradle.startParameter.taskNames.any {
+    it.contains("Release", ignoreCase = true)
+}
+
 android {
     namespace = "com.grunch.choke"
     compileSdk = flutter.compileSdkVersion
@@ -40,6 +50,33 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        // Release ships one architecture; see `releaseOnlyArm64` above.
+        //
+        // `flutter build apk --target-platform android-arm64` only narrows
+        // Flutter's own libraries. It does not stop Cargokit from building the
+        // Rust crate for every Android ABI — that is what this reaches.
+        if (releaseOnlyArm64) {
+            ndk {
+                abiFilters += "arm64-v8a"
+            }
+        }
+    }
+
+    // `abiFilters` does not reach native code that arrives *prebuilt* inside a
+    // plugin's AAR: ML Kit's barcode scanner (the QR reader on the Account
+    // screen) was still shipping 8.8 MB of x86_64 and armeabi-v7a libraries in
+    // every release. Nothing on an arm64 phone will ever load them.
+    packaging {
+        jniLibs {
+            if (releaseOnlyArm64) {
+                excludes += setOf(
+                    "**/x86/**",
+                    "**/x86_64/**",
+                    "**/armeabi-v7a/**",
+                )
+            }
+        }
     }
 
     signingConfigs {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,16 +16,6 @@ if (keystorePropertiesFile.exists()) {
 val releaseKeystoreFile =
     keystoreProperties["storeFile"]?.toString()?.let { file(it) }
 
-// Strip every ABI but arm64 — but only when building a release artifact.
-//
-// Every 64-bit Android phone of the last decade is arm64-v8a, so nothing a
-// referee holds is affected, and it halves the download. Debug builds keep all
-// ABIs on purpose: filtering them would break an x86_64 emulator at runtime,
-// with an UnsatisfiedLinkError and no hint as to why.
-val releaseOnlyArm64 = gradle.startParameter.taskNames.any {
-    it.contains("Release", ignoreCase = true)
-}
-
 android {
     namespace = "com.grunch.choke"
     compileSdk = flutter.compileSdkVersion
@@ -50,33 +40,6 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-
-        // Release ships one architecture; see `releaseOnlyArm64` above.
-        //
-        // `flutter build apk --target-platform android-arm64` only narrows
-        // Flutter's own libraries. It does not stop Cargokit from building the
-        // Rust crate for every Android ABI — that is what this reaches.
-        if (releaseOnlyArm64) {
-            ndk {
-                abiFilters += "arm64-v8a"
-            }
-        }
-    }
-
-    // `abiFilters` does not reach native code that arrives *prebuilt* inside a
-    // plugin's AAR: ML Kit's barcode scanner (the QR reader on the Account
-    // screen) was still shipping 8.8 MB of x86_64 and armeabi-v7a libraries in
-    // every release. Nothing on an arm64 phone will ever load them.
-    packaging {
-        jniLibs {
-            if (releaseOnlyArm64) {
-                excludes += setOf(
-                    "**/x86/**",
-                    "**/x86_64/**",
-                    "**/armeabi-v7a/**",
-                )
-            }
-        }
     }
 
     signingConfigs {
@@ -97,7 +60,38 @@ android {
             } else {
                 signingConfigs.getByName("debug")
             }
+
+            // Release ships one architecture. `flutter build apk
+            // --target-platform android-arm64` only narrows Flutter's own
+            // libraries — it does not stop Cargokit from building the Rust
+            // crate for every Android ABI. This does.
+            //
+            // Debug keeps every ABI on purpose: filtering it would break an
+            // x86_64 emulator at runtime, with an UnsatisfiedLinkError and no
+            // hint as to why.
+            ndk {
+                abiFilters += "arm64-v8a"
+            }
         }
+    }
+}
+
+// `abiFilters` above does not reach native code that arrives *prebuilt* inside
+// a plugin's AAR: ML Kit's barcode scanner (the QR reader on the Account
+// screen) was still shipping 8.8 MB of x86_64 and armeabi-v7a libraries in
+// every release. Nothing on an arm64 phone will ever load them.
+//
+// Scoped to the release variant, not to the Gradle invocation. Keying off the
+// task names would flip this on for debug too the moment anything built both in
+// one run (`gradle build` does), and the emulator would break for reasons the
+// build output would never explain.
+androidComponents {
+    onVariants(selector().withBuildType("release")) { variant ->
+        variant.packaging.jniLibs.excludes.addAll(
+            "**/x86/**",
+            "**/x86_64/**",
+            "**/armeabi-v7a/**",
+        )
     }
 }
 


### PR DESCRIPTION
The release APK was **86.1 MB**, and more than half of that was native code nobody runs: three copies of everything, one per ABI. Since the Nostr stack became a Rust library, that included three copies of *it* too.

| | Release APK |
|---|---|
| Before | 86.1 MB |
| After | **35.7 MB** |
| | **−59%** |

**The filename is unchanged.** The build still emits `app-release.apk`, so the release artifact is still `choke-vX.Y.Z.apk`. I deliberately did **not** use `--split-per-abi`, which renames the output to `app-arm64-v8a-release.apk` and would have broken the rename step.

## The flag alone wasn't enough

`flutter build apk --release --target-platform android-arm64` is the obvious change, and it's *not sufficient* — I checked what actually ended up in the archive:

- it narrows **Flutter's own** libraries, but leaves **Cargokit** building the Rust crate for every Android ABI;
- it doesn't touch native code that arrives **prebuilt inside a plugin's AAR**. ML Kit's barcode scanner — the QR reader on the Account screen — was shipping **8.8 MB** of `x86_64` and `armeabi-v7a` libraries all by itself.

So the workflow flag is paired with two things in Gradle: `ndk.abiFilters` (reaches Cargokit) and a `jniLibs` exclude (reaches the AARs). Verified by listing the archive, not by assuming:

```
before:  arm64-v8a 24.9 MB · x86_64 27.6 MB · armeabi-v7a 20.2 MB
after:   arm64-v8a 24.9 MB
```

## Debug builds keep every ABI, on purpose

Both filters are gated on the build actually being a release. Applying them to debug would **break an x86_64 emulator at runtime** — an `UnsatisfiedLinkError`, with no hint as to why. Verified: the debug APK still carries all three.

Every 64-bit Android phone of the last decade is `arm64-v8a`, so nothing a referee holds is affected.

## Test plan

- [x] Release APK: **35.7 MB**, contains `arm64-v8a` and nothing else
- [x] Output filename is still `app-release.apk` → artifact still `choke-vX.Y.Z.apk`
- [x] Debug APK still contains all three ABIs (emulators keep working)
- [x] `flutter test` — 142 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD1yHCBE9EBjjafUz8N1Gg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android release builds by targeting arm64 devices.
  * Reduced release package compatibility issues involving Rust-based native libraries.
  * Debug builds continue to support multiple device architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->