### PR TITLE
docs: add privacy policy for Google Play

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,54 @@
+# Privacy Policy for Choke
+
+**Effective date:** 2026-07-17
+
+Choke ("the app") is an open-source Brazilian Jiu-Jitsu match scoring app
+developed by ProtoLayer OÜ. This policy explains how the app handles data.
+
+## Summary
+
+Choke has **no user accounts** and **no analytics**. We do not collect,
+transmit, or sell your personal data. Everything the app stores stays on your
+device — except the match data you deliberately publish to the Nostr network,
+which is public by design.
+
+## Data stored on your device
+
+- **Nostr keys:** generated on your device and stored in the operating system's
+  secure storage. We never receive or have access to them.
+- **App settings and relay list:** stored locally on your device.
+
+## Data you publish to Nostr
+
+When you score and publish a match, the app broadcasts that match data (for
+example the competitor names you enter, scores, and timestamps) as **public
+events** to the Nostr relays you configure. Nostr is a public, decentralized
+network: anything published is public, may be copied by relays and other
+clients, and cannot be guaranteed to be deleted. Do not enter information you do
+not want to be public.
+
+## Permissions
+
+- **Camera:** used only to scan QR codes (for example, to import a key). No
+  images are stored or transmitted.
+
+## Third parties
+
+The app contains **no advertising SDKs, no analytics, and no trackers**. Nostr
+relays are operated by third parties you choose; how they handle published
+events is outside our control.
+
+## Children
+
+Choke is not directed to children under 13.
+
+## Changes
+
+We may update this policy. Any changes will be posted at this URL.
+
+## Contact
+
+- GitHub: <https://github.com/protolayer-io/choke>
+- Nostr: `npub14e8x7ggcvgy4j0wcsqh6kv4pfmtax7rkryenux9u7ytemjcuce7q9qpjtk`
+
+ProtoLayer OÜ

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -48,7 +48,7 @@ We may update this policy. Any changes will be posted at this URL.
 
 ## Contact
 
+- Email: contact@protolayer.io
 - GitHub: <https://github.com/protolayer-io/choke>
-- Nostr: `npub14e8x7ggcvgy4j0wcsqh6kv4pfmtax7rkryenux9u7ytemjcuce7q9qpjtk`
 
 ProtoLayer OÜ

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -48,7 +48,7 @@ We may update this policy. Any changes will be posted at this URL.
 
 ## Contact
 
-- Email: contact@protolayer.io
+- Email: privacy@protolayer.io
 - GitHub: <https://github.com/protolayer-io/choke>
 
 ProtoLayer OÜ


### PR DESCRIPTION
Adds `PRIVACY.md` to serve as the privacy policy URL required by the Google Play Console listing.

Content: no accounts, no analytics, no trackers; keys and settings stay on-device; match data published to Nostr is public by design; camera used only for QR scanning.

Once merged, the policy URL is:
`https://github.com/protolayer-io/choke/blob/main/PRIVACY.md`