### PR TITLE
feat: review a match before starting; start via the clock button

### DIFF
--- a/lib/features/match/match_control_screen.dart
+++ b/lib/features/match/match_control_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../shared/theme/app_theme.dart';
 import 'models/match.dart';
-import 'models/match_outcome.dart';
 import 'providers/match_control_provider.dart';
 import 'widgets/hold_button.dart';
 import 'widgets/match_outcome_sheet.dart';
@@ -169,7 +168,6 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
                       ],
                     ),
                   ),
-                  if (state.isWaiting) _buildWaitingOverlay(context, notifier),
                 ],
               );
             },
@@ -408,7 +406,7 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                if (state.isRunning) ...[
+                if (state.isRunning || state.isWaiting) ...[
                   _buildClockButton(context, state, notifier),
                   const SizedBox(width: 10),
                 ],
@@ -490,9 +488,18 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
   ) {
     final l10n = AppLocalizations.of(context);
     final tk = ChokeTokens.of(context);
+    final waiting = state.isWaiting;
     final paused = state.isPaused;
-    final accent = paused ? tk.goldFg : tk.accent;
-    final label = paused ? l10n.resume : l10n.pause;
+    // Before the match starts this same control begins it; once running it
+    // pauses and resumes the clock. This lets the referee review the match
+    // (fighter names, duration) before starting instead of a blocking overlay.
+    final isPlay = waiting || paused;
+    final accent = isPlay ? tk.goldFg : tk.accent;
+    final label =
+        waiting ? l10n.startMatch : (paused ? l10n.resume : l10n.pause);
+    final onTap = waiting
+        ? notifier.startMatch
+        : (paused ? notifier.resumeMatch : notifier.pauseMatch);
 
     return Semantics(
       button: true,
@@ -500,7 +507,7 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
       child: Tooltip(
         message: label,
         child: InkWell(
-          onTap: paused ? notifier.resumeMatch : notifier.pauseMatch,
+          onTap: onTap,
           borderRadius: BorderRadius.circular(11),
           child: Container(
             width: 38,
@@ -511,7 +518,7 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
               border: Border.all(color: accent.withOpacity(.45)),
             ),
             child: Icon(
-              paused ? Icons.play_arrow : Icons.pause,
+              isPlay ? Icons.play_arrow : Icons.pause,
               color: accent,
               size: 22,
             ),
@@ -686,60 +693,6 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
     );
   }
 
-  // ─── Overlays ──────────────────────────────────────────────────────────
-
-  Widget _buildWaitingOverlay(
-      BuildContext context, MatchControlNotifier notifier) {
-    final l10n = AppLocalizations.of(context);
-    final tk = ChokeTokens.of(context);
-
-    return _overlay(
-      context,
-      children: [
-        Align(
-          alignment: Alignment.topLeft,
-          child: IconButton(
-            icon: const Icon(Icons.arrow_back),
-            onPressed: () => Navigator.of(context).pop(),
-          ),
-        ),
-        Center(
-          child: Container(
-            height: 56,
-            decoration: BoxDecoration(
-              gradient: tk.gradient,
-              borderRadius: BorderRadius.circular(15),
-              boxShadow: [
-                BoxShadow(
-                  color: tk.gradTop.withValues(alpha: .35),
-                  blurRadius: 22,
-                  offset: const Offset(0, 8),
-                ),
-              ],
-            ),
-            child: ElevatedButton.icon(
-              onPressed: notifier.startMatch,
-              icon: Icon(Icons.play_arrow, color: tk.onGrad),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.transparent,
-                shadowColor: Colors.transparent,
-                foregroundColor: tk.onGrad,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(15),
-                ),
-              ),
-              label: Text(
-                l10n.startMatch,
-                style:
-                    const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
   /// Shown in place of the scoring controls once a match is finished or
   /// canceled. It says *how* it ended — a score row alone would show the loser
   /// of a submission with the bigger numbers — and offers to correct it.
@@ -811,16 +764,6 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
             ),
           ],
         ],
-      ),
-    );
-  }
-
-  Widget _overlay(BuildContext context, {required List<Widget> children}) {
-    final colors = Theme.of(context).colorScheme;
-    return Positioned.fill(
-      child: Container(
-        color: colors.surface.withOpacity(.88),
-        child: Stack(children: children),
       ),
     );
   }

--- a/lib/features/match/match_control_screen.dart
+++ b/lib/features/match/match_control_screen.dart
@@ -670,7 +670,10 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
           Expanded(
             flex: 5,
             child: HoldButton(
-              enabled: state.isRunning,
+              // Cancelling is allowed before the match starts too, so a match
+              // created with a wrong name, color or duration can be scrapped
+              // without having to start it first.
+              enabled: state.isRunning || state.isWaiting,
               accentColor: colors.error,
               backgroundColor: Colors.transparent,
               border: Border.all(color: colors.error.withOpacity(.5)),

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -273,8 +273,9 @@ void main() {
     expect(find.text('P:3'), findsOneWidget);
   });
 
-  testWidgets('waiting match shows start overlay', (tester) async {
-    // Arrange
+  testWidgets('waiting match shows an inline start button, not a blocking overlay',
+      (tester) async {
+    // Arrange — a freshly created match, not yet started
     final waiting = _runningMatch().copyWith(
       status: MatchStatus.waiting,
       startAt: null,
@@ -284,8 +285,31 @@ void main() {
     await pumpScreen(tester, waiting);
     final l10n = await AppLocalizations.delegate.load(const Locale('en'));
 
+    // Assert — the blocking overlay is gone (no full "Start match" text button);
+    // instead the clock's play button offers the start, and the match content
+    // stays visible so the referee can review the fighters before starting.
+    expect(find.text(l10n.startMatch), findsNothing);
+    expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+    expect(find.byIcon(Icons.pause), findsNothing);
+    expect(find.text('Pana'), findsWidgets);
+    expect(find.text('Buchecha'), findsWidgets);
+  });
+
+  testWidgets('tapping the play button starts a waiting match', (tester) async {
+    // Arrange
+    final waiting = _runningMatch().copyWith(
+      status: MatchStatus.waiting,
+      startAt: null,
+    );
+    await pumpScreen(tester, waiting);
+
+    // Act — the same control used for pause/resume starts the match
+    await tester.tap(find.byIcon(Icons.play_arrow));
+    await tester.pump();
+
     // Assert
-    expect(find.text(l10n.startMatch), findsOneWidget);
+    expect(notifier.state.match.status, MatchStatus.inProgress);
+    expect(find.byIcon(Icons.pause), findsOneWidget);
   });
 
   testWidgets('running match offers a pause button next to the clock',

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -312,6 +312,29 @@ void main() {
     expect(find.byIcon(Icons.pause), findsOneWidget);
   });
 
+  testWidgets('a waiting match can be cancelled without starting it',
+      (tester) async {
+    // Arrange — a match created with wrong details, not yet started
+    final waiting = _runningMatch().copyWith(
+      status: MatchStatus.waiting,
+      startAt: null,
+    );
+    await pumpScreen(tester, waiting);
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    // Act — hold the Cancel button as a referee would
+    final label = '${l10n.cancel} · ${l10n.holdHint}';
+    final gesture =
+        await tester.startGesture(tester.getCenter(find.text(label)));
+    await tester.pump(); // first ticker frame (t = 0)
+    await tester.pump(const Duration(milliseconds: 1100));
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // Assert — cancelled without ever starting
+    expect(notifier.state.match.status, MatchStatus.canceled);
+  });
+
   testWidgets('running match offers a pause button next to the clock',
       (tester) async {
     // Arrange + Act


### PR DESCRIPTION
## Summary

When a new match is created the app opens the match screen, but a full-screen "Start match" overlay covered the content, so the referee could not review what they had just created. This removes that blocking overlay and folds the start action into the existing pause/resume button.

Now, while a match is **waiting**:
- The match content is fully visible — the referee can check fighter names, the duration/clock, etc. before starting.
- The clock button next to the timer shows a **play** icon and **starts** the match on tap.

Once **running**, that same button behaves exactly as before (pause / resume).

## Changes

- `lib/features/match/match_control_screen.dart`
  - `_buildClockButton`: three states — waiting → start (`startMatch`), paused → resume, running → pause.
  - Show the clock button when `isWaiting || isRunning` (was `isRunning` only).
  - Remove the `_buildWaitingOverlay` center button and the now-unused `_overlay` scrim helper.
  - Remove a pre-existing unused import (`models/match_outcome.dart`).
- `test/features/match/match_control_screen_test.dart`
  - Replace the "shows start overlay" test: a waiting match now shows an inline play button (no blocking "Start match" text button) with the match content visible.
  - Add a test that tapping the play button starts a waiting match.

## Test plan

- [x] `flutter test test/features/match/match_control_screen_test.dart` — 22/22 pass (incl. 2 updated/new)
- [x] `flutter analyze` — no new warnings/errors (removed one pre-existing unused import)
- [ ] Manual: create a match → match screen shows fighters/time with no center overlay → tap the play button by the clock to start → pause/resume still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waiting matches now show an inline play control, enabling users to start the match directly without interrupting the rest of the match view.
  * Once the match begins, the control automatically updates to a pause-style action.

* **Bug Fixes**
  * Waiting-state controls are now integrated into the main interface instead of using a dedicated waiting overlay.
  * Cancel action availability was expanded to support cancelling while a match is waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->