### PR TITLE
ci: skip Android APK build on merge to main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,6 +90,11 @@ jobs:
   android:
     name: Android build (proves the crate links into the APK)
     runs-on: ubuntu-latest
+    # Only on PRs. This APK-link check gates code before it reaches main; the
+    # crate + bridge tests already re-run on push:main to guard against semantic
+    # merge conflicts, and the release workflow builds the real APK on a tag, so
+    # re-linking a debug APK on every merge would be redundant CPU.
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Qué

Añade `if: github.event_name == 'pull_request'` al job `android` de `rust.yml` para que **no** se ejecute al fusionar a `main`.

## Por qué

El job `android` cross-compila el crate de Rust y construye un APK debug. Al fusionar un PR que ya pasó ese check, volver a correrlo en `push: main` es redundante:

- Los tests (`crate`, `bridge`) **siguen corriendo en `main`** → protegen contra conflictos semánticos entre PRs.
- El APK-link se sigue verificando **en cada PR**, antes de fusionar.
- El APK firmado de verdad se construye en `release.yml` al hacer push de un tag `v*`.

Resultado: se elimina una compilación pesada (NDK + cross-compile ARM64) en cada merge, sin perder ninguna garantía.

## Impacto por job

| Job | PR | push:main |
|-----|:--:|:---------:|
| crate | ✅ | ✅ |
| bridge | ✅ | ✅ |
| android | ✅ | ❌ (nuevo) |

## Test plan

- [ ] En este PR, los 3 jobs (`crate`, `bridge`, `android`) corren normalmente.
- [ ] Tras fusionar, en `main` solo corren `crate` y `bridge` (el job `android` aparece omitido/skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated Android build validation for pull requests.
  * Continued running core crate and bridge checks for both pull requests and updates to the main branch.
  * Reduced redundant Android APK link checks during merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->