### PR TITLE
fix: stop local builds from poisoning release updates

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,7 +18,13 @@ val releaseKeystoreFile =
 val hasReleaseKeystore = releaseKeystoreFile?.exists() == true
 
 /// Opt in to a debug-signed release: `flutter build apk --release -PdebugSignRelease`.
-val debugSignRelease = project.hasProperty("debugSignRelease")
+///
+/// The VALUE is what counts, not the presence of the flag: `-PdebugSignRelease=false`
+/// has to mean false, or a `gradle.properties` line someone added months ago
+/// silently keeps the guard down forever. Bare `-PdebugSignRelease` (no value)
+/// still means true, which is how everyone expects a Gradle flag to read.
+val debugSignRelease = (project.findProperty("debugSignRelease") as String?)
+    ?.let { it.isEmpty() || it.toBoolean() } == true
 
 // Refuse to BUILD a release we cannot sign properly — and refuse it here, when
 // the task graph is known, rather than while configuring: a check in the

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -83,6 +83,25 @@ android {
                 storeFile = releaseKeystoreFile
                 storePassword = keystoreProperties["storePassword"] as String
             }
+
+            // Sign with v3 as well as v2 — releases were coming out v2-only.
+            //
+            // v3 is the scheme that carries a signing-key LINEAGE, and it is
+            // the only way a signing key is ever replaceable: with it, a future
+            // keystore can prove it descends from this one, and phones accept
+            // the update. Without it, the key below is Choke's identity
+            // forever, and losing it means every user reinstalls from scratch —
+            // which, since the nsec lives in app storage, means every user
+            // loses their identity too.
+            //
+            // Costs nothing: v3 is additive, the APK stays installable on
+            // anything that took the v2-only ones.
+            //
+            // v1 (JAR signing) stays off. It only matters below API 24 and
+            // minSdk is 24.
+            enableV1Signing = false
+            enableV2Signing = true
+            enableV3Signing = true
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,6 +15,39 @@ if (keystorePropertiesFile.exists()) {
 }
 val releaseKeystoreFile =
     keystoreProperties["storeFile"]?.toString()?.let { file(it) }
