### PR TITLE
ci: auto-upload the .aab to Google Play on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,9 @@ jobs:
       # to users; `internal` is the safe default for automated releases.
       - name: Publish to Google Play (internal track)
         if: env.HAS_PLAY_SA == 'true'
-        uses: r0adkll/upload-google-play@v1
+        # Pinned to a full commit SHA (supply-chain hardening for a third-party
+        # action); the trailing comment tracks the human-readable version.
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: io.protolayer.choke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ permissions:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    # Exposes "is the Play service-account secret configured?" to step-level
+    # `if:`, since the secrets context can't be read directly there. Lets the
+    # Play upload skip cleanly (e.g. on forks) instead of failing the release.
+    env:
+      HAS_PLAY_SA: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -331,3 +336,23 @@ jobs:
           generate_release_notes: false
           draft: false
           prerelease: false
+
+      # Publish the signed bundle to Google Play's internal testing track.
+      # Skipped when PLAY_SERVICE_ACCOUNT_JSON is not set, so the GitHub release
+      # still succeeds. Requirements before the first automated upload works:
+      #   1. Create the app in the Play Console and upload one build manually
+      #      (Play won't accept API uploads until the listing exists).
+      #   2. Create a Google Cloud service account, grant it access in the Play
+      #      Console (Users & permissions), and store its JSON key as the
+      #      PLAY_SERVICE_ACCOUNT_JSON repo secret.
+      # Change `track` to `production` (or alpha/beta) once you're ready to ship
+      # to users; `internal` is the safe default for automated releases.
+      - name: Publish to Google Play (internal track)
+        if: env.HAS_PLAY_SA == 'true'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: io.protolayer.choke
+          releaseFiles: choke-${{ steps.version.outputs.full_tag }}.aab
+          track: internal
+          status: completed


### PR DESCRIPTION
## What

Adds a final step to the release workflow that automatically publishes the signed `.aab` to **Google Play's internal testing track** on every `v*` tag.

> **Stacked on #109** (base branch `ci/release-aab`, which builds the `.aab`). Merge #109 first; GitHub will then auto-retarget this PR to `main`.

## How it works

- Uses [`r0adkll/upload-google-play@v1`](https://github.com/r0adkll/upload-google-play).
- Uploads `choke-<tag>.aab` to the `internal` track with `status: completed`.
- `packageName: io.protolayer.choke` (the release `applicationId`).
- **Gated on a secret:** a job-level `HAS_PLAY_SA` env derived from `PLAY_SERVICE_ACCOUNT_JSON`. If the secret isn't set (forks, or before setup), the step **skips** and the GitHub release still succeeds.

## One-time setup required before it works

1. **Create the app in the Play Console** and upload one build manually — Play rejects API uploads until the listing exists.
2. **Create a Google Cloud service account**, grant it access under Play Console → *Users & permissions*, download its JSON key.
3. **Add the key as a repo secret** named `PLAY_SERVICE_ACCOUNT_JSON`.

## Going to production

The `track` is `internal` on purpose (safe for automation). Change it to `production` (or `alpha`/`beta`) once you're comfortable shipping straight to users.

## Test plan

- [ ] Before adding the secret: push a tag and confirm the release succeeds with the Play step **skipped**.
- [ ] After setup: push a tag and confirm the `.aab` lands on the Play Console internal track.
- [ ] Confirm no secrets leak in workflow logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android App Bundles can now be published to Google Play’s internal testing track as part of the release process.

* **Improvements**
  * Releases remain successful when Google Play publishing is not configured, allowing distribution through other supported release channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->