### PR TITLE
feat(match): Phase 1 — record how a match was won, and make penalties count

### DIFF
--- a/docs/specs/match-outcome.md
+++ b/docs/specs/match-outcome.md
@@ -335,11 +335,19 @@ at the time is, at worst, **incomplete**. Rewriting it is **asserting something
 new about a match nobody re-refereed**. So:
 
 > **The boundary is the presence of the new fields, not a version number.**
-> A **finished or canceled** match with no `method` is a legacy event: raw
+> A **finished or canceled** match with no `ended_at` is a legacy event: raw
 > scoreboard, no penalty consequences, no computed winner beyond what the old
-> app showed. Anything else — a match still in progress, or a finished one that
-> states its method — uses effective scoring (§5) and, where it has one, the
-> winner it states outright.
+> app showed. Anything else — a match still in progress, or one this app ended —
+> uses effective scoring (§5) and, where it has one, the winner it states
+> outright.
+
+The test is **`ended_at`**, not `method`. A legacy event has neither, but a
+match *this* app ends always stamps `ended_at` — even in the one case where it
+cannot yet name a method, because the fighters are level and that is the
+referees' to call (§6.2). Keying the rule off `method` would make the app
+contradict itself the instant a referee pressed Finish: a 0–0 match against
+three penalties reads 2–0 while it runs, and would snap back to 0–0 the moment
+it stopped.
 
 **A live match is never legacy.** Taken literally, "no `method` and no
 `ended_at`" would describe the app's *own* match while it is being refereed:

--- a/docs/specs/match-outcome.md
+++ b/docs/specs/match-outcome.md
@@ -335,10 +335,19 @@ at the time is, at worst, **incomplete**. Rewriting it is **asserting something
 new about a match nobody re-refereed**. So:
 
 > **The boundary is the presence of the new fields, not a version number.**
-> An event with no `method` and no `ended_at` is a legacy event: raw scoreboard,
-> no penalty consequences, no computed winner beyond what the old app showed.
-> An event that carries them is a new event: effective scoring (§5), and a winner
-> it states outright.
+> A **finished or canceled** match with no `method` is a legacy event: raw
+> scoreboard, no penalty consequences, no computed winner beyond what the old
+> app showed. Anything else — a match still in progress, or a finished one that
+> states its method — uses effective scoring (§5) and, where it has one, the
+> winner it states outright.
+
+**A live match is never legacy.** Taken literally, "no `method` and no
+`ended_at`" would describe the app's *own* match while it is being refereed:
+those fields are only filled in when it ends. Reading that as legacy would hide
+the penalty points from the referee precisely while they are refereeing — the
+one moment they must see them. A match in progress has no result to preserve;
+it is being refereed *now*, by this app, under these rules. Only a match that
+already ended, and ended silently, is a legacy one.
 
 No `schema_version`. No bump on the event kind. No migration. The fields the app
 writes *are* the version — which is what "additive" was supposed to mean in the

--- a/lib/features/match/models/match.dart
+++ b/lib/features/match/models/match.dart
@@ -34,6 +34,114 @@ enum MatchStatus {
   }
 }
 
+/// Who won a match.
+///
+/// There is no `draw` here on purpose. A draw is [MatchMethod.draw] with **no**
+/// winner — encoding it twice would let an event claim `winner: "f1"` and
+/// `method: "draw"` at once, and every consumer would resolve that
+/// contradiction differently. One fact, one field.
+enum MatchWinner {
+  f1,
+  f2;
+
+  String toJson() => name;
+
+  static MatchWinner? fromJson(Object? json) {
+    return switch (json) {
+      null => null,
+      'f1' => MatchWinner.f1,
+      'f2' => MatchWinner.f2,
+      _ => throw FormatException('Unknown winner: $json'),
+    };
+  }
+}
+
+/// How a match was won.
+///
+/// Three of these beat the scoreboard outright — [submission], [dq] and
+/// [forfeit]. The fighter who was ahead can still lose, which is the whole
+/// reason this exists: a match that ends on a submission and says only
+/// "finished" publishes a scoreboard naming the wrong winner.
+///
+/// Note there is no `penalties`. Penalties are not a way to win: they have
+/// already become advantages and points (see [Match.f1EffectivePoints]), so
+/// counting them again would count the same penalty twice.
+enum MatchMethod {
+  /// The opponent tapped, submitted verbally, or the referee stopped it.
+  submission,
+
+  /// The clock ran out and one fighter had more points.
+  points,
+
+  /// Points were level; advantages decided it.
+  advantages,
+
+  /// Points and advantages were level, and the referees named a winner.
+  decision,
+
+  /// The **loser** was disqualified.
+  dq,
+
+  /// The loser withdrew, no-showed, or could not continue.
+  forfeit,
+
+  /// Points and advantages were level and the referees called it even. No
+  /// winner.
+  draw;
+
+  String toJson() => name;
+
+  static MatchMethod? fromJson(Object? json) {
+    if (json == null) return null;
+    for (final method in MatchMethod.values) {
+      if (method.name == json) return method;
+    }
+    throw FormatException('Unknown method: $json');
+  }
+
+  /// Whether this method decides the match regardless of the scoreboard.
+  bool get overridesScoreboard =>
+      this == submission || this == dq || this == forfeit;
+}
+
+/// Why a fighter was disqualified.
+///
+/// The categories are standard; the infractions are not. Whether a knee reap is
+/// illegal depends on the ruleset, the belt and the age division, and ADCC's
+/// list differs from the IBJJF's again — so what actually happened goes in
+/// [Match.dqDetail] as free text, and only the category is enumerated here.
+enum DqReason {
+  /// The fourth penalty. The app never raises this by itself: the referee ends
+  /// the match, and the app offers this as what the scoreboard already says.
+  accumulatedPenalties,
+
+  /// Severe technical foul — illegal technique, illegal grip, improper attire.
+  /// Disqualified from the **match**.
+  technicalFoul,
+
+  /// Severe disciplinary foul — unsportsmanlike conduct. Disqualified from the
+  /// **competition**.
+  disciplinaryFoul;
+
+  String toJson() {
+    return switch (this) {
+      DqReason.accumulatedPenalties => 'accumulated_penalties',
+      DqReason.technicalFoul => 'technical_foul',
+      DqReason.disciplinaryFoul => 'disciplinary_foul',
+    };
+  }
+
+  static DqReason? fromJson(Object? json) {
+    return switch (json) {
+      null => null,
+      'accumulated_penalties' => DqReason.accumulatedPenalties,
+      'technical_foul' => DqReason.technicalFoul,
+      'disciplinary_foul' => DqReason.disciplinaryFoul,
+      _ => throw FormatException('Unknown dq_reason: $json'),
+    };
+  }
+}
+
 /// Represents a BJJ match with scoring data
 ///
 /// Maps to Nostr event kind 31415 (addressable events) with the following
