### PR TITLE
fix: resume must never strand the relay transport

### DIFF
--- a/rust/src/api/relay.rs
+++ b/rust/src/api/relay.rs
@@ -53,6 +53,19 @@ pub struct RelayStatusData {
     pub connected: bool,
 }
 
+/// Every URL the caller has asked for, whether or not the pool holds it.
+///
+/// The pool is not this list: a relay whose re-add failed mid-reconnect is
+/// gone from the pool, and a reconnect that rebuilds "whatever the pool has"
+/// would never try it again — the relay would be silently gone until the
+/// process restarts. This registry is what was *asked for*; the pool is what
+/// *succeeded*. Reconnect rebuilds from the former.
+static CONFIGURED: OnceLock<std::sync::Mutex<std::collections::BTreeSet<String>>> = OnceLock::new();
+
+fn configured() -> &'static std::sync::Mutex<std::collections::BTreeSet<String>> {
+    CONFIGURED.get_or_init(|| std::sync::Mutex::new(std::collections::BTreeSet::new()))
+}
+
 /// A NIP-01 `REQ` filter. Empty vectors and `None` mean "unconstrained" — the
 /// same shape the Dart `Filter` has, so the mapping stays honest.
 pub struct FilterData {
@@ -69,8 +82,17 @@ pub async fn relay_add(url: String) -> Result<(), String> {
     client().add_relay(&url).await.map_err(|e| e.to_string())?;
 
     // Watch this relay's status so the caller learns when it (re)connects.
-    let relay = client().relay(&url).await.map_err(|e| e.to_string())?;
-    let mut notifications = relay.notifications();
+    //
+    // The task holds the RECEIVER only, never the `Relay` itself. Capturing the
+    // relay would keep its notification channel's senders alive after the pool
+    // drops it, so `Closed` would never arrive: every resume (which rebuilds
+    // relays) would leak one more immortal watcher, each still forwarding a
+    // dead relay's word under a live relay's URL.
+    let mut notifications = client()
+        .relay(&url)
+        .await
+        .map_err(|e| e.to_string())?
+        .notifications();
     let relay_url = url.clone();
     tokio::spawn(async move {
         loop {
@@ -88,12 +110,18 @@ pub async fn relay_add(url: String) -> Result<(), String> {
                 // Fell behind and skipped notifications. `while let Ok` here
                 // used to KILL the watcher — and a dead watcher is a Dart-side
                 // connection view frozen until the process restarts. Report
-                // the status we may have skipped past, and keep watching.
+                // the current status (looked up fresh, so a removed relay ends
+                // the watch instead of being resurrected), and keep watching.
                 Err(broadcast::error::RecvError::Lagged(_)) => {
-                    let _ = status_tx().send(RelayStatusData {
-                        url: relay_url.clone(),
-                        connected: relay.status() == RelayStatus::Connected,
-                    });
+                    match client().relay(&relay_url).await {
+                        Ok(current) => {
+                            let _ = status_tx().send(RelayStatusData {
+                                url: relay_url.clone(),
+                                connected: current.status() == RelayStatus::Connected,
+                            });
+                        }
+                        Err(_) => break,
+                    }
                 }
                 // The relay was removed from the pool; the watch is over.
                 Err(broadcast::error::RecvError::Closed) => break,
@@ -106,10 +134,17 @@ pub async fn relay_add(url: String) -> Result<(), String> {
         .connect_relay(&url)
         .await
         .map_err(|e| e.to_string())?;
+
+    // Registered only on success: a URL that never made it into the pool is
+    // the caller's error to hear about, not something to keep redialing.
+    configured().lock().unwrap().insert(url);
     Ok(())
 }
 
 pub async fn relay_remove(url: String) -> Result<(), String> {
+    // Out of the registry first, so a concurrent reconnect cannot resurrect a
+    // relay the user just removed.
+    configured().lock().unwrap().remove(&url);
     client().remove_relay(&url).await.map_err(|e| e.to_string())
 }
 
@@ -152,16 +187,30 @@ pub async fn relay_disconnect() {
 /// subscriptions survive by design: a newly added relay inherits them
 /// (`nostr-relay-pool` inherits pool subscriptions on `add_relay`).
 pub async fn relay_reconnect_all() {
-    let urls = relay_urls().await;
+    // Rebuild from what was ASKED FOR, not from what the pool currently holds:
+    // a relay whose previous re-add failed is absent from the pool, and a pool
+    // snapshot would silently abandon it forever.
+    let urls: Vec<String> = configured().lock().unwrap().iter().cloned().collect();
 
     for url in &urls {
         let _ = client().remove_relay(url).await;
     }
     for url in urls {
-        // Re-registers the status watcher too. If an add fails outright the
-        // relay is gone from the pool; the caller's own relay list still holds
-        // it, and the next resume retries the add.
-        let _ = relay_add(url).await;
+        // Re-registers the status watcher too. A failed add is retried here a
+        // couple of times (resume often races the network coming back up), and
+        // a URL that still fails stays in the registry — the next resume tries
+        // again, instead of the relay being quietly gone until app restart.
+        for attempt in 0..3u8 {
+            match relay_add(url.clone()).await {
+                Ok(()) => break,
+                // Still failing after the retries is not a dead end: the URL
+                // is in the registry, so the next resume starts over with it.
+                Err(_) if attempt == 2 => {}
+                Err(_) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                }
+            }
+        }
     }
 }
 
@@ -289,9 +338,18 @@ pub async fn relay_event_stream(sink: StreamSink<SignedEventData>) {
                 }
             }
             Ok(_) => {}
-            // Skipped events are tolerable — subscriptions redeliver and the
-            // resend sweep converges — but a dead stream is forever.
-            Err(broadcast::error::RecvError::Lagged(_)) => {}
+            // Fell behind: some events were skipped and a broadcast channel
+            // cannot replay them. The relays can, though — re-issuing every
+            // live REQ makes them resend what they hold, and for addressable
+            // events the latest state is the only state that matters. What
+            // must not happen is the old behavior: the stream dying here.
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                for (id, per_relay) in client().subscriptions().await {
+                    if let Some(filter) = per_relay.into_values().flatten().next() {
+                        let _ = client().subscribe_with_id(id, filter, None).await;
+                    }
+                }
+            }
             Err(broadcast::error::RecvError::Closed) => break,
         }
     }
@@ -311,11 +369,24 @@ pub async fn relay_status_stream(sink: StreamSink<RelayStatusData>) {
                     break;
                 }
             }
-            // Missed some transitions. The per-relay watchers re-report after
-            // their own lag, and the reconnect verifier re-nudges stragglers —
-            // what must not happen here is the stream dying and taking Dart's
-            // connection view with it.
-            Err(broadcast::error::RecvError::Lagged(_)) => {}
+            // Missed some transitions — and this channel's lag is independent
+            // of the per-relay watchers' lag, so nobody else re-reports them.
+            // Skipping here would leave Dart's connection view wrong until a
+            // relay happens to change state again; instead, send the current
+            // status of every registered relay straight into the sink. It is
+            // the same truth the missed notifications were carrying, minus the
+            // history nobody needs.
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                for (url, relay) in client().relays().await {
+                    let snapshot = RelayStatusData {
+                        url: url.to_string(),
+                        connected: relay.status() == RelayStatus::Connected,
+                    };
+                    if sink.add(snapshot).is_err() {
+                        return;
+                    }
+                }
+            }
             Err(broadcast::error::RecvError::Closed) => break,
         }
     }

