### PR TITLE
feat: compact home status filters, default to active matches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Cargokit cross-compiles the crate for three Android ABIs and, together
+      # with the Android SDK/NDK and Gradle caches, exhausts the ~14 GB free on
+      # the runner ("No space left on device"). Reclaim space from preinstalled
+      # toolchains this job never uses.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/share/swift /usr/local/share/powershell \
+            /usr/local/share/chromium /usr/local/lib/node_modules
+          sudo apt-get clean
+          df -h /
+
       - name: Setup Rust
         run: rustup show
 

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -137,28 +137,12 @@ class HomeScreen extends ConsumerWidget {
     List<Match> allMatches,
     ChokeTokens tk,
   ) {
-    final statuses = MatchStatus.values;
-
-    return Column(
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
       children: [
-        for (var row = 0; row < statuses.length; row += 2) ...[
-          if (row > 0) const SizedBox(height: 12),
-          Row(
-            children: [
-              Expanded(
-                child: _buildStatusCard(
-                    context, ref, statuses[row], selected, allMatches, tk),
-              ),
-              if (row + 1 < statuses.length) ...[
-                const SizedBox(width: 12),
-                Expanded(
-                  child: _buildStatusCard(context, ref, statuses[row + 1],
-                      selected, allMatches, tk),
-                ),
-              ],
-            ],
-          ),
-        ],
+        for (final status in MatchStatus.values)
+          _buildStatusCard(context, ref, status, selected, allMatches, tk),
       ],
     );
   }
