### PR TITLE
docs: clarify which files to commit after gen-l10n

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -54,6 +54,34 @@ with your `.arb` changes — they are tracked in the repo. (A plain
 is set in `pubspec.yaml`, but run the command explicitly so the diff is part of
 your commit.)
 
+### Which files do I commit?
+
+**Both** — the `.arb` file you edited **and** every file that changed under
+`lib/l10n/generated/`. In this repo the generated Dart is versioned (it is *not*
+in `.gitignore`), so it must stay in sync with the source `.arb`.
+
+For example, if you fix a Spanish string, `flutter gen-l10n` updates
+`lib/l10n/generated/app_localizations_es.dart`, and you commit:
+
+```bash
+git add lib/l10n/app_es.arb lib/l10n/generated/
+git status --short   # make sure no generated/ file is left unstaged
+```
+
+Why not just the `.arb`?
+
+- The app is compiled from the generated **Dart**, not the `.arb`. Because
+  `generate: true` is set, your own `flutter run` / `flutter build` regenerates
+  it locally, so *your* build looks correct even if you forget to commit it —
+  which is exactly why it's easy to miss.
+- But the committed `app_localizations_es.dart` would then be **out of sync**
+  with the `.arb`: anyone reading the diff, and any process that doesn't
+  regenerate before reading it, sees the old translation. Committing both keeps
+  the source and the generated output consistent.
+
+If you changed the **template** (`app_en.arb`) — adding or removing keys — several
+files under `lib/l10n/generated/` are regenerated at once; stage all of them.
+
 ---
 
 ## Change an existing translation


### PR DESCRIPTION
## Summary

Follow-up to the [translations guide](docs/translations.md). Adds a **"Which files do I commit?"** subsection under *Regenerating* that answers a common contributor question:

> After I edit an `.arb` and run `flutter gen-l10n`, do I commit both the `.arb` and `lib/l10n/generated/app_localizations_*.dart`, or just the `.arb`?

The answer, spelled out in the doc: **both**. The generated Dart is versioned in this repo and must stay in sync with the source `.arb`. Committing only the `.arb` still builds fine locally (because `generate: true` regenerates it), which is exactly why the stale generated file is easy to miss in the diff.

Includes the `git add lib/l10n/app_es.arb lib/l10n/generated/` example and a note that changing the `app_en.arb` template regenerates several files at once.

## Notes

- Documentation only — no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on which localization files to commit after regenerating language bindings.
  - Included a Git workflow example for reviewing and staging updated localization files.
  - Explained that generated localization files must remain synchronized with language source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->