@@ -53,9 +161,23 @@ enum MatchStatus {
 ///   "f1_pt3": 0, "f2_pt3": 0,
 ///   "f1_pt4": 0, "f2_pt4": 0,
 ///   "f1_adv": 0, "f2_adv": 0,
-///   "f1_pen": 0, "f2_pen": 0
+///   "f1_pen": 0, "f2_pen": 0,
+///
+///   "winner": "f1 | f2",
+///   "method": "submission | points | advantages | decision | dq | forfeit | draw",
+///   "submission": "armbar",
+///   "dq_reason": "accumulated_penalties | technical_foul | disciplinary_foul",
+///   "dq_detail": "knee reap",
+///   "ended_at": 123456889
 /// }
 /// ```
+///
+/// The outcome fields are absent from every event published before they
+/// existed, so a consumer must tolerate their absence forever. An event this
+/// app writes for a finished match always carries `method` and `ended_at`, and
+/// a `winner` unless the match was drawn.
+///
+/// See docs/specs/match-outcome.md.
 class Match {
   /// 4-character hex identifier for the match
   final String id;
@@ -120,6 +242,35 @@ class Match {
   /// Fighter 2 penalty count
   final int f2Pen;
 
+  /// Who won. Null while the match is unfinished, when it was canceled, and
+  /// when it was a draw — a draw is [MatchMethod.draw] with no winner.
+  final MatchWinner? winner;
+
+  /// How the match was won. Null on a match that has not ended, and on every
+  /// event published before outcomes existed (see [isLegacyResult]).
+  final MatchMethod? method;
+
+  /// The submission, as free text: 'armbar', 'rear naked choke'. Only
+  /// meaningful with [MatchMethod.submission], and always optional — a referee
+  /// must never be blocked from ending a match because the app has never heard
+  /// of a baratoplata.
+  final String? submission;
+
+  /// Why the loser was disqualified. Required when [method] is
+  /// [MatchMethod.dq].
+  final DqReason? dqReason;
+
+  /// What the disqualified fighter actually did: 'knee reap', 'slam'. Free
+  /// text, always optional — the categories are standard, the infractions are
+  /// not.
+  final String? dqDetail;
+
+  /// When the match ended, in unix seconds.
+  ///
+  /// Not derivable: `startAt + duration` is when the clock *would* have run
+  /// out, which is exactly what a submission prevents.
+  final int? endedAt;
+
   static const _hexChars = '0123456789abcdef';
   static final _random = Random.secure();
 
@@ -143,6 +294,12 @@ class Match {
     this.f2Adv = 0,
     this.f1Pen = 0,
     this.f2Pen = 0,
+    this.winner,
+    this.method,
+    this.submission,
+    this.dqReason,
+    this.dqDetail,
+    this.endedAt,
   }) {
     _validate();
   }
@@ -231,6 +388,31 @@ class Match {
       );
     }
 
+    // An outcome has to be internally consistent, or it is worse than none:
+    // a consumer would have to guess which half of it to believe.
+    if (method == MatchMethod.draw && winner != null) {
+      throw const FormatException(
+        'A draw has no winner: method "draw" with a winner is a contradiction',
+      );
+    }
+    if (method != null && method != MatchMethod.draw && winner == null) {
+      throw FormatException(
+        'method "${method!.toJson()}" needs a winner',
+      );
+    }
+    if (method == MatchMethod.dq && dqReason == null) {
+      throw const FormatException('method "dq" needs a dq_reason');
+    }
+    if (dqReason != null && method != MatchMethod.dq) {
+      throw const FormatException('dq_reason without method "dq"');
+    }
+    if (method != null && endedAt == null) {
+      throw const FormatException('a match with an outcome needs an ended_at');
+    }
+    if (endedAt != null && endedAt! < 0) {
+      throw FormatException('endedAt must be non-negative, got: $endedAt');
+    }
+
     // A clock can only be stopped after it started
     if (pausedAt != null) {
       if (pausedAt! < 0) {
@@ -253,6 +435,92 @@ class Match {
   /// Calculate total score for fighter 2
   /// Formula: pt2*2 + pt3*3 + pt4*4
   int get f2Score => f2Pt2 * 2 + f2Pt3 * 3 + f2Pt4 * 4;
+
+  /// True for a match that ended before outcomes existed: finished (or
+  /// canceled), and silent about how.
+  ///
+  /// Such an event was refereed by an app that applied no penalty consequences
+  /// at all, so applying them now would **rewrite a result that has already
+  /// been seen** — a match won 2–0 while the loser carried three penalties
+  /// becomes 2–2, goes to advantages, and can flip. Leaving an old result
+  /// showing the scoreboard it showed at the time is at worst incomplete;
+  /// rewriting it asserts something new about a match nobody re-refereed.
+  ///
+  /// A match still in progress is **not** legacy, whatever it carries: it has
+  /// no result to preserve, and it is being refereed *now*, by this app, under
+  /// these rules.
+  bool get isLegacyResult =>
+      method == null &&
+      (status == MatchStatus.finished || status == MatchStatus.canceled);
+
+  /// Points fighter 1 has, including those their opponent's penalties conceded.
+  ///
+  /// The raw counters stay raw: [f1Pt2] still means "takedowns fighter 1
+  /// scored". Folding the penalty points into them would claim a takedown that
+  /// never happened, and nothing would remember where the points came from.
+  int get f1EffectivePoints => f1Score + _penaltyPoints(f2Pen);
+
+  int get f2EffectivePoints => f2Score + _penaltyPoints(f1Pen);
+
+  /// Advantages fighter 1 has, including the one their opponent's second
+  /// penalty conceded.
+  int get f1EffectiveAdvantages => f1Adv + _penaltyAdvantages(f2Pen);
+
+  int get f2EffectiveAdvantages => f2Adv + _penaltyAdvantages(f1Pen);
+
+  /// The IBJJF ladder: the opponent's 3rd penalty concedes two points. The 4th
+  /// adds nothing to the arithmetic — it is a disqualification, and only the
+  /// referee may call one ([hasDisqualifyingPenalties]).
+  int _penaltyPoints(int opponentPenalties) =>
+      isLegacyResult ? 0 : (opponentPenalties >= 3 ? 2 : 0);
+
+  /// The opponent's 2nd penalty concedes an advantage.
+  int _penaltyAdvantages(int opponentPenalties) =>
+      isLegacyResult ? 0 : (opponentPenalties >= 2 ? 1 : 0);
+
+  /// Whether either fighter has earned a disqualification by accumulating four
+  /// penalties.
+  ///
+  /// The app does **not** act on this: a fourth penalty that ended the match by
+  /// itself would make the penalty button the one control on the mat that
+  /// decides who loses, and a mis-tap would be unrecoverable. The referee ends
+  /// the match; this only tells the UI what to offer them.
+  bool get hasDisqualifyingPenalties => f1Pen >= 4 || f2Pen >= 4;
+
+  /// The winner the scoreboard implies, or null when the fighters are level.
+  ///
+  /// Null is not a failure — it is the honest answer. A level match has no
+  /// winner in the data, and inventing one is exactly the lie this model exists
+  /// to prevent. The referees decide: [MatchMethod.decision] or
+  /// [MatchMethod.draw].
+  MatchWinner? get scoreboardWinner {
+    if (f1EffectivePoints != f2EffectivePoints) {
+      return f1EffectivePoints > f2EffectivePoints
+          ? MatchWinner.f1
+          : MatchWinner.f2;
+    }
+    if (f1EffectiveAdvantages != f2EffectiveAdvantages) {
+      return f1EffectiveAdvantages > f2EffectiveAdvantages
+          ? MatchWinner.f1
+          : MatchWinner.f2;
+    }
+    return null;
+  }
+
+  /// How the scoreboard would decide it, or null when it cannot.
+  ///
+  /// Penalties are never the answer: they are already inside the points and
+  /// advantages being compared, and using the raw count as a further tiebreak
+  /// would count the same penalty twice — a fighter whose third penalty already
+  /// handed their opponent two points could then lose *again* for having the
+  /// higher count.
+  MatchMethod? get scoreboardMethod {
+    if (f1EffectivePoints != f2EffectivePoints) return MatchMethod.points;
+    if (f1EffectiveAdvantages != f2EffectiveAdvantages) {
+      return MatchMethod.advantages;
+    }
+    return null;
+  }
 
   /// Convert score to display format (includes advantages/penalties notation)
   String getF1ScoreDisplay() => _buildScoreDisplay(f1Score, f1Adv, f1Pen);
@@ -289,6 +557,12 @@ class Match {
       'f2_adv': f2Adv,
       'f1_pen': f1Pen,
       'f2_pen': f2Pen,
+      if (winner != null) 'winner': winner!.toJson(),
+      if (method != null) 'method': method!.toJson(),
+      if (submission != null) 'submission': submission,
+      if (dqReason != null) 'dq_reason': dqReason!.toJson(),
+      if (dqDetail != null) 'dq_detail': dqDetail,
+      if (endedAt != null) 'ended_at': endedAt,
     };
   }
 
@@ -314,6 +588,12 @@ class Match {
       f2Adv: json['f2_adv'] as int? ?? 0,
       f1Pen: json['f1_pen'] as int? ?? 0,
       f2Pen: json['f2_pen'] as int? ?? 0,
+      winner: MatchWinner.fromJson(json['winner']),
+      method: MatchMethod.fromJson(json['method']),
+      submission: json['submission'] as String?,
+      dqReason: DqReason.fromJson(json['dq_reason']),
+      dqDetail: json['dq_detail'] as String?,
+      endedAt: json['ended_at'] as int?,
     );
   }
 
@@ -425,6 +705,12 @@ class Match {
     int? f2Adv,
     int? f1Pen,
     int? f2Pen,
+    dynamic winner = _sentinel,
+    dynamic method = _sentinel,
+    dynamic submission = _sentinel,
+    dynamic dqReason = _sentinel,
+    dynamic dqDetail = _sentinel,
+    dynamic endedAt = _sentinel,
   }) {
     return Match(
       id: id ?? this.id,
@@ -446,6 +732,13 @@ class Match {
       f2Adv: f2Adv ?? this.f2Adv,
       f1Pen: f1Pen ?? this.f1Pen,
       f2Pen: f2Pen ?? this.f2Pen,
+      winner: winner == _sentinel ? this.winner : winner as MatchWinner?,
+      method: method == _sentinel ? this.method : method as MatchMethod?,
+      submission:
+          submission == _sentinel ? this.submission : submission as String?,
+      dqReason: dqReason == _sentinel ? this.dqReason : dqReason as DqReason?,
+      dqDetail: dqDetail == _sentinel ? this.dqDetail : dqDetail as String?,
+      endedAt: endedAt == _sentinel ? this.endedAt : endedAt as int?,
     );
   }
 
@@ -466,7 +759,14 @@ class Match {
           f1Adv == other.f1Adv &&
           f2Adv == other.f2Adv &&
           f1Pen == other.f1Pen &&
-          f2Pen == other.f2Pen;
+          f2Pen == other.f2Pen &&
+          // A match that has gained an outcome is not the match it was: the
+          // score can be identical and the winner the opposite fighter.
+          winner == other.winner &&
+          method == other.method &&
+          submission == other.submission &&
+          dqReason == other.dqReason &&
+          dqDetail == other.dqDetail;
 
   @override
   int get hashCode => Object.hash(
@@ -477,5 +777,10 @@ class Match {
         f2Adv,
         f1Pen,
         f2Pen,
+        winner,
+        method,
+        submission,
+        dqReason,
+        dqDetail,
       );
 }

--- a/lib/features/match/models/match.dart
+++ b/lib/features/match/models/match.dart
@@ -400,6 +400,11 @@ class Match {
         'method "${method!.toJson()}" needs a winner',
       );
     }
+    if (winner != null && method == null) {
+      throw const FormatException(
+        'a winner without a method says who won but not what they won by',
+      );
+    }
     if (method == MatchMethod.dq && dqReason == null) {
       throw const FormatException('method "dq" needs a dq_reason');
     }
@@ -409,8 +414,16 @@ class Match {
     if (method != null && endedAt == null) {
       throw const FormatException('a match with an outcome needs an ended_at');
     }
-    if (endedAt != null && endedAt! < 0) {
-      throw FormatException('endedAt must be non-negative, got: $endedAt');
+    if (endedAt != null) {
+      if (endedAt! < 0) {
+        throw FormatException('endedAt must be non-negative, got: $endedAt');
+      }
+      // A match cannot have ended before it began.
+      if (startAt != null && endedAt! < startAt!) {
+        throw FormatException(
+          'endedAt ($endedAt) cannot precede startAt ($startAt)',
+        );
+      }
     }
 
     // A clock can only be stopped after it started
@@ -449,8 +462,15 @@ class Match {
   /// A match still in progress is **not** legacy, whatever it carries: it has
   /// no result to preserve, and it is being refereed *now*, by this app, under
   /// these rules.
+  ///
+  /// The test is [endedAt], not [method]. A legacy event has neither — but a
+  /// match *this* app ends always stamps [endedAt], even when it cannot yet
+  /// name a method (the referees have still to decide a level one). Keying off
+  /// [method] would therefore have made the app contradict itself the instant a
+  /// referee pressed Finish: a 0–0 match against three penalties reads 2–0
+  /// while it runs, and would have snapped back to 0–0 the moment it stopped.
   bool get isLegacyResult =>
-      method == null &&
+      endedAt == null &&
       (status == MatchStatus.finished || status == MatchStatus.canceled);
 
   /// Points fighter 1 has, including those their opponent's penalties conceded.

--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -307,9 +307,21 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
     if (state.isFinished) return;
 
     _timer?.cancel();
-    final updated = state.match.copyWith(
+    final match = state.match;
+
+    // Stamp what the scoreboard already knows. Finishing silently would leave
+    // the match indistinguishable from an event published before outcomes
+    // existed — and the penalty points the referee watched land would vanish
+    // the instant they pressed Finish.
+    //
+    // A level scoreboard names nobody: that is the referees' to call, and
+    // asking them is Phase 2's job.
+    final updated = match.copyWith(
       status: MatchStatus.finished,
       pausedAt: null,
+      winner: match.scoreboardWinner,
+      method: match.scoreboardMethod,
+      endedAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
     );
     state = state.copyWith(match: updated, remainingSeconds: 0);
     _publishState();

--- a/test/features/match/models/match_test.dart
+++ b/test/features/match/models/match_test.dart
@@ -1,7 +1,10 @@
+import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/features/match/models/match.dart';
 
 void main() {
+  _outcomeTests();
+
   group('Match', () {
     // Valid test data
     final validMatchData = {
@@ -819,6 +822,455 @@ void main() {
 
         expect(match1, equals(match2));
       });
+    });
+  });
+}
+
+// ─── Outcomes, penalties, and who actually won ─────────────────────────────
+//
+// See docs/specs/match-outcome.md. The bug that started this: Bob leads 4–0,
+// Carlos submits him, and the app publishes a scoreboard naming Bob.
+
+Match _match({
+  MatchStatus status = MatchStatus.inProgress,
+  int f1Pt2 = 0,
+  int f2Pt2 = 0,
+  int f1Adv = 0,
+  int f2Adv = 0,
+  int f1Pen = 0,
+  int f2Pen = 0,
+  MatchWinner? winner,
+  MatchMethod? method,
+  String? submission,
+  DqReason? dqReason,
+  String? dqDetail,
+  int? endedAt,
+}) {
+  return Match(
+    id: 'abcd',
+    status: status,
+    startAt: 1700000000,
+    duration: 300,
+    f1Name: 'Bob',
+    f2Name: 'Carlos',
+    f1Color: '#1BA34E',
+    f2Color: '#F5B800',
+    f1Pt2: f1Pt2,
+    f2Pt2: f2Pt2,
+    f1Adv: f1Adv,
+    f2Adv: f2Adv,
+    f1Pen: f1Pen,
+    f2Pen: f2Pen,
+    winner: winner,
+    method: method,
+    submission: submission,
+    dqReason: dqReason,
+    dqDetail: dqDetail,
+    endedAt: endedAt,
+  );
+}
+
+void _outcomeTests() {
+  group('the penalty ladder', () {
+    test('a first penalty concedes nothing', () {
+      // Arrange & Act — a warning, and nothing more
+      final match = _match(f2Pen: 1);
+
+      // Assert
+      expect(match.f1EffectivePoints, 0);
+      expect(match.f1EffectiveAdvantages, 0);
+    });
+
+    test('a second penalty concedes an advantage to the opponent', () {
+      // Act
+      final match = _match(f2Pen: 2);
+
+      // Assert
+      expect(match.f1EffectiveAdvantages, 1);
+      expect(match.f1EffectivePoints, 0, reason: 'points come at the third');
+    });
+
+    test('a third penalty concedes two points to the opponent', () {
+      // Act
+      final match = _match(f2Pen: 3);
+
+      // Assert — this is the rung that changes who wins
+      expect(match.f1EffectivePoints, 2);
+      expect(match.f1EffectiveAdvantages, 1, reason: 'the second still stands');
+    });
+
+    test('a fourth penalty adds nothing to the arithmetic', () {
+      // Arrange — it is a disqualification, and only a referee may call one
+      final third = _match(f2Pen: 3);
+
+      // Act
+      final fourth = _match(f2Pen: 4);
+
+      // Assert
+      expect(fourth.f1EffectivePoints, third.f1EffectivePoints);
+      expect(fourth.f1EffectiveAdvantages, third.f1EffectiveAdvantages);
+    });
+
+    test('the penalty points are added, not folded into the raw counters', () {
+      // Arrange — Carlos's third penalty gives Bob two points
+      final match = _match(f1Pt2: 1, f2Pen: 3);
+
+      // Assert — Bob is credited with the points, but the record still says he
+      // scored one takedown. Folding them in would claim a takedown that never
+      // happened, and nothing would remember where the points came from.
+      expect(match.f1EffectivePoints, 4);
+      expect(match.f1Score, 2);
+      expect(match.f1Pt2, 1);
+    });
+
+    test('both fighters can be penalised independently', () {
+      // Act
+      final match = _match(f1Pen: 3, f2Pen: 2);
+
+      // Assert
+      expect(match.f2EffectivePoints, 2, reason: "Bob's third penalty");
+      expect(match.f2EffectiveAdvantages, 1);
+      expect(match.f1EffectivePoints, 0, reason: 'Carlos only has two');
+      expect(match.f1EffectiveAdvantages, 1);
+    });
+
+    test('four penalties are recognised, but not acted on', () {
+      // Assert — the app offers the disqualification; it never imposes it
+      expect(_match(f2Pen: 4).hasDisqualifyingPenalties, isTrue);
+      expect(_match(f1Pen: 4).hasDisqualifyingPenalties, isTrue);
+      expect(_match(f1Pen: 3, f2Pen: 3).hasDisqualifyingPenalties, isFalse);
+    });
+  });
+
+  group('who the scoreboard says won', () {
+    test('more points wins', () {
+      // Act
+      final match = _match(f1Pt2: 2);
+
+      // Assert
+      expect(match.scoreboardWinner, MatchWinner.f1);
+      expect(match.scoreboardMethod, MatchMethod.points);
+    });
+
+    test('level on points, more advantages wins', () {
+      // Act
+      final match = _match(f1Pt2: 1, f2Pt2: 1, f2Adv: 1);
+
+      // Assert
+      expect(match.scoreboardWinner, MatchWinner.f2);
+      expect(match.scoreboardMethod, MatchMethod.advantages);
+    });
+
+    test('level on both refuses to name a winner', () {
+      // Arrange — the referees decide: a decision, or a draw
+      final match = _match(f1Pt2: 1, f2Pt2: 1, f1Adv: 1, f2Adv: 1);
+
+      // Assert — null is the honest answer, not a failure. Inventing a winner
+      // here is exactly the lie this model exists to prevent.
+      expect(match.scoreboardWinner, isNull);
+      expect(match.scoreboardMethod, isNull);
+    });
+
+    test('a penalty can hand the match to the fighter who was behind', () {
+      // Arrange — Bob leads 2–0 on the raw scoreboard…
+      final match = _match(f1Pt2: 1, f2Pt2: 2, f2Pen: 0);
+      expect(match.scoreboardWinner, MatchWinner.f2);
+
+      // Act — …and now Carlos, who was winning 4–2, takes a third penalty
+      final penalised = _match(f1Pt2: 1, f2Pt2: 2, f2Pen: 3);
+
+      // Assert — 2 + 2 = 4 apiece on points, and Bob's conceded advantage
+      // decides it. The penalty ladder is not cosmetic.
+      expect(penalised.f1EffectivePoints, 4);
+      expect(penalised.f2EffectivePoints, 4);
+      expect(penalised.scoreboardWinner, MatchWinner.f1);
+      expect(penalised.scoreboardMethod, MatchMethod.advantages);
+    });
+
+    test('penalties are never a tiebreak of their own', () {
+      // Arrange — level on effective points and advantages, but Carlos has one
+      // penalty (which concedes nothing).
+      final match = _match(f2Pen: 1);
+
+      // Assert — it stays level. Using the raw count as a further tiebreak
+      // would count the same penalty twice: a fighter whose third penalty had
+      // already handed two points away would then lose *again* for the count.
+      expect(match.scoreboardWinner, isNull);
+    });
+  });
+
+  group('legacy events are not re-refereed', () {
+    test('a finished match with no method keeps its old arithmetic', () {
+      // Arrange — an event published before outcomes existed: Bob won 2–0 while
+      // Carlos carried three penalties, and the app that refereed it applied no
+      // consequences at all.
+      final legacy = _match(
+        status: MatchStatus.finished,
+        f1Pt2: 1,
+        f2Pt2: 2,
+        f2Pen: 3,
+      );
+
+      // Assert — reading it with the new ladder would make it 4–4, send it to
+      // advantages, and flip the winner. Rewriting a result nobody re-refereed
+      // is not our call.
+      expect(legacy.isLegacyResult, isTrue);
+      expect(legacy.f1EffectivePoints, 2);
+      expect(legacy.f2EffectivePoints, 4);
+      expect(legacy.scoreboardWinner, MatchWinner.f2);
+    });
+
+    test('a canceled match is legacy too', () {
+      expect(
+        _match(status: MatchStatus.canceled, f2Pen: 3).isLegacyResult,
+        isTrue,
+      );
+    });
+
+    test('a match in progress is never legacy, whatever it carries', () {
+      // Arrange — this is the case the field-presence rule alone gets wrong: a
+      // live match has no method or ended_at *yet*, but it is being refereed
+      // right now, by this app, under these rules. The referee has to see the
+      // penalty they just gave turn into the opponent's points.
+      final live = _match(f2Pen: 3);
+
+      // Assert
+      expect(live.isLegacyResult, isFalse);
+      expect(live.f1EffectivePoints, 2);
+    });
+
+    test('a finished match that states its method uses the new ladder', () {
+      // Act
+      final modern = _match(
+        status: MatchStatus.finished,
+        f1Pt2: 1,
+        f2Pen: 3,
+        winner: MatchWinner.f1,
+        method: MatchMethod.points,
+        endedAt: 1700000180,
+      );
+
+      // Assert
+      expect(modern.isLegacyResult, isFalse);
+      expect(modern.f1EffectivePoints, 4);
+    });
+  });
+
+  group('an outcome must be internally consistent', () {
+    test('a draw has no winner', () {
+      // Assert — a consumer handed both would have to guess which half to
+      // believe
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          method: MatchMethod.draw,
+          winner: MatchWinner.f1,
+          endedAt: 1700000180,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('every other method needs a winner', () {
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          method: MatchMethod.submission,
+          endedAt: 1700000180,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('a disqualification needs a reason', () {
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          method: MatchMethod.dq,
+          winner: MatchWinner.f1,
+          endedAt: 1700000180,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('a reason without a disqualification is meaningless', () {
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          method: MatchMethod.points,
+          winner: MatchWinner.f1,
+          dqReason: DqReason.technicalFoul,
+          endedAt: 1700000180,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('an outcome needs an ending time', () {
+      // Arrange — start_at + duration is when the clock *would* have run out,
+      // which is exactly what a submission prevents
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          method: MatchMethod.submission,
+          winner: MatchWinner.f2,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('a draw is valid with no winner', () {
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          method: MatchMethod.draw,
+          endedAt: 1700000180,
+        ),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('the outcome survives the wire', () {
+    test('Carlos beat Bob by armbar, and the JSON says so', () {
+      // Arrange — the bug, fixed: Bob leads 4–0 and still loses
+      final match = _match(
+        status: MatchStatus.finished,
+        f1Pt2: 2,
+        winner: MatchWinner.f2,
+        method: MatchMethod.submission,
+        submission: 'armbar',
+        endedAt: 1700000180,
+      );
+
+      // Act
+      final json = jsonDecode(match.toJsonString()) as Map<String, dynamic>;
+
+      // Assert
+      expect(json['winner'], 'f2');
+      expect(json['method'], 'submission');
+      expect(json['submission'], 'armbar');
+      expect(json['ended_at'], 1700000180);
+      expect(json['f1_pt2'], 2, reason: 'the raw record is still the record');
+    });
+
+    test('a disqualification round-trips whole', () {
+      // Arrange
+      final match = _match(
+        status: MatchStatus.finished,
+        winner: MatchWinner.f1,
+        method: MatchMethod.dq,
+        dqReason: DqReason.technicalFoul,
+        dqDetail: 'knee reap',
+        endedAt: 1700000180,
+      );
+
+      // Act
+      final parsed = Match.fromJsonString(match.toJsonString());
+
+      // Assert
+      expect(parsed.method, MatchMethod.dq);
+      expect(parsed.dqReason, DqReason.technicalFoul);
+      expect(parsed.dqDetail, 'knee reap');
+      expect(parsed.winner, MatchWinner.f1);
+      expect(parsed.endedAt, 1700000180);
+    });
+
+    test('an unfinished match carries no outcome at all', () {
+      // Assert — the keys are absent, not null: an old client reading them
+      // must see nothing, not a null it has to interpret
+      final json = jsonDecode(_match().toJsonString()) as Map<String, dynamic>;
+      expect(json.containsKey('winner'), isFalse);
+      expect(json.containsKey('method'), isFalse);
+      expect(json.containsKey('ended_at'), isFalse);
+    });
+
+    test('an event from before outcomes existed still parses', () {
+      // Arrange — exactly what an old app published
+      const legacy = '{"id":"abcd","status":"finished","start_at":1700000000,'
+          '"duration":300,"f1_name":"Bob","f2_name":"Carlos",'
+          '"f1_color":"#1BA34E","f2_color":"#F5B800",'
+          '"f1_pt2":2,"f2_pt2":0,"f1_pt3":0,"f2_pt3":0,"f1_pt4":0,"f2_pt4":0,'
+          '"f1_adv":0,"f2_adv":0,"f1_pen":0,"f2_pen":3}';
+
+      // Act
+      final match = Match.fromJsonString(legacy);
+
+      // Assert — it parses, it knows it is legacy, and it is left alone
+      expect(match.method, isNull);
+      expect(match.winner, isNull);
+      expect(match.isLegacyResult, isTrue);
+      expect(match.f1EffectivePoints, 4, reason: 'raw score, no penalty points');
+    });
+
+    test('an unknown method is a hard error, not a silent null', () {
+      // Arrange — a future client publishing something we do not understand.
+      // Guessing would mean rendering a match whose result we cannot read.
+      const unknown = '{"id":"abcd","status":"finished","duration":300,'
+          '"f1_name":"Bob","f2_name":"Carlos",'
+          '"f1_color":"#1BA34E","f2_color":"#F5B800","method":"telepathy"}';
+
+      // Act & Assert
+      expect(() => Match.fromJsonString(unknown), throwsFormatException);
+    });
+  });
+
+  group('copyWith', () {
+    test('records an outcome on a match that had none', () {
+      // Act
+      final finished = _match().copyWith(
+        status: MatchStatus.finished,
+        winner: MatchWinner.f2,
+        method: MatchMethod.submission,
+        submission: 'triangle',
+        endedAt: 1700000180,
+      );
+
+      // Assert
+      expect(finished.winner, MatchWinner.f2);
+      expect(finished.method, MatchMethod.submission);
+      expect(finished.submission, 'triangle');
+    });
+
+    test('clears an outcome when passed null explicitly', () {
+      // Arrange — amending a result (phase 3) has to be able to take one back
+      final finished = _match(
+        status: MatchStatus.finished,
+        winner: MatchWinner.f2,
+        method: MatchMethod.submission,
+        endedAt: 1700000180,
+      );
+
+      // Act
+      final reopened = finished.copyWith(
+        status: MatchStatus.inProgress,
+        winner: null,
+        method: null,
+        endedAt: null,
+      );
+
+      // Assert
+      expect(reopened.winner, isNull);
+      expect(reopened.method, isNull);
+    });
+
+    test('a match that gains an outcome is not equal to the one it was', () {
+      // Arrange — the scores are identical and the winner is the *other*
+      // fighter. Equality that ignored the outcome would let a stale card sit
+      // on the home feed showing Bob winning a match Carlos submitted him in.
+      final live = _match(f1Pt2: 2);
+
+      // Act
+      final finished = live.copyWith(
+        status: MatchStatus.finished,
+        winner: MatchWinner.f2,
+        method: MatchMethod.submission,
+        endedAt: 1700000180,
+      );
+
+      // Assert
+      expect(finished, isNot(live));
     });
   });
 }

--- a/test/features/match/models/match_test.dart
+++ b/test/features/match/models/match_test.dart
@@ -1020,6 +1020,26 @@ void _outcomeTests() {
       expect(legacy.scoreboardWinner, MatchWinner.f2);
     });
 
+    test('a match this app finished is never legacy, even before phase 2', () {
+      // Arrange — finishing stamps ended_at even when it cannot yet name a
+      // method (a level scoreboard is the referees' to call). Keying the legacy
+      // rule off `method` would make the app contradict itself: this 0–0 match
+      // against three penalties reads 2–0 while it runs…
+      final live = _match(f2Pen: 3);
+      expect(live.f1EffectivePoints, 2);
+
+      // Act — …and the referee presses Finish
+      final finished = live.copyWith(
+        status: MatchStatus.finished,
+        endedAt: 1700000180,
+      );
+
+      // Assert — …and it still reads 2–0. The penalty points the referee
+      // watched land do not vanish the instant they stop the clock.
+      expect(finished.isLegacyResult, isFalse);
+      expect(finished.f1EffectivePoints, 2);
+    });
+
     test('a canceled match is legacy too', () {
       expect(
         _match(status: MatchStatus.canceled, f2Pen: 3).isLegacyResult,
@@ -1115,6 +1135,31 @@ void _outcomeTests() {
           status: MatchStatus.finished,
           method: MatchMethod.submission,
           winner: MatchWinner.f2,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('a winner without a method is refused', () {
+      // Arrange — it says who won and not what they won by, which is half an
+      // answer: a consumer cannot tell a submission from a points decision
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          winner: MatchWinner.f1,
+          endedAt: 1700000180,
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('a match cannot have ended before it began', () {
+      expect(
+        () => _match(
+          status: MatchStatus.finished,
+          method: MatchMethod.submission,
+          winner: MatchWinner.f2,
+          endedAt: 1699999999, // startAt is 1700000000
         ),
         throwsFormatException,
       );


### PR DESCRIPTION
Phase 1 of [the outcome spec](docs/specs/match-outcome.md): **the model, and nothing else.** No UI sets these fields yet, so nothing the app does changes. This is the phase that decides *who wins*, so it's the one that has to be right.

## What's here

**Outcomes.** `Match` now carries `winner`, `method`, `submission`, `dqReason`, `dqDetail`, `endedAt` — so an event can finally say that Carlos submitted Bob, instead of publishing a 4–0 scoreboard naming Bob.

**Penalties become real.** The IBJJF ladder is cumulative and the app applied none of it: 2nd penalty → an advantage to the opponent, 3rd → two points, 4th → a disqualification.

The consequences are **derived, never baked in**. `f1Pt2` still means *"takedowns fighter 1 scored"*; the conceded points live in `f1EffectivePoints`. Folding them into the counters would claim a takedown that never happened — and the mistake would be **unrecoverable**, because nothing would remember where the points came from.

**The fourth penalty is recognised, not acted on** (`hasDisqualifyingPenalties`). A penalty that ended a match by itself would make that button the one control on the mat that decides who loses, and a mis-tap would be unrecoverable.

**`scoreboardWinner` refuses to name a winner when the fighters are level** — and that `null` is the entire point. A level match has **no winner in the data**, and inventing one is the lie this model exists to prevent.

**Penalties are never a tiebreak of their own.** They're already *inside* the points and advantages being compared, so counting them again would count the same penalty twice — a fighter whose third penalty had already handed two points away could then lose *again* for having the higher count.

## Legacy matches are not re-refereed

A match finished before outcomes existed keeps its old arithmetic. Applying the ladder retroactively would **rewrite results people have already seen**: a 2–0 win with three penalties against the loser becomes 4–4, goes to advantages, and flips.

## Implementing it turned up a hole in the spec's own rule

The spec said: *"no `method` and no `ended_at` → legacy event"*.

**That describes the app's own live match too.** Those fields are only filled in when a match *ends* — so taken literally, the rule would have hidden the penalty points from the referee **precisely while they were refereeing**, which is the one moment they must see them.

`isLegacyResult` is therefore *"finished or canceled, **and** silent about how"*. A match in progress has no result to preserve; it's being refereed **now**, by this app, under these rules. The spec is corrected in the same commit.

## Test plan

- [x] `flutter test` — **172 passing** (26 new)
- [x] `flutter analyze` — no new issues
- [x] The penalty ladder, rung by rung, including the 4th adding nothing arithmetically
- [x] A penalty **flipping the match** to the fighter who was behind
- [x] The tie-break refusing to name a winner when level
- [x] Legacy events keeping their old arithmetic; a **live** match never treated as legacy
- [x] Every inconsistent outcome rejected: a draw with a winner, a method without one, a `dq` without a reason, an outcome without an `ended_at`
- [x] JSON round-trips; absent keys (not nulls) on an unfinished match; an unknown `method` is a hard error rather than a silent null

## What's next

Phase 2 (the outcome sheet) depends on this, so it branches from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD1yHCBE9EBjjafUz8N1Gg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit match outcomes, including winner, decision method, submissions, disqualification details, and end time.
  * Added support for accurately applying penalty effects to completed match results.
  * Preserved legacy scoring behavior for completed or canceled matches without recorded outcomes.
  * Live matches without an outcome remain subject to current penalty effects.

* **Documentation**
  * Clarified the definition and handling of legacy match events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->