@@ -191,48 +175,38 @@ class HomeScreen extends ConsumerWidget {
           ref.read(statusFilterProvider.notifier).state = current;
         },
         child: Container(
-          padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           decoration: BoxDecoration(
             color: isSelected ? color.withOpacity(.12) : tk.card,
-            borderRadius: BorderRadius.circular(18),
+            borderRadius: BorderRadius.circular(12),
             border: Border.all(
               color: isSelected ? color.withOpacity(.5) : tk.cardBorder,
             ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Container(
-                    width: 8,
-                    height: 8,
-                    decoration:
-                        BoxDecoration(color: color, shape: BoxShape.circle),
-                  ),
-                  const SizedBox(width: 8),
-                  Flexible(
-                    child: Text(
-                      _statusLabel(l10n, status),
-                      style: TextStyle(
-                        color: isSelected ? color : tk.muted,
-                        fontSize: 15,
-                        fontWeight: FontWeight.w700,
-                      ),
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ),
-                ],
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(width: 8),
+              Text(
+                _statusLabel(l10n, status),
+                style: TextStyle(
+                  color: isSelected ? color : tk.muted,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(width: 6),
               Text(
                 '$count',
                 style: TextStyle(
                   color: count > 0 ? color : tk.faint,
-                  fontSize: 30,
+                  fontSize: 13,
                   fontWeight: FontWeight.w700,
-                  height: 1,
                 ),
               ),
             ],

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -175,6 +175,9 @@ class HomeScreen extends ConsumerWidget {
           ref.read(statusFilterProvider.notifier).state = current;
         },
         child: Container(
+          // Enforce the 44px minimum interactive height for an accessible tap
+          // target; the visible layout and styling stay compact.
+          constraints: const BoxConstraints(minHeight: 44),
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           decoration: BoxDecoration(
             color: isSelected ? color.withOpacity(.12) : tk.card,

--- a/lib/features/home/providers/home_providers.dart
+++ b/lib/features/home/providers/home_providers.dart
@@ -6,13 +6,12 @@ import '../../match/providers/match_providers.dart';
 import '../../../services/nostr/nostr_service.dart';
 
 /// Status filter: which statuses to show on the home screen.
-/// All statuses shown by default (24h window already limits the list).
+/// Only active matches (waiting + in progress) are shown by default; the user
+/// can reveal finished and canceled matches by tapping their filter chips.
 final statusFilterProvider = StateProvider<Set<MatchStatus>>((ref) {
   return {
     MatchStatus.waiting,
     MatchStatus.inProgress,
-    MatchStatus.finished,
-    MatchStatus.canceled,
   };
 });
 

--- a/test/features/home/providers/home_providers_test.dart
+++ b/test/features/home/providers/home_providers_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/features/home/providers/home_providers.dart';
 import 'package:choke/features/match/models/match.dart';
@@ -99,6 +100,68 @@ void main() {
 
       // Assert
       expect(feed.state.single.f1Pt2, 3);
+    });
+  });
+
+  group('statusFilter default', () {
+    test('shows only active matches (waiting + in progress) by default', () {
+      // Arrange
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      // Assert
+      expect(
+        container.read(statusFilterProvider),
+        {MatchStatus.waiting, MatchStatus.inProgress},
+      );
+    });
+
+    test('filtered list hides finished and canceled matches by default', () {
+      // Arrange — one match of every status is available
+      final container = ProviderContainer(
+        overrides: [
+          recentMatchListProvider.overrideWithValue([
+            _match(status: MatchStatus.waiting),
+            _match(status: MatchStatus.inProgress),
+            _match(status: MatchStatus.finished),
+            _match(status: MatchStatus.canceled),
+          ]),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Act
+      final visible = container.read(filteredMatchListProvider);
+
+      // Assert — finished/canceled are hidden until the user opts in
+      expect(
+        visible.map((m) => m.status).toSet(),
+        {MatchStatus.waiting, MatchStatus.inProgress},
+      );
+    });
+
+    test('tapping a hidden filter reveals its matches', () {
+      // Arrange — only a finished match exists, hidden by default
+      final container = ProviderContainer(
+        overrides: [
+          recentMatchListProvider.overrideWithValue([
+            _match(status: MatchStatus.finished),
+          ]),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(container.read(filteredMatchListProvider), isEmpty);
+
+      // Act — the user taps the "finished" filter chip
+      container.read(statusFilterProvider.notifier).update(
+            (selected) => {...selected, MatchStatus.finished},
+          );
+
+      // Assert
+      expect(
+        container.read(filteredMatchListProvider).single.status,
+        MatchStatus.finished,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Makes the home screen status filters smaller and defaults them to active matches.

- **Compact filters**: the large 2×2 grid of number cards (big count, ~14 px padding) is replaced by compact single-row pills — a colored dot, the status label, and its count inline — laid out in a `Wrap` so they flow in far less vertical space.
- **Active-by-default**: the status filter now defaults to **waiting + in progress** only. Finished and canceled matches are hidden until the user taps their filter chip (the toggle already adds/removes a status from the selected set).

## Why

Most of the time an operator only cares about matches that are waiting or live; finished/canceled just add noise. They remain one tap away.

## Changes

- `lib/features/home/providers/home_providers.dart` — default `statusFilterProvider` to `{waiting, inProgress}`.
- `lib/features/home/home_screen.dart` — `_buildStatusCards` now uses a `Wrap`; `_buildStatusCard` is a compact pill.
- `test/features/home/providers/home_providers_test.dart` — new `statusFilter default` group covering the default set, the hidden finished/canceled behavior, and reveal-on-tap.

## Test plan

- [x] `flutter test test/features/home/` — passes (6/6, incl. 3 new)
- [x] `flutter analyze` — no new warnings/errors (pre-existing `withOpacity` infos and unused `_MatchEntry`/import remain untouched)
- [ ] Manual: open Home → only waiting/in-progress matches show by default; tapping "Finished"/"Canceled" reveals them; filters are visibly smaller

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home screen status filter cards use a more compact, space-efficient layout.
  * Active match statuses are shown by default; finished and canceled remain hidden until enabled.
* **Bug Fixes**
  * Improved status card spacing, readability, and the visual emphasis of match counts.
* **Tests**
  * Added coverage to verify the default status filter behavior.
* **Chores**
  * Updated CI workflow to free disk space during Android builds to prevent storage-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->