### PR TITLE
ci: also build a signed .aab for Google Play in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,19 @@ jobs:
           git commit -m "chore: update changelog and version for ${{ steps.version.outputs.full_tag }}"
           git push origin main
 
+      # The App Bundle packs native code for every ABI, so Cargokit
+      # cross-compiles the Rust crate three times (arm, arm64, x86_64). Together
+      # with the APK build, the NDK, and the Gradle/cargo caches this exhausts
+      # the ~14 GB free on the runner ("No space left on device"). Reclaim space
+      # from preinstalled toolchains this job never uses.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/share/swift /usr/local/share/powershell \
+            /usr/local/share/chromium /usr/local/lib/node_modules
+          sudo apt-get clean
+          df -h /
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -236,6 +249,20 @@ jobs:
           VERSION=${{ steps.version.outputs.full_tag }}
           cp build/app/outputs/flutter-apk/app-release.apk "choke-${VERSION}.apk"
 
+      # The Android App Bundle for Google Play. Unlike the sideload APK above,
+      # this deliberately keeps ALL ABIs (the default): Play generates optimized
+      # per-device APKs from the bundle, so every user still downloads only their
+      # own architecture — including all ABIs here costs nothing at install time
+      # and is what lets Play serve arm64, armeabi-v7a, and x86_64 devices.
+      # It is signed with the same upload key as the APK via android/key.properties.
+      - name: Build App Bundle (AAB for Google Play)
+        run: flutter build appbundle --release
+
+      - name: Rename AAB
+        run: |
+          VERSION=${{ steps.version.outputs.full_tag }}
+          cp build/app/outputs/bundle/release/app-release.aab "choke-${VERSION}.aab"
+
       - name: Generate release description
         id: description
         run: |
@@ -283,7 +310,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: RELEASE_BODY.md
-          files: choke-${{ steps.version.outputs.full_tag }}.apk
+          files: |
+            choke-${{ steps.version.outputs.full_tag }}.apk
+            choke-${{ steps.version.outputs.full_tag }}.aab
           generate_release_notes: false
           draft: false
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,17 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "full_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          FULL_TAG=${GITHUB_REF#refs/tags/}
+          # Refuse anything that isn't a clean semver tag (vX.Y.Z, optional
+          # pre-release/build suffix). Tag refs can legally contain shell
+          # metacharacters, and this value flows into later `run:` steps — so
+          # validating it here neutralizes template injection at the source.
+          if ! printf '%s' "$FULL_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'; then
+            echo "::error::Refusing to release: tag '$FULL_TAG' is not a clean vX.Y.Z tag."
+            exit 1
+          fi
+          echo "tag=${FULL_TAG#v}" >> $GITHUB_OUTPUT
+          echo "full_tag=$FULL_TAG" >> $GITHUB_OUTPUT
 
           # Get the previous tag for changelog range
           PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | sed -n '2p')
@@ -35,11 +43,13 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        # Pass tag-derived values through env, never interpolated into shell
+        # source (template-injection hardening).
+        env:
+          TAG: ${{ steps.version.outputs.full_tag }}
+          PREV_TAG: ${{ steps.version.outputs.prev_tag }}
+          IS_FIRST: ${{ steps.version.outputs.is_first }}
         run: |
-          TAG=${{ steps.version.outputs.full_tag }}
-          PREV_TAG=${{ steps.version.outputs.prev_tag }}
-          IS_FIRST=${{ steps.version.outputs.is_first }}
-
           if [ "$IS_FIRST" = "true" ]; then
             # First release — all commits
             COMMITS=$(git log --pretty=format:"- %s (%h)" --no-merges)
@@ -130,8 +140,9 @@ jobs:
           mv CHANGELOG_NEW.md CHANGELOG.md
 
       - name: Update version in pubspec.yaml
+        env:
+          VERSION: ${{ steps.version.outputs.tag }}
         run: |
-          VERSION=${{ steps.version.outputs.tag }}
           # Extract build number: count total commits
           BUILD=$(git rev-list --count HEAD)
           sed -i "s/^version: .*/version: ${VERSION}+${BUILD}/" pubspec.yaml
@@ -139,14 +150,16 @@ jobs:
           grep "^version:" pubspec.yaml
 
       - name: Commit changelog and version bump
