### PR TITLE
feat: rebrand settings footer to ProtoLayer with website link

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -170,10 +170,10 @@ class SettingsScreen extends ConsumerWidget {
               tk: tk,
               icon: Icons.code,
               title: l10n.sourceCode,
-              subtitle: 'github.com/grunch/choke',
+              subtitle: 'github.com/protolayer-io/choke',
               trailingIcon: Icons.open_in_new,
               onTap: () => launchUrl(
-                Uri.parse('https://github.com/grunch/choke'),
+                Uri.parse('https://github.com/protolayer-io/choke'),
                 mode: LaunchMode.externalApplication,
               ),
             ),
@@ -188,7 +188,7 @@ class SettingsScreen extends ConsumerWidget {
             ),
             const SizedBox(height: 32),
 
-            // Built by Pana footer
+            // Built by ProtoLayer footer
             Consumer(
               builder: (context, ref, child) {
                 final packageInfo = ref.watch(packageInfoProvider);
@@ -204,10 +204,18 @@ class SettingsScreen extends ConsumerWidget {
                 return Center(
                   child: Column(
                     children: [
-                      Text(
-                        l10n.builtBy('Pana'),
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: colors.onSurface.withValues(alpha: 0.5),
+                      GestureDetector(
+                        onTap: () => launchUrl(
+                          Uri.parse('https://protolayer.io'),
+                          mode: LaunchMode.externalApplication,
+                        ),
+                        child: Text(
+                          l10n.builtBy('ProtoLayer'),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: tk.accent,
+                            decoration: TextDecoration.underline,
+                            decorationColor: tk.accent.withValues(alpha: 0.5),
+                          ),
                         ),
                       ),
                       const SizedBox(height: 10),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -221,32 +221,41 @@ class SettingsScreen extends ConsumerWidget {
                               l10n.builtBy('ProtoLayer'),
                               style: theme.textTheme.bodySmall?.copyWith(
                                 color: tk.accent,
-                                decoration: TextDecoration.underline,
-                                decorationColor: tk.accent.withValues(alpha: 0.5),
                               ),
                             ),
                           ),
                         ),
                       ),
                       const SizedBox(height: 10),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 12,
-                        ),
-                        decoration: isDark
-                            ? BoxDecoration(
-                                // Subtle lighter backdrop so the black belt
-                                // stays visible against the dark theme.
-                                color: colors.onSurface.withValues(alpha: 0.08),
-                                borderRadius: BorderRadius.circular(16),
-                              )
-                            : null,
-                        child: Image.asset(
-                          'assets/branding/bjj_black_belt.webp',
-                          width: 120,
-                          fit: BoxFit.contain,
-                          semanticLabel: l10n.bjjBlackBelt,
+                      Semantics(
+                        link: true,
+                        child: InkWell(
+                          onTap: () => launchUrl(
+                            Uri.parse('https://protolayer.io'),
+                            mode: LaunchMode.externalApplication,
+                          ),
+                          borderRadius: BorderRadius.circular(16),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 12,
+                            ),
+                            decoration: isDark
+                                ? BoxDecoration(
+                                    // Subtle lighter backdrop so the black belt
+                                    // stays visible against the dark theme.
+                                    color:
+                                        colors.onSurface.withValues(alpha: 0.08),
+                                    borderRadius: BorderRadius.circular(16),
+                                  )
+                                : null,
+                            child: Image.asset(
+                              'assets/branding/bjj_black_belt.webp',
+                              width: 120,
+                              fit: BoxFit.contain,
+                              semanticLabel: l10n.bjjBlackBelt,
+                            ),
+                          ),
                         ),
                       ),
                       const SizedBox(height: 10),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -204,17 +204,27 @@ class SettingsScreen extends ConsumerWidget {
                 return Center(
                   child: Column(
                     children: [
-                      GestureDetector(
-                        onTap: () => launchUrl(
-                          Uri.parse('https://protolayer.io'),
-                          mode: LaunchMode.externalApplication,
-                        ),
-                        child: Text(
-                          l10n.builtBy('ProtoLayer'),
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: tk.accent,
-                            decoration: TextDecoration.underline,
-                            decorationColor: tk.accent.withValues(alpha: 0.5),
+                      Semantics(
+                        link: true,
+                        child: InkWell(
+                          onTap: () => launchUrl(
+                            Uri.parse('https://protolayer.io'),
+                            mode: LaunchMode.externalApplication,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 8,
+                            ),
+                            child: Text(
+                              l10n.builtBy('ProtoLayer'),
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: tk.accent,
+                                decoration: TextDecoration.underline,
+                                decorationColor: tk.accent.withValues(alpha: 0.5),
+                              ),
+                            ),
                           ),
                         ),
                       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -578,7 +578,7 @@
     "placeholders": {
       "name": {
         "type": "String",
-        "example": "Pana"
+        "example": "ProtoLayer"
       }
     }
   },

--- a/test/features/settings/settings_footer_test.dart
+++ b/test/features/settings/settings_footer_test.dart
@@ -40,7 +40,7 @@ void main() {
 
       // Scroll to the bottom to find the footer
       await tester.scrollUntilVisible(
-        find.text('Built by Pana'),
+        find.text('Built by ProtoLayer'),
         200,
         scrollable: find.byType(Scrollable).first,
       );
@@ -58,7 +58,7 @@ void main() {
       );
 
       // Creator credit (localized)
-      expect(find.text('Built by Pana'), findsOneWidget);
+      expect(find.text('Built by ProtoLayer'), findsOneWidget);
 
       // Version from packageInfoProvider
       expect(find.text('v1.2.3'), findsOneWidget);
@@ -89,7 +89,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.scrollUntilVisible(
-        find.text('Built by Pana'),
+        find.text('Built by ProtoLayer'),
         200,
         scrollable: find.byType(Scrollable).first,
       );
@@ -105,7 +105,7 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(find.text('Built by Pana'), findsOneWidget);
+      expect(find.text('Built by ProtoLayer'), findsOneWidget);
 
       // Error fallback
       expect(find.text('—'), findsOneWidget);


### PR DESCRIPTION
## Summary

Gives the settings footer a more corporate, branded identity by attributing the app to **ProtoLayer** and linking to the company website. Also updates the source-code link to reflect the repo's move to the `protolayer-io` org.

## Changes

- **Creator credit**: `Built by Pana` → `Built by ProtoLayer` (localized across all languages via the existing parameterized `builtBy` key — the brand name is not translated).
- **Tappable credit**: the footer credit now opens <https://protolayer.io> in an external browser, styled with the accent color + subtle underline to read as a link. Reuses the existing `url_launcher` dependency.
- **Source-code link**: updated from `github.com/grunch/choke` to `github.com/protolayer-io/choke`.
- **Tests**: footer test assertions updated to the new name; `builtBy` ARB `example` metadata updated.

## Notes

- No i18n structure changes — `builtBy` was already parameterized (`"Construido por {name}"` / `"Built by {name}"`), so only the argument changed. This keeps the brand name consistent (untranslated) in every locale.

## Test plan

- [x] `flutter test test/features/settings/settings_footer_test.dart` — passes (2/2)
- [ ] Manual: open Settings → tap the "Built by ProtoLayer" credit → confirms it opens protolayer.io
- [ ] Manual: tap "Source code" row → confirms it opens the protolayer-io/choke repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Content Updates**
  * Updated the About section’s “source code” link to the ProtoLayer GitHub repository.
  * Rebranded the settings footer from “Built by Pana” to “Built by ProtoLayer”.
  * Made the footer “built by” elements tappable, opening protolayer.io externally.
  * Refreshed footer presentation to match the theme accent styling.
* **Tests**
  * Updated settings footer tests to expect “Built by ProtoLayer”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->