### PR TITLE
feat(match): Phase 3 — show the result, and let a wrong one be corrected

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -45,11 +45,56 @@ Fetch events from nostr relays in real time, the events we are fetching are auth
   "f1_adv": 0,
   "f2_adv": 0,
   "f1_pen": 0,
-  "f2_pen": 0
+  "f2_pen": 0,
+
+  "winner": "f1",
+  "method": "submission",
+  "submission": "armbar",
+  "dq_reason": null,
+  "dq_detail": null,
+  "ended_at": 1700000180
 }
 ```
 
-> **Score = pt2×2 + pt3×3 + pt4×4** (per fighter)
+> **Raw score = pt2×2 + pt3×3 + pt4×4** (per fighter)
+>
+> **Effective score = raw score + 2 if the *opponent* has 3+ penalties**
+> **Effective advantages = adv + 1 if the *opponent* has 2+ penalties**
+
+### Outcome (how the match was won)
+
+The scoreboard cannot name the winner on its own: a fighter can lead 4–0 and
+lose to an armbar. These fields say what actually happened, and they are
+**absent** from events published before they existed — a consumer must tolerate
+that forever.
+
+| Field | Values |
+|---|---|
+| `winner` | `f1` \| `f2`. **Absent** while unfinished, when canceled, and on a draw. |
+| `method` | `submission` \| `points` \| `advantages` \| `decision` \| `dq` \| `forfeit` \| `draw` |
+| `submission` | Free text (`"armbar"`). Optional, and only with `method: submission`. |
+| `dq_reason` | `accumulated_penalties` \| `technical_foul` \| `disciplinary_foul`. Required with `method: dq`. |
+| `dq_detail` | Free text (`"knee reap"`). Optional. |
+| `ended_at` | Unix seconds. Not derivable — `start_at + duration` is when the clock *would* have run out, which is exactly what a submission prevents. |
+
+`submission`, `dq` and `forfeit` **beat the scoreboard**: the winner is whoever
+`winner` says, whatever the numbers show. The rest *are* the scoreboard.
+
+There is no `penalties` method. Penalties already became advantages and points
+(see the effective score above), so counting them again would count the same
+penalty twice.
+
+**Penalties (IBJJF):** the 2nd concedes an advantage to the opponent, the 3rd
+concedes two points, the 4th is a disqualification — which the referee calls,
+not the app. The raw counters stay raw: the conceded points are derived, never
+folded into `f1_pt2`, or the record would claim a takedown that never happened.
+
+**Legacy events are not re-refereed.** A *finished* match with no `method`
+predates all of this: read it with the raw scoreboard and no penalty
+consequences. Applying the ladder retroactively would rewrite results people
+have already seen.
+
+See `docs/specs/match-outcome.md`.
 
 ### Field Definitions
 

--- a/docs/specs/match-outcome.md
+++ b/docs/specs/match-outcome.md
@@ -408,18 +408,20 @@ Today, holding *Finish* ends the match immediately. Proposed:
 
 ## 10. Open questions
 
-### 10.1 Amending a finished match — deferred to phase 3
+### 10.1 Amending a finished match — ✅ done (phase 3)
 
 A finished match is read-only today (`_buildReadOnlyFooter`; `finishMatch` and
 `cancelMatch` are no-ops once `isFinished`). So a match the clock closed with the
 wrong winner — a penalty entered against the wrong fighter, say — **stays wrong
 forever**.
 
-That is a real gap, and this spec deliberately does **not** promise otherwise:
-nothing in phases 1 or 2 lets a referee correct a finished match. The mechanics
-are cheap (the event is addressable, republishing is what the app already does,
-and the monotonic `created_at` already handles it) — the cost is the UI. It goes
-in phase 3, and until it exists the app should not pretend.
+Phase 3 fixes it: a finished match offers **Amend result**, which reopens the
+outcome sheet and republishes. The mechanics were cheap, as expected — the event
+is addressable, so the correction supersedes the mistake on every relay, and the
+monotonic `created_at` makes sure it wins.
+
+A **canceled** match has no amend button: it is not a result, it is the absence
+of one.
 
 ### 10.2 Everything else is decided.
 

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -5,6 +5,7 @@ import '../../shared/theme/app_theme.dart';
 import '../match/create_match_screen.dart';
 import '../match/match_control_screen.dart';
 import '../match/models/match.dart';
+import '../match/widgets/outcome_label.dart';
 import '../match/providers/match_control_provider.dart';
 import 'providers/home_providers.dart';
 
@@ -341,9 +342,12 @@ class HomeScreen extends ConsumerWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                     ),
-                    if (match.f1Adv > 0) ...[
+                    if (match.f1EffectiveAdvantages > 0) ...[
                       const SizedBox(width: 6),
-                      _buildSmallBadge('A:${match.f1Adv}', tk.goldFg),
+                      _buildSmallBadge(
+                        'A:${match.f1EffectiveAdvantages}',
+                        tk.goldFg,
+                      ),
                     ],
                     if (match.f1Pen > 0) ...[
                       const SizedBox(width: 4),
@@ -357,9 +361,9 @@ class HomeScreen extends ConsumerWidget {
                 textBaseline: TextBaseline.alphabetic,
                 children: [
                   Text(
-                    '${match.f1Score}',
+                    '${match.f1EffectivePoints}',
                     style: TextStyle(
-                      color: match.f1Score > match.f2Score && !isCanceled
+                      color: _isWinning(match, MatchWinner.f1, isCanceled)
                           ? tk.accent
                           : tk.muted,
                       fontWeight: FontWeight.bold,
@@ -375,9 +379,9 @@ class HomeScreen extends ConsumerWidget {
                     ),
                   ),
                   Text(
-                    '${match.f2Score}',
+                    '${match.f2EffectivePoints}',
                     style: TextStyle(
-                      color: match.f2Score > match.f1Score && !isCanceled
+                      color: _isWinning(match, MatchWinner.f2, isCanceled)
                           ? tk.accent
                           : tk.muted,
                       fontWeight: FontWeight.bold,
@@ -391,8 +395,11 @@ class HomeScreen extends ConsumerWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
-                    if (match.f2Adv > 0) ...[
-                      _buildSmallBadge('A:${match.f2Adv}', tk.goldFg),
+                    if (match.f2EffectiveAdvantages > 0) ...[
+                      _buildSmallBadge(
+                        'A:${match.f2EffectiveAdvantages}',
+                        tk.goldFg,
+                      ),
                       const SizedBox(width: 6),
                     ],
                     if (match.f2Pen > 0) ...[
@@ -423,6 +430,31 @@ class HomeScreen extends ConsumerWidget {
               ),
             ],
           ),
+
+          // How it ended — because the scoreboard above cannot say. A match
+          // that finished on a submission shows the loser's numbers as the
+          // bigger ones, and only this line names the fighter who actually won.
+          if (describeOutcome(l10n, match) case final outcome?) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(Icons.emoji_events_outlined, size: 13, color: tk.goldFg),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    outcome,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: tk.goldFg,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
         ],
       ),
     );
@@ -480,6 +512,22 @@ class HomeScreen extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  /// Whether to light this fighter's number up.
+  ///
+  /// A finished match names its winner, and that name is the only thing worth
+  /// believing: Bob can lead 4–0 and still lose to an armbar. Only while a
+  /// match is undecided does the scoreboard get to speak for itself — and a
+  /// canceled match has no winner at all.
+  bool _isWinning(Match match, MatchWinner fighter, bool isCanceled) {
+    if (isCanceled) return false;
+
+    final winner = match.winner;
+    if (winner != null) return winner == fighter;
+    if (match.method != null) return false; // a draw: nobody won
+
+    return match.scoreboardWinner == fighter;
   }
 
   Widget _buildSmallBadge(String text, Color color) {

--- a/lib/features/match/match_control_screen.dart
+++ b/lib/features/match/match_control_screen.dart
@@ -8,6 +8,7 @@ import 'models/match_outcome.dart';
 import 'providers/match_control_provider.dart';
 import 'widgets/hold_button.dart';
 import 'widgets/match_outcome_sheet.dart';
+import 'widgets/outcome_label.dart';
 
 /// Parse hex color string (#RRGGBB) to Color with fallback
 Color _hexToColor(String hex, Color fallback) {
@@ -76,7 +77,12 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
         suggested: state.suggestedOutcome,
       );
       if (outcome == null || !mounted) return;
-      ref.read(matchControlProvider.notifier).finishWith(outcome);
+      final notifier = ref.read(matchControlProvider.notifier);
+      if (state.isFinished) {
+        notifier.amendOutcome(outcome);
+      } else {
+        notifier.finishWith(outcome);
+      }
     } finally {
       _askingOutcome = false;
     }
@@ -717,46 +723,77 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
     );
   }
 
-  /// Read-only footer shown in place of the scoring controls once a match is
-  /// finished or canceled. The match detail stays fully visible above it.
+  /// Shown in place of the scoring controls once a match is finished or
+  /// canceled. It says *how* it ended — a score row alone would show the loser
+  /// of a submission with the bigger numbers — and offers to correct it.
   Widget _buildReadOnlyFooter(BuildContext context, MatchControlState state) {
     final l10n = AppLocalizations.of(context);
     final tk = ChokeTokens.of(context);
     final finished = state.match.status == MatchStatus.finished;
     final accent = finished ? tk.statusFinishedFg : tk.dangerFg;
-    final label = finished ? l10n.matchFinished : l10n.matchCanceled;
+
+    final outcome = describeOutcome(l10n, state.match);
+    final label = outcome ??
+        (finished ? l10n.matchFinished : l10n.matchCanceled);
 
     return SizedBox(
       height: 44,
-      child: Center(
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          decoration: BoxDecoration(
-            color: accent.withOpacity(.12),
-            borderRadius: BorderRadius.circular(99),
-            border: Border.all(color: accent.withOpacity(.4)),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                finished ? Icons.emoji_events_outlined : Icons.cancel_outlined,
-                size: 16,
-                color: accent,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Flexible(
+            child: Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(
+                color: accent.withValues(alpha: .12),
+                borderRadius: BorderRadius.circular(99),
+                border: Border.all(color: accent.withValues(alpha: .4)),
               ),
-              const SizedBox(width: 8),
-              Text(
-                '$label · ${l10n.matchReadOnly}',
-                style: TextStyle(
-                  color: accent,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: .5,
-                ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    finished
+                        ? Icons.emoji_events_outlined
+                        : Icons.cancel_outlined,
+                    size: 16,
+                    color: accent,
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: accent,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: .5,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
-        ),
+
+          // A result the clock got wrong would otherwise stay wrong forever.
+          // Canceled matches are not results, so there is nothing to amend.
+          if (finished) ...[
+            const SizedBox(width: 8),
+            TextButton.icon(
+              onPressed: () => _askOutcome(state),
+              icon: const Icon(Icons.edit_outlined, size: 15),
+              label: Text(
+                l10n.outcomeAmend,
+                style: const TextStyle(fontSize: 11),
+              ),
+              style: TextButton.styleFrom(foregroundColor: tk.faint),
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/features/match/match_control_screen.dart
+++ b/lib/features/match/match_control_screen.dart
@@ -88,8 +88,14 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
         suggested: state.suggestedOutcome,
       );
       if (outcome == null || !mounted) return;
+
+      // Re-read the state: the clock can run out while the sheet is open, and
+      // the match may have finished itself behind it. Deciding from the state
+      // this sheet was *opened* with would call finishWith on an
+      // already-finished match — a silent no-op — and the referee's answer
+      // would simply vanish.
       final notifier = ref.read(matchControlProvider.notifier);
-      if (state.isFinished) {
+      if (ref.read(matchControlProvider).isFinished) {
         notifier.amendOutcome(outcome);
       } else {
         notifier.finishWith(outcome);

--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -327,7 +327,7 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   /// happened to reopen it — see [_onTimeUp].
   void finishWith(MatchOutcome outcome, {int? endedAt}) {
     if (state.isFinished) return;
-    _setOutcome(outcome);
+    _setOutcome(outcome, endedAt: endedAt);
   }
 
   /// Correct a result that is already published.
@@ -339,7 +339,10 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   /// created_at makes sure the correction wins.
   void amendOutcome(MatchOutcome outcome) => _setOutcome(outcome);
 
-  void _setOutcome(MatchOutcome outcome) {
+  /// [endedAt] defaults to now, which is what a referee ending a match in front
+  /// of them means. It is *not* what the clock means: a match whose time ran out
+  /// while the app was closed ended then, not when someone reopened it.
+  void _setOutcome(MatchOutcome outcome, {int? endedAt}) {
     _timer?.cancel();
     final match = state.match;
 

--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -337,7 +337,16 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   /// match is read-only, and the event is out on the relays. The event is
   /// addressable, so republishing it replaces the old one, and the monotonic
   /// created_at makes sure the correction wins.
-  void amendOutcome(MatchOutcome outcome) => _setOutcome(outcome);
+  void amendOutcome(MatchOutcome outcome) {
+    // Keep the time the *match* ended. A correction is not an ending: the event
+    // is republished, and its Nostr created_at already records when the fix went
+    // out. Stamping the amendment over endedAt would tell every consumer that a
+    // match from yesterday ended the moment somebody edited it.
+    //
+    // A legacy result has no endedAt to keep, so it gets one now — which is the
+    // best available answer, and better than none.
+    _setOutcome(outcome, endedAt: state.match.endedAt);
+  }
 
   /// [endedAt] defaults to now, which is what a referee ending a match in front
   /// of them means. It is *not* what the clock means: a match whose time ran out

--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -323,7 +323,19 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   /// that can name the wrong fighter.
   void finishWith(MatchOutcome outcome) {
     if (state.isFinished) return;
+    _setOutcome(outcome);
+  }
 
+  /// Correct a result that is already published.
+  ///
+  /// A match the clock closed with the wrong winner — a penalty entered against
+  /// the wrong fighter, say — would otherwise stay wrong forever: a finished
+  /// match is read-only, and the event is out on the relays. The event is
+  /// addressable, so republishing it replaces the old one, and the monotonic
+  /// created_at makes sure the correction wins.
+  void amendOutcome(MatchOutcome outcome) => _setOutcome(outcome);
+
+  void _setOutcome(MatchOutcome outcome) {
     _timer?.cancel();
     final updated = state.match.copyWith(
       status: MatchStatus.finished,

--- a/lib/features/match/widgets/outcome_label.dart
+++ b/lib/features/match/widgets/outcome_label.dart
@@ -1,0 +1,52 @@
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+import '../models/match.dart';
+
+/// How a finished match is described to a human: *"Buchecha · Submission
+/// (armbar)"*.
+///
+/// The reason this exists rather than a score comparison: a scoreboard cannot
+/// name the winner of a match that ended in a submission. Bob leads 4–0, Carlos
+/// armbars him, and every number on the card still says Bob. The result has to
+/// be read from the result.
+///
+/// Returns null when the match has no outcome — because it is still running, or
+/// because it was published before outcomes existed. A legacy match is not
+/// re-refereed: it shows the scoreboard it showed at the time.
+///
+/// See docs/specs/match-outcome.md.
+String? describeOutcome(AppLocalizations l10n, Match match) {
+  final method = match.method;
+  if (method == null) return null;
+
+  final label = methodLabel(l10n, method, submission: match.submission);
+
+  final winner = match.winner;
+  if (winner == null) return label; // a draw has no winner, by construction
+
+  final name = winner == MatchWinner.f1 ? match.f1Name : match.f2Name;
+  return '$name · $label';
+}
+
+/// The method on its own — naming the submission when the referee recorded one.
+String methodLabel(
+  AppLocalizations l10n,
+  MatchMethod method, {
+  String? submission,
+}) {
+  if (method == MatchMethod.submission &&
+      submission != null &&
+      submission.isNotEmpty) {
+    return l10n.outcomeSubmissionOf(submission);
+  }
+
+  return switch (method) {
+    MatchMethod.submission => l10n.outcomeSubmission,
+    MatchMethod.points => l10n.outcomePoints,
+    MatchMethod.advantages => l10n.outcomeAdvantages,
+    MatchMethod.decision => l10n.outcomeDecision,
+    MatchMethod.dq => l10n.outcomeDq,
+    MatchMethod.forfeit => l10n.outcomeForfeit,
+    MatchMethod.draw => l10n.outcomeDraw,
+  };
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -650,5 +650,18 @@
   "skip": "Skip",
   "@skip": {
     "description": "Skip an optional field"
+  },
+  "outcomeAmend": "Amend result",
+  "@outcomeAmend": {
+    "description": "Outcome: outcomeAmend"
+  },
+  "outcomeSubmissionOf": "Submission ({technique})",
+  "@outcomeSubmissionOf": {
+    "description": "Outcome: outcomeSubmissionOf",
+    "placeholders": {
+      "technique": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -162,5 +162,7 @@
   "outcomeConfirm": "Confirmar",
   "outcomeTimeUp": "Se acabó el tiempo — ¿cómo terminó?",
   "outcomeWinsBy": "Gana {name}",
-  "skip": "Omitir"
+  "skip": "Omitir",
+  "outcomeAmend": "Corregir resultado",
+  "outcomeSubmissionOf": "Sumisión ({technique})"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -162,5 +162,7 @@
   "outcomeConfirm": "確定",
   "outcomeTimeUp": "時間終了 — 試合の終わり方は？",
   "outcomeWinsBy": "{name} の勝ち",
-  "skip": "スキップ"
+  "skip": "スキップ",
+  "outcomeAmend": "結果を修正",
+  "outcomeSubmissionOf": "一本（{technique}）"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -162,5 +162,7 @@
   "outcomeConfirm": "Confirmar",
   "outcomeTimeUp": "Tempo esgotado — como terminou?",
   "outcomeWinsBy": "{name} vence",
-  "skip": "Pular"
+  "skip": "Pular",
+  "outcomeAmend": "Corrigir resultado",
+  "outcomeSubmissionOf": "Finalização ({technique})"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1079,6 +1079,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Skip'**
   String get skip;
+
+  /// Outcome: outcomeAmend
+  ///
+  /// In en, this message translates to:
+  /// **'Amend result'**
+  String get outcomeAmend;
+
+  /// Outcome: outcomeSubmissionOf
+  ///
+  /// In en, this message translates to:
+  /// **'Submission ({technique})'**
+  String outcomeSubmissionOf(String technique);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -522,4 +522,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get skip => 'Skip';
+
+  @override
+  String get outcomeAmend => 'Amend result';
+
+  @override
+  String outcomeSubmissionOf(String technique) {
+    return 'Submission ($technique)';
+  }
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -527,4 +527,12 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get skip => 'Omitir';
+
+  @override
+  String get outcomeAmend => 'Corregir resultado';
+
+  @override
+  String outcomeSubmissionOf(String technique) {
+    return 'Sumisión ($technique)';
+  }
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -507,4 +507,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get skip => 'スキップ';
+
+  @override
+  String get outcomeAmend => '結果を修正';
+
+  @override
+  String outcomeSubmissionOf(String technique) {
+    return '一本（$technique）';
+  }
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -526,4 +526,12 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get skip => 'Pular';
+
+  @override
+  String get outcomeAmend => 'Corrigir resultado';
+
+  @override
+  String outcomeSubmissionOf(String technique) {
+    return 'Finalização ($technique)';
+  }
 }

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -351,6 +351,8 @@ void main() {
 
     // Assert
     expect(find.text(l10n.outcomeAmend), findsNothing);
+  });
+
   testWidgets('reopening a match whose clock already expired asks at once',
       (tester) async {
     // Arrange — the referee closed the app mid-match and came back. The

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -284,4 +284,68 @@ void main() {
     // Assert
     expect(notifier.state.match.f1Score, 2);
   });
+
+  testWidgets('a finished match says how it ended, not just that it did',
+      (tester) async {
+    // Arrange — Pana leads 4–0 on the scoreboard, and lost to an armbar
+    final finished = _runningMatch().copyWith(
+      status: MatchStatus.finished,
+      f1Pt4: 1,
+      winner: MatchWinner.f2,
+      method: MatchMethod.submission,
+      submission: 'armbar',
+      endedAt: 1700000180,
+    );
+    await pumpScreen(tester, finished);
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    // Assert — the footer names the fighter who won, not the bigger number
+    expect(
+      find.text('Buchecha · ${l10n.outcomeSubmissionOf('armbar')}'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a wrong result can be corrected', (tester) async {
+    // Arrange — the clock closed it on points, against the wrong fighter (a
+    // penalty entered against the wrong man, say). Without this, the mistake is
+    // published and permanent.
+    final finished = _runningMatch().copyWith(
+      status: MatchStatus.finished,
+      f1Pt2: 1,
+      winner: MatchWinner.f1,
+      method: MatchMethod.points,
+      endedAt: 1700000180,
+    );
+    await pumpScreen(tester, finished);
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    // Act
+    await tester.tap(find.text(l10n.outcomeAmend));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(l10n.outcomeSubmission));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Buchecha'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(l10n.skip));
+    await tester.pumpAndSettle();
+
+    // Assert — the result is replaced, and republished: the event is
+    // addressable, so the correction supersedes the mistake on every relay
+    final match = notifier.state.match;
+    expect(match.winner, MatchWinner.f2);
+    expect(match.method, MatchMethod.submission);
+    expect(match.status, MatchStatus.finished);
+  });
+
+  testWidgets('a canceled match has nothing to amend', (tester) async {
+    // Arrange — a canceled match is not a result; it is the absence of one
+    final canceled =
+        _runningMatch().copyWith(status: MatchStatus.canceled);
+    await pumpScreen(tester, canceled);
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    // Assert
+    expect(find.text(l10n.outcomeAmend), findsNothing);
+  });
 }

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -288,13 +288,15 @@ void main() {
   testWidgets('a finished match says how it ended, not just that it did',
       (tester) async {
     // Arrange — Pana leads 4–0 on the scoreboard, and lost to an armbar
+    final startAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 180;
     final finished = _runningMatch().copyWith(
       status: MatchStatus.finished,
+      startAt: startAt,
       f1Pt4: 1,
       winner: MatchWinner.f2,
       method: MatchMethod.submission,
       submission: 'armbar',
-      endedAt: 1700000180,
+      endedAt: startAt + 120,
     );
     await pumpScreen(tester, finished);
     final l10n = await AppLocalizations.delegate.load(const Locale('en'));
@@ -310,12 +312,14 @@ void main() {
     // Arrange — the clock closed it on points, against the wrong fighter (a
     // penalty entered against the wrong man, say). Without this, the mistake is
     // published and permanent.
+    final startAt = DateTime.now().millisecondsSinceEpoch ~/ 1000 - 300;
     final finished = _runningMatch().copyWith(
       status: MatchStatus.finished,
+      startAt: startAt,
       f1Pt2: 1,
       winner: MatchWinner.f1,
       method: MatchMethod.points,
-      endedAt: 1700000180,
+      endedAt: startAt + 300,
     );
     await pumpScreen(tester, finished);
     final l10n = await AppLocalizations.delegate.load(const Locale('en'));

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/features/match/match_control_screen.dart';
 import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/match/models/match_outcome.dart';
 import 'package:choke/features/match/providers/match_control_provider.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import 'package:choke/services/key_management/key_manager.dart';
@@ -374,4 +375,37 @@ void main() {
     expect(notifier.state.awaitsOutcome, isTrue);
     expect(find.text(l10n.outcomeTitle), findsOneWidget);
   });
+
+  testWidgets('an outcome chosen after the match finished behind the sheet is '
+      'not lost', (tester) async {
+    // Arrange — the referee opens the sheet, and the clock runs out underneath
+    // it: the notifier finishes the match on points, on its own, while the
+    // sheet is still up. (Driven directly here, because the provider's clock
+    // reads the real wall clock and cannot be advanced by the test.)
+    await pumpScreen(tester, _runningMatch().copyWith(f1Pt2: 1));
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    await holdFinish(tester, l10n);
+
+    notifier.finishWith(
+      const MatchOutcome.onScoreboard(MatchWinner.f1, MatchMethod.points),
+    );
+    await tester.pump();
+
+    // Act — and *then* the referee says it was a submission, by the other man
+    await tester.tap(find.text(l10n.outcomeSubmission));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Buchecha'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(l10n.skip));
+    await tester.pumpAndSettle();
+
+    // Assert — the referee's answer wins. Deciding from the state the sheet was
+    // *opened* with would have called finishWith on a match that was already
+    // finished — a silent no-op — and the submission would simply have
+    // vanished, leaving the wrong fighter published as the winner.
+    final match = notifier.state.match;
+    expect(match.winner, MatchWinner.f2);
+    expect(match.method, MatchMethod.submission);
+  });
+
 }

--- a/test/features/match/providers/match_control_provider_test.dart
+++ b/test/features/match/providers/match_control_provider_test.dart
@@ -879,4 +879,49 @@ void main() {
       expect(notifier.state.match.status, MatchStatus.inProgress);
     });
   });
+
+  group('amending a result', () {
+    test('keeps the time the match actually ended', () {
+      // Arrange — a match that ended yesterday, decided against the wrong
+      // fighter
+      nostr = _FakeNostrService();
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final startAt = now - 86400;
+      final finished = _runningMatch().copyWith(
+        status: MatchStatus.finished,
+        startAt: startAt,
+        f1Pt2: 1,
+        winner: MatchWinner.f1,
+        method: MatchMethod.points,
+        endedAt: startAt + 300,
+      );
+      notifier = MatchControlNotifier(finished, nostr);
+
+      // Act — the referee corrects it today
+      notifier.amendOutcome(
+        const MatchOutcome.submissionBy(MatchWinner.f2, submission: 'armbar'),
+      );
+
+      // Assert — the result changes; when the match *ended* does not. A
+      // correction is not an ending, and the event's own created_at already
+      // records when the fix went out.
+      expect(notifier.state.match.winner, MatchWinner.f2);
+      expect(notifier.state.match.endedAt, startAt + 300);
+    });
+
+    test('gives a legacy result the only end time available', () {
+      // Arrange — an event from before ended_at existed
+      nostr = _FakeNostrService();
+      final legacy = _runningMatch().copyWith(status: MatchStatus.finished);
+      expect(legacy.endedAt, isNull);
+      notifier = MatchControlNotifier(legacy, nostr);
+
+      // Act
+      notifier.amendOutcome(const MatchOutcome.submissionBy(MatchWinner.f1));
+
+      // Assert — there is nothing to preserve, so now is the best answer there
+      // is, and better than none
+      expect(notifier.state.match.endedAt, isNotNull);
+    });
+  });
 }


### PR DESCRIPTION
Phase 3 of [the outcome spec](docs/specs/match-outcome.md) — the last one. **Depends on #92 → #91**, so the chain merges 91 → 92 → this.

## The home card was lighting up the fighter who lost

This is the original bug in its purest form. The card highlighted **the bigger number**:

```dart
color: match.f1Score > match.f2Score ? tk.accent : tk.muted,
```

A match that ended on a submission shows **the loser's numbers as the bigger ones** — so the card lit up the fighter who lost, in the winner's colour.

It now names the winner **the event names**, and only falls back to the scoreboard while a match is genuinely undecided. The numbers themselves are the **effective** ones, so a penalty that conceded points shows up there too.

## Both surfaces now say *how* it ended

*"Buchecha · Submission (armbar)"* — on the card and in the match screen's footer. A score row cannot say that, which is the entire premise of the feature.

## A wrong result can be corrected (§10.1)

This was the gap I flagged in the spec and refused to promise away: a result the clock closed against the wrong fighter — a penalty entered against the wrong man, say — **would stay wrong forever**. A finished match was read-only, and the event was already out on the relays.

**Amend result** reopens the outcome sheet and republishes. The mechanics are cheap, as predicted: the event is addressable, so the correction **supersedes the mistake on every relay**, and the monotonic `created_at` makes sure it wins.

A **canceled** match has no amend button — it isn't a result, it's the absence of one.

## `docs/SPEC.md` is updated

The schema other clients read now documents the outcome fields, the penalty ladder, the effective-score formulas, and the rule that **legacy events are not re-refereed**.

## Test plan

- [x] `flutter test` — **191 passing**
- [x] `flutter analyze` — no new issues
- [x] A finished match says how it ended, not just that it did
- [x] **A wrong result can be corrected**, and the correction republishes
- [x] A canceled match has nothing to amend
- [x] Android APK builds

## The feature, end to end

Bob leads 4–0. Carlos armbars him. The referee holds Finish, taps **Submission**, taps **Carlos** — and every relay, every dashboard, and the app's own card now say **Carlos won by submission (armbar)**, with Bob's 4–0 still on the record where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BD1yHCBE9EBjjafUz8N1Gg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Match cards now show how each match ended, including winner, method, and submission details.
  * Finished match results can be amended and republished.
  * Finished and canceled match views now clearly distinguish available actions.
  * Score and advantage displays reflect effective values, including penalty adjustments.
  * Added localized outcome labels in English, Spanish, Japanese, and Portuguese.

* **Documentation**
  * Updated scoring, outcome, penalty, and result-amendment guidance.

* **Tests**
  * Added coverage for outcome display, result amendments, and canceled-match behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->