+        env:
+          FULL_TAG: ${{ steps.version.outputs.full_tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin main
           git checkout main
-          git merge --ff-only ${{ steps.version.outputs.full_tag }} || true
+          git merge --ff-only "$FULL_TAG" || true
           git add CHANGELOG.md pubspec.yaml
-          git commit -m "chore: update changelog and version for ${{ steps.version.outputs.full_tag }}"
+          git commit -m "chore: update changelog and version for $FULL_TAG"
           git push origin main
 
       # The App Bundle packs native code for every ABI, so Cargokit
@@ -245,9 +258,9 @@ jobs:
         run: flutter build apk --release --target-platform android-arm64
 
       - name: Rename APK
-        run: |
-          VERSION=${{ steps.version.outputs.full_tag }}
-          cp build/app/outputs/flutter-apk/app-release.apk "choke-${VERSION}.apk"
+        env:
+          FULL_TAG: ${{ steps.version.outputs.full_tag }}
+        run: cp build/app/outputs/flutter-apk/app-release.apk "choke-${FULL_TAG}.apk"
 
       # The Android App Bundle for Google Play. Unlike the sideload APK above,
       # this deliberately keeps ALL ABIs (the default): Play generates optimized
@@ -259,16 +272,16 @@ jobs:
         run: flutter build appbundle --release
 
       - name: Rename AAB
-        run: |
-          VERSION=${{ steps.version.outputs.full_tag }}
-          cp build/app/outputs/bundle/release/app-release.aab "choke-${VERSION}.aab"
+        env:
+          FULL_TAG: ${{ steps.version.outputs.full_tag }}
+        run: cp build/app/outputs/bundle/release/app-release.aab "choke-${FULL_TAG}.aab"
 
       - name: Generate release description
         id: description
+        env:
+          TAG: ${{ steps.version.outputs.full_tag }}
+          VERSION: ${{ steps.version.outputs.tag }}
         run: |
-          TAG=${{ steps.version.outputs.full_tag }}
-          VERSION=${{ steps.version.outputs.tag }}
-
           # Read the categorized changes
           FEATURES=$(cat RELEASE_NOTES.md | sed -n '/### ✨/,/^###\|^$/p' | grep "^-" || true)
           FIXES=$(cat RELEASE_NOTES.md | sed -n '/### 🐛/,/^###\|^$/p' | grep "^-" || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,14 @@ jobs:
         id: version
         run: |
           FULL_TAG=${GITHUB_REF#refs/tags/}
-          # Refuse anything that isn't a clean semver tag (vX.Y.Z, optional
-          # pre-release/build suffix). Tag refs can legally contain shell
-          # metacharacters, and this value flows into later `run:` steps — so
-          # validating it here neutralizes template injection at the source.
-          if ! printf '%s' "$FULL_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$'; then
-            echo "::error::Refusing to release: tag '$FULL_TAG' is not a clean vX.Y.Z tag."
+          # Refuse anything that isn't a plain vX.Y.Z tag. Tag refs can legally
+          # contain shell metacharacters, and this value flows into later `run:`
+          # steps — validating it here neutralizes template injection at the
+          # source. Pre-release/build suffixes are rejected on purpose: the
+          # version-bump step appends its own +<build>, so a suffixed tag (e.g.
+          # v1.2.3+ci) would produce a malformed pubspec version.
+          if ! printf '%s' "$FULL_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Refusing to release: tag '$FULL_TAG' is not a plain vX.Y.Z tag."
             exit 1
           fi
           echo "tag=${FULL_TAG#v}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Extends `release.yml` so each `v*` tag also produces a **signed Android App Bundle (`.aab`)** for Google Play, alongside the existing sideload APK.

## Why

Google Play only accepts App Bundles, not APKs. The release workflow previously built just `choke-<tag>.apk` (arm64, for direct download), so there was no artifact you could upload to the Play Console.

## Changes

- **Build the AAB** with `flutter build appbundle --release`, signed with the same upload key as the APK (via `android/key.properties`, already set up in the workflow).
- **All ABIs on purpose:** unlike the arm64-only sideload APK, the bundle keeps every ABI (the default). Play generates optimized per-device APKs from the bundle, so each user still downloads only their own architecture — including all ABIs costs nothing at install time and covers arm64, armeabi-v7a, and x86_64.
- **Free disk space step:** building the all-ABI bundle plus the APK, NDK, and caches would otherwise exhaust the runner (`No space left on device`). Mirrors the existing step in the `android` job of `rust.yml`.
- **Attach both artifacts** (`.apk` + `.aab`) to the GitHub release.

## Test plan

- [ ] Push a `v*` tag and confirm the workflow builds both `choke-<tag>.apk` and `choke-<tag>.aab`.
- [ ] Confirm the `.aab` is signed (`jarsigner -verify` / `bundletool`) with the upload key.
- [ ] Upload the `.aab` to the Play Console internal testing track and confirm it is accepted.
- [ ] Confirm the runner does not run out of disk during the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases now include Android App Bundle (AAB) artifacts alongside APK files.
  * AAB files are published with versioned filenames for easier identification.
  * Both APK and AAB are uploaded as part of the same release.
* **Bug Fixes**
  * Hardened release/tag handling with stricter semantic version validation and safer output generation.
  * Improved changelog generation and release-step reliability.
  * Added automated runner disk cleanup to prevent build failures due to low disk space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->