+val hasReleaseKeystore = releaseKeystoreFile?.exists() == true
+
+/// Opt in to a debug-signed release: `flutter build apk --release -PdebugSignRelease`.
+val debugSignRelease = project.hasProperty("debugSignRelease")
+
+// Refuse to BUILD a release we cannot sign properly — and refuse it here, when
+// the task graph is known, rather than while configuring: a check in the
+// `release {}` block runs for every build in the project, so it would break
+// `flutter run` for anyone without a keystore.
+//
+// What it prevents: a silently debug-signed `app-release.apk`. It looks like a
+// real release and installs like one, but the debug key is regenerated per
+// machine (and per run on a CI runner), so once it is on a phone, every genuine
+// release afterwards is rejected — an update must carry the same signature as
+// the install it replaces. The only way out is uninstalling, which here means
+// losing the nsec.
+gradle.taskGraph.whenReady {
+    if (hasReleaseKeystore || debugSignRelease) return@whenReady
+
+    val buildingRelease = allTasks.any { task ->
+        task.project.path == ":app" &&
+            Regex("^(assemble|bundle|package).*Release$").matches(task.name)
+    }
+    if (buildingRelease) {
+        throw GradleException(
+            "No release keystore: expected android/key.properties pointing at one " +
+                "(CI writes it from the KEYSTORE_BASE64 secret).\n" +
+                "To build a release locally without it, pass -PdebugSignRelease — the " +
+                "result is DEBUG-SIGNED, cannot update a real install, and must never be " +
+                "distributed."
+        )
+    }
+}
 
 android {
     namespace = "io.protolayer.choke"
@@ -54,8 +87,39 @@ android {
     }
 
     buildTypes {
+        debug {
+            // A debug build installs as a SEPARATE app, beside the real one.
+            //
+            // Without this, `flutter run` overwrites the release install — same
+            // id, but signed with the machine's debug key. Android then refuses
+            // every future release, and the only way out is uninstalling and
+            // losing the app's data, which here is the nsec. Developing on the
+            // phone you referee with should not cost you your identity.
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
+
         release {
-            signingConfig = if (releaseKeystoreFile?.exists() == true) {
+            // Fail rather than fall back to the debug key.
+            //
+            // The fallback used to be silent, and it produced a file called
+            // `app-release.apk` signed with a key that is regenerated per
+            // machine — and, on a CI runner, per run. Install one of those and
+            // every real release afterwards is rejected, because an update must
+            // carry the same signature as the install it replaces. A build that
+            // cannot sign properly should say so, not hand over a poisoned
+            // artifact that looks exactly like a good one.
+            //
+            // Escape hatch for a contributor with no keystore:
+            //   flutter build apk --release -PdebugSignRelease
+            // What that produces is fine to run and must never be distributed.
+            //
+            // The refusal itself lives in `assembleRelease` below, NOT here:
+            // this block runs at CONFIGURATION time, so throwing from it would
+            // fail every build in the project — `flutter run` included — for
+            // anyone without a keystore. That is a worse footgun than the one
+            // being fixed.
+            signingConfig = if (hasReleaseKeystore) {
                 signingConfigs.getByName("release")
             } else {
                 signingConfigs.getByName("debug")


### PR DESCRIPTION
Follow-up to #96 (the app-id rename). Fixes the actual cause of "you must uninstall to update".

## It was never the releases

| APK | signer | versionCode |
|---|---|---|
| v1.1.4 | `c2ce5c0b…` (old key) | — |
| v1.2.0 | `3a89d511…` | 145 |
| v1.2.1 | `3a89d511…` | 153 |
| v1.3.0 | `3a89d511…` | 163 |

From v1.2.0 on they share a certificate and the versionCode rises, so **they
update over each other cleanly**. Whatever was installed on the phone was signed
with something else. This repo offered two ways to get there.

## 1. `flutter run` overwrote the real app

Same `applicationId`, signed with the machine's debug key. Debug builds now take
an `applicationIdSuffix`, so they install **beside** the release rather than
replacing it:

```text
io.protolayer.choke.debug   1.3.0-debug
```

Developing on the phone you referee with should not cost you the app — and the
app's data *is* the nsec.

## 2. A local release build was silently debug-signed

`key.properties` is a secret, so it is absent everywhere except CI — and the
release build type quietly fell back to `signingConfigs.debug`. It produced a
file called `app-release.apk`, signed with a key that is **regenerated per
machine, and per run on a CI runner**. Install one and every genuine release
afterwards is rejected, because an update must carry the same signature as the
install it replaces. The only way out is uninstalling, which here loses the key.

That build now refuses, and says why. A contributor without a keystore can still
opt in with `-PdebugSignRelease`, which warns and produces an APK that must never
be distributed.

## The bug inside the fix

I first threw from inside the `release {}` block. That block runs at
**configuration** time, so it failed `assembleDebug` too — `flutter run` broke
for anyone without a keystore, which is a worse footgun than the one being
fixed. The refusal is now bound to the task graph and fires only when a release
is actually being assembled. Caught by building it, not by reading it.

## Verified end to end

```text
debug, no keystore          → builds, io.protolayer.choke.debug, 1.3.0-debug
release, no keystore        → fails, with the reason and the escape hatch
release, -PdebugSignRelease → builds, debug-signed (4704f7f1…)
release, with keystore      → builds, signed by that keystore  ← the CI path
```

The last one is the one that must not break; I simulated CI with a throwaway
keystore and confirmed the APK comes out signed by it (`CN=CI Sim`), not by the
debug key.

## What you still have to do once

Uninstall whatever is on the phone now — it is signed with a foreign key and
nothing can bridge that. **Export the nsec from Account first** (#96 changes the
app id too, so storage starts empty regardless). After that, releases update
themselves, and `flutter run` never touches the installed app again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented release builds from being accidentally distributed with debug signing when a release keystore is unavailable.
  * Improved Android release signing compatibility by enabling modern signing schemes.

* **Chores**
  * Added clearer safeguards and configuration behavior for Android release builds.
  * Debug builds continue to support separate installation from release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->