--- a/rust/src/api/relay.rs
+++ b/rust/src/api/relay.rs
@@ -66,6 +66,54 @@ fn configured() -> &'static std::sync::Mutex<std::collections::BTreeSet<String>>
     CONFIGURED.get_or_init(|| std::sync::Mutex::new(std::collections::BTreeSet::new()))
 }
 
+/// Serializes add, remove and reconnect, whole operations at a time.
+///
+/// Locking only the registry accesses is not enough: reconnect snapshots the
+/// registry and then spends seconds rebuilding relays, and a `relay_remove`
+/// landing inside that window would be undone — the rebuild re-adds the URL
+/// the user just deleted, from its stale snapshot. Whole-operation
+/// serialization makes the interleaving impossible instead of unlikely.
+///
+/// Ordering: this lock is taken first, and the `configured()` mutex is only
+/// ever taken while holding it (and never across an await), so there is no
+/// path to a deadlock. The public wrappers lock; `*_locked` variants do not,
+/// and exist for reconnect to compose.
+static OPS: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+fn ops() -> &'static tokio::sync::Mutex<()> {
+    OPS.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// Which incarnation of each URL's relay is the live one.
+///
+/// Rebuilding a relay replaces its watcher, but tasks do not die in order: the
+/// OLD watcher can still be draining its backlog — a `Terminated` from the
+/// relay that was just torn down — after the NEW relay has already reported
+/// `Connected`. Forwarded, that late word would clear the caller's connected
+/// view of a relay that is in fact healthy, and nothing would correct it until
+/// the relay next changed state. So every watcher is stamped with the
+/// generation it was born under, and a watcher whose generation has passed
+/// says nothing and exits.
+static GENERATION: OnceLock<std::sync::Mutex<std::collections::HashMap<String, u64>>> =
+    OnceLock::new();
+
+fn generation() -> &'static std::sync::Mutex<std::collections::HashMap<String, u64>> {
+    GENERATION.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Invalidate every watcher spawned for [url] so far; returns the new
+/// generation, for the watcher about to be spawned.
+fn bump_generation(url: &str) -> u64 {
+    let mut map = generation().lock().unwrap();
+    let next = map.get(url).copied().unwrap_or(0) + 1;
+    map.insert(url.to_string(), next);
+    next
+}
+
+fn current_generation(url: &str) -> u64 {
+    generation().lock().unwrap().get(url).copied().unwrap_or(0)
+}
+
 /// A NIP-01 `REQ` filter. Empty vectors and `None` mean "unconstrained" — the
 /// same shape the Dart `Filter` has, so the mapping stays honest.
 pub struct FilterData {
@@ -79,6 +127,12 @@ pub struct FilterData {
 
 /// Register a relay with the pool and dial it.
 pub async fn relay_add(url: String) -> Result<(), String> {
+    let _ops = ops().lock().await;
+    relay_add_locked(url).await
+}
+
+/// The body of [relay_add], for callers already holding [ops].
+async fn relay_add_locked(url: String) -> Result<(), String> {
     client().add_relay(&url).await.map_err(|e| e.to_string())?;
 
     // Watch this relay's status so the caller learns when it (re)connects.
@@ -88,6 +142,12 @@ pub async fn relay_add(url: String) -> Result<(), String> {
     // drops it, so `Closed` would never arrive: every resume (which rebuilds
     // relays) would leak one more immortal watcher, each still forwarding a
     // dead relay's word under a live relay's URL.
+    //
+    // It is also stamped with its generation, and checks it before every send:
+    // watchers do not die in order, and one draining the torn-down relay's
+    // backlog must not speak — its `Terminated` arriving after the replacement
+    // relay's `Connected` would clear the caller's view of a healthy relay.
+    let generation = bump_generation(&url);
     let mut notifications = client()
         .relay(&url)
         .await
@@ -96,8 +156,14 @@ pub async fn relay_add(url: String) -> Result<(), String> {
     let relay_url = url.clone();
     tokio::spawn(async move {
         loop {
+            if current_generation(&relay_url) != generation {
+                break; // superseded: a newer incarnation is being watched
+            }
             match notifications.recv().await {
                 Ok(RelayNotification::RelayStatus { status }) => {
+                    if current_generation(&relay_url) != generation {
+                        break;
+                    }
                     // No receivers yet is not an error: Dart may not have
                     // opened the stream, and the relay's status is what it is
                     // regardless.
@@ -113,6 +179,9 @@ pub async fn relay_add(url: String) -> Result<(), String> {
                 // the current status (looked up fresh, so a removed relay ends
                 // the watch instead of being resurrected), and keep watching.
                 Err(broadcast::error::RecvError::Lagged(_)) => {
+                    if current_generation(&relay_url) != generation {
+                        break;
+                    }
                     match client().relay(&relay_url).await {
                         Ok(current) => {
                             let _ = status_tx().send(RelayStatusData {
@@ -142,9 +211,12 @@ pub async fn relay_add(url: String) -> Result<(), String> {
 }
 
 pub async fn relay_remove(url: String) -> Result<(), String> {
-    // Out of the registry first, so a concurrent reconnect cannot resurrect a
-    // relay the user just removed.
+    let _ops = ops().lock().await;
+    // Out of the registry first, so a reconnect can never resurrect a relay
+    // the user just removed — and the generation bump silences its watcher
+    // before the teardown notifications it is about to receive.
     configured().lock().unwrap().remove(&url);
+    bump_generation(&url);
     client().remove_relay(&url).await.map_err(|e| e.to_string())
 }
 
@@ -187,12 +259,21 @@ pub async fn relay_disconnect() {
 /// subscriptions survive by design: a newly added relay inherits them
 /// (`nostr-relay-pool` inherits pool subscriptions on `add_relay`).
 pub async fn relay_reconnect_all() {
+    // Held for the WHOLE rebuild: a remove landing between the snapshot below
+    // and the re-adds would otherwise be undone — the user deletes a relay,
+    // and the resume resurrects it from a stale snapshot.
+    let _ops = ops().lock().await;
+
     // Rebuild from what was ASKED FOR, not from what the pool currently holds:
     // a relay whose previous re-add failed is absent from the pool, and a pool
     // snapshot would silently abandon it forever.
     let urls: Vec<String> = configured().lock().unwrap().iter().cloned().collect();
 
     for url in &urls {
+        // Silence the outgoing watcher before the teardown it is about to
+        // observe; the registry keeps the URL — this removal is a rebuild,
+        // not a goodbye.
+        bump_generation(url);
         let _ = client().remove_relay(url).await;
     }
     for url in urls {
@@ -201,7 +282,7 @@ pub async fn relay_reconnect_all() {
         // a URL that still fails stays in the registry — the next resume tries
         // again, instead of the relay being quietly gone until app restart.
         for attempt in 0..3u8 {
-            match relay_add(url.clone()).await {
+            match relay_add_locked(url.clone()).await {
                 Ok(()) => break,
                 // Still failing after the retries is not a dead end: the URL
                 // is in the registry, so the next resume starts over with it.
@@ -343,6 +424,14 @@ pub async fn relay_event_stream(sink: StreamSink<SignedEventData>) {
             // live REQ makes them resend what they hold, and for addressable
             // events the latest state is the only state that matters. What
             // must not happen is the old behavior: the stream dying here.
+            //
+            // Taking one filter per subscription is exact, not lossy: every
+            // subscription in this pool is single-filter by construction —
+            // [relay_subscribe] is the only writer, and `subscribe_with_id`
+            // takes exactly one `Filter` — and pool-level subscriptions carry
+            // that same filter to every relay. (Re-issuing per filter with the
+            // same id would be wrong anyway: a repeated REQ id REPLACES, so
+            // only the last filter would survive.)
             Err(broadcast::error::RecvError::Lagged(_)) => {
                 for (id, per_relay) in client().subscriptions().await {
                     if let Some(filter) = per_relay.into_values().flatten().next() {

--- a/rust/src/api/relay.rs
+++ b/rust/src/api/relay.rs
@@ -73,14 +73,30 @@ pub async fn relay_add(url: String) -> Result<(), String> {
     let mut notifications = relay.notifications();
     let relay_url = url.clone();
     tokio::spawn(async move {
-        while let Ok(notification) = notifications.recv().await {
-            if let RelayNotification::RelayStatus { status } = notification {
-                // No receivers yet is not an error: Dart may not have opened
-                // the stream, and the relay's status is what it is regardless.
-                let _ = status_tx().send(RelayStatusData {
-                    url: relay_url.clone(),
-                    connected: status == RelayStatus::Connected,
-                });
+        loop {
+            match notifications.recv().await {
+                Ok(RelayNotification::RelayStatus { status }) => {
+                    // No receivers yet is not an error: Dart may not have
+                    // opened the stream, and the relay's status is what it is
+                    // regardless.
+                    let _ = status_tx().send(RelayStatusData {
+                        url: relay_url.clone(),
+                        connected: status == RelayStatus::Connected,
+                    });
+                }
+                Ok(_) => {}
+                // Fell behind and skipped notifications. `while let Ok` here
+                // used to KILL the watcher — and a dead watcher is a Dart-side
+                // connection view frozen until the process restarts. Report
+                // the status we may have skipped past, and keep watching.
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    let _ = status_tx().send(RelayStatusData {
+                        url: relay_url.clone(),
+                        connected: relay.status() == RelayStatus::Connected,
+                    });
+                }
+                // The relay was removed from the pool; the watch is over.
+                Err(broadcast::error::RecvError::Closed) => break,
             }
         }
     });
@@ -112,9 +128,41 @@ pub async fn relay_disconnect() {
 /// TCP timeouts. When the app resumes we already know the sockets are suspect —
 /// the OS kills them without a close frame — and the referee's next tap must
 /// not wait for the kernel to work that out.
+///
+/// ## Why this rebuilds the relays instead of calling disconnect + connect
+///
+/// `nostr-sdk` 0.44's revival races its own teardown, and losing that race
+/// **strands the relay permanently**. `disconnect()` stores a termination
+/// permit (a tokio `Notify`) and returns with the status already `Terminated`;
+/// `connect()` then flips it to `Pending` and spawns a task — which sees the
+/// OLD task still registered and declines. The old task meanwhile wakes from
+/// `connect_and_run`, reads `Pending` (not terminated, so it keeps going),
+/// marks the relay `Disconnected`, and dies in its backoff sleep by consuming
+/// the stored permit. End state: status `Disconnected`, **no task**, and
+/// `connect()` is a no-op on `Disconnected` — nothing dials again until the
+/// process restarts. That is the app's "no connection until I kill it" bug,
+/// reproduced by the `resume never strands the transport` drill.
+///
+/// Nudging stragglers back to life with more disconnect/connect pairs just
+/// re-enters the same race (the drill stayed red under a 20-round nudge loop).
+/// The only sequence that cannot lose it is the one with no revival in it at
+/// all: **remove the relay and add it back**. A removed relay's watcher ends
+/// (its channel closes), and `relay_add` builds a fresh `Relay` — new `Notify`
+/// with no stored permit, no zombie task, a new watcher — and dials. Pool
+/// subscriptions survive by design: a newly added relay inherits them
+/// (`nostr-relay-pool` inherits pool subscriptions on `add_relay`).
 pub async fn relay_reconnect_all() {
-    client().disconnect().await;
-    client().connect().await;
+    let urls = relay_urls().await;
+
+    for url in &urls {
+        let _ = client().remove_relay(url).await;
+    }
+    for url in urls {
+        // Re-registers the status watcher too. If an add fails outright the
+        // relay is gone from the pool; the caller's own relay list still holds
+        // it, and the next resume retries the add.
+        let _ = relay_add(url).await;
+    }
 }
 
 /// Publish to **one** relay and report that relay's verdict.
@@ -229,16 +277,22 @@ pub async fn relay_connected() -> Vec<String> {
 pub async fn relay_event_stream(sink: StreamSink<SignedEventData>) {
     let mut notifications = client().notifications();
 
-    while let Ok(notification) = notifications.recv().await {
-        if let RelayPoolNotification::Message {
-            message: RelayMessage::Event { event, .. },
-            ..
-        } = notification
-        {
-            if sink.add(to_signed_data(&event)).is_err() {
-                // Dart dropped the stream; nobody is listening any more.
-                break;
+    loop {
+        match notifications.recv().await {
+            Ok(RelayPoolNotification::Message {
+                message: RelayMessage::Event { event, .. },
+                ..
+            }) => {
+                if sink.add(to_signed_data(&event)).is_err() {
+                    // Dart dropped the stream; nobody is listening any more.
+                    break;
+                }
             }
+            Ok(_) => {}
+            // Skipped events are tolerable — subscriptions redeliver and the
+            // resend sweep converges — but a dead stream is forever.
+            Err(broadcast::error::RecvError::Lagged(_)) => {}
+            Err(broadcast::error::RecvError::Closed) => break,
         }
     }
 }
@@ -250,9 +304,19 @@ pub async fn relay_event_stream(sink: StreamSink<SignedEventData>) {
 pub async fn relay_status_stream(sink: StreamSink<RelayStatusData>) {
     let mut status = status_tx().subscribe();
 
-    while let Ok(change) = status.recv().await {
-        if sink.add(change).is_err() {
-            break;
+    loop {
+        match status.recv().await {
+            Ok(change) => {
+                if sink.add(change).is_err() {
+                    break;
+                }
+            }
+            // Missed some transitions. The per-relay watchers re-report after
+            // their own lag, and the reconnect verifier re-nudges stragglers —
+            // what must not happen here is the stream dying and taking Dart's
+            // connection view with it.
+            Err(broadcast::error::RecvError::Lagged(_)) => {}
+            Err(broadcast::error::RecvError::Closed) => break,
         }
     }
 }

--- a/test/services/nostr/relay/convergence_drills.dart
+++ b/test/services/nostr/relay/convergence_drills.dart
@@ -177,6 +177,38 @@ void runConvergenceDrills(
       expect(relayB.received.single['content'], 'f1: 7');
     });
 
+    test('resume never strands the transport', () async {
+      // Arrange — a healthy, connected relay.
+      await service.addRelay(relayA.url);
+      await connected(relayA.url);
+
+      // Act — what main.dart does every time the app returns to the
+      // foreground: reconnectAll(), i.e. disconnect + connect. Hammered,
+      // because the failure being hunted is a race — the user's report is
+      // "a veces": sometimes the app comes back, sometimes it needs a kill.
+      for (var i = 0; i < 20; i++) {
+        await service.reconnectAll();
+        // Vary the phase: half the iterations give the old connection task a
+        // beat to reach its next await, half fire into it mid-flight.
+        if (i.isOdd) {
+          await Future<void>.delayed(const Duration(milliseconds: 25));
+        }
+      }
+
+      // Assert — however the coin lands, the transport must come back on its
+      // own. When this fails, connectedRelays stays empty forever, every
+      // publish throws "No connected relays", and no retry can fix it —
+      // exactly the referee tapping Retry against a dead app.
+      await eventually(
+        () => backend.connectedRelays.contains(relayA.url),
+        timeout: const Duration(seconds: 20),
+      );
+
+      // And the next score must actually land.
+      await service.publishEvent(score(1700000000, 'f1 leads'));
+      await eventually(() => relayA.received.isNotEmpty);
+    });
+
     test('with nothing reachable, the score survives until the relay returns',
         () async {
       // Arrange — airplane mode: the app knows its relay, and nothing answers

--- a/test/services/nostr/relay/convergence_drills.dart
+++ b/test/services/nostr/relay/convergence_drills.dart
@@ -209,6 +209,31 @@ void runConvergenceDrills(
       await eventually(() => relayA.received.isNotEmpty);
     });
 
+    test('a score given right after resume lands anyway', () async {
+      // Arrange — a healthy relay, and the app freshly resumed. This is the
+      // literal sequence from the bug report: reopen the app (the lifecycle
+      // hook fires reconnectAll) and immediately create a match.
+      await service.addRelay(relayA.url);
+      await connected(relayA.url);
+      await service.reconnectAll();
+
+      // Act — publish with no settling delay. Mid-rebuild there may be no
+      // connected relay yet, and then the publish throws; that is the honest
+      // answer at that instant, and the referee sees a retry option. What must
+      // NOT happen is the score silently never arriving.
+      try {
+        await service.publishEvent(score(1700000000, 'f1 leads'));
+      } catch (_) {
+        // Registered as pending before the throw; the reconnect listener
+        // delivers it the moment the rebuilt relay comes up.
+      }
+
+      // Assert — the score lands without the referee doing anything else.
+      await eventually(() => relayA.received.isNotEmpty,
+          timeout: const Duration(seconds: 20));
+      expect(relayA.received.last['content'], 'f1 leads');
+    });
+
     test('with nothing reachable, the score survives until the relay returns',
         () async {
       // Arrange — airplane mode: the app knows its relay, and nothing answers


### PR DESCRIPTION
Fixes the "app has no connection until I kill it" bug.

## The symptom

Sometimes, after returning to the app, creating a match fails with a no-connection
error. Retry fails too — every time. Killing and reopening the app fixes it
instantly. Wi-Fi is fine and every other app works.

## The cause

Our own resume hook, racing a bug in nostr-sdk 0.44.

On every `AppLifecycleState.resumed`, the app calls `reconnectAll()` —
`disconnect()` + `connect()` on the pool. In nostr-sdk 0.44 that revival can
lose a race against its own teardown:

1. `disconnect()` stores a termination permit (a tokio `Notify`) and returns
   with the relay already `Terminated`.
2. `connect()` flips it to `Pending` and spawns a connection task — which sees
   the **old task still registered**, and declines.
3. The old task wakes, reads `Pending` (not terminated → it keeps going), marks
   the relay `Disconnected`, and dies in its backoff sleep by consuming the
   stored permit.

End state: **no task, status `Disconnected`** — and `connect()` is a no-op on
`Disconnected`. Nothing ever dials again. Dart's `connectedRelays` stays empty,
so every publish throws before touching the network. Only a process restart
rebuilds the world. It is a race, hence "sometimes".

## Reproduced before fixed

The new drill (`resume never strands the transport`) hammers `reconnectAll()`
twenty times against a live relay — exactly as the lifecycle hook fires it —
and asserts the transport comes back and a score lands.

- **Red** on the old code: `connectedRelays` stays empty for 20s+, the referee's
  Retry against a dead app.
- A first fix attempt (re-nudging stragglers with more disconnect/connect
  pairs, 20 rounds) **stayed red**: each nudge re-enters the same race. Worth
  recording so nobody retries that road.
- A probe confirmed the strand is Rust-side (`relay_connected()` empty), not a
  lost Dart notification.

## The fix

The one sequence with no revival in it: **remove every relay and add it back.**
A fresh `Relay` has a fresh `Notify` (no stored permit), no zombie task, and a
new status watcher. Pool subscriptions survive by design — nostr-relay-pool
makes newly added relays inherit them.

Also hardened all three notification loops against broadcast `Lagged`: they
used `while let Ok`, so falling behind by one channel capacity killed the loop
**silently** — the status-watcher variant of that is a Dart-side connection
view frozen until restart, the same symptom by another road. They now skip what
they missed (the watcher re-reports the relay's current status) and exit only
when the channel closes.

## Tests

- New drill red→green; the four #78 convergence drills still pass (44 rust-tagged).
- Full suite: 227 passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay reconnect behavior so repeated reconnects and app resume no longer strand transports or resurrect removed relays.
  * Updated relay status and event streaming to recover cleanly after missed/broadcast-lagged updates and to continue emitting fresh status snapshots.
  * Enhanced relays’ reported connection state after temporary delays to keep the client view accurate.
* **Tests**
  * Added an integration convergence drill covering repeated resume/reconnect timing races, verifying the relay reconnects and can receive events afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->