### PR TITLE
feat(account): share a bjjscore.live live-board link

### DIFF
--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -2,9 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../services/key_management/key_manager.dart';
+
+/// Base of the public live board. A shared link carries the organizer's npub in
+/// the query string (`?npub=…`), so opening it drops the spectator straight onto
+/// this user's matches with nothing to paste. Must match the reader in
+/// choke-scoreboard (`buildShareLink` / `readSharedPubkey`).
+const String kLiveBoardBaseUrl = 'https://bjjscore.live';
+
+/// Build the share link for an organizer's npub.
+String liveBoardShareUrl(String npub) => '$kLiveBoardBaseUrl/?npub=$npub';
 
 class AccountScreen extends ConsumerStatefulWidget {
   const AccountScreen({super.key});
@@ -36,6 +46,24 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
         ),
       );
     }
+  }
+
+  /// Open the platform share sheet with a bjjscore.live link for this npub, so
+  /// a spectator only has to tap it — no key to copy or paste on the web.
+  Future<void> _shareLiveBoard(String npub) async {
+    final l10n = AppLocalizations.of(context);
+    final url = liveBoardShareUrl(npub);
+
+    // iPad requires a non-null origin to anchor the share popover; the screen's
+    // render box is a safe fallback on phones.
+    final box = context.findRenderObject() as RenderBox?;
+    final origin = box != null ? box.localToGlobal(Offset.zero) & box.size : null;
+
+    await Share.share(
+      '${l10n.shareLiveBoardMessage}\n$url',
+      subject: l10n.shareLiveBoard,
+      sharePositionOrigin: origin,
+    );
   }
 
   Future<void> _showImportDialog() async {
@@ -391,25 +419,36 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                             ),
                             const SizedBox(height: 12),
                             if (npub != null)
-                              Row(
+                              Column(
                                 children: [
-                                  Expanded(
-                                    child: _buildActionButton(
-                                      context: context,
-                                      icon: Icons.copy,
-                                      label: l10n.copy,
-                                      onTap: () => _copyToClipboard(
-                                          npub, l10n.publicKey),
-                                    ),
+                                  Row(
+                                    children: [
+                                      Expanded(
+                                        child: _buildActionButton(
+                                          context: context,
+                                          icon: Icons.copy,
+                                          label: l10n.copy,
+                                          onTap: () => _copyToClipboard(
+                                              npub, l10n.publicKey),
+                                        ),
+                                      ),
+                                      const SizedBox(width: 9),
+                                      Expanded(
+                                        child: _buildActionButton(
+                                          context: context,
+                                          icon: Icons.qr_code,
+                                          label: l10n.showQr,
+                                          onTap: () =>
+                                              _showQRCode(context, npub),
+                                        ),
+                                      ),
+                                    ],
                                   ),
-                                  const SizedBox(width: 9),
-                                  Expanded(
-                                    child: _buildActionButton(
-                                      context: context,
-                                      icon: Icons.qr_code,
-                                      label: l10n.showQr,
-                                      onTap: () => _showQRCode(context, npub),
-                                    ),
+                                  const SizedBox(height: 9),
+                                  _buildShareButton(
+                                    context: context,
+                                    label: l10n.shareLiveBoard,
+                                    onTap: () => _shareLiveBoard(npub),
                                   ),
                                 ],
                               )
@@ -622,6 +661,47 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
                   color: tk.accent,
+                  fontSize: 13.5,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// The share CTA: filled accent, full width, sitting just under Copy/QR — the
+  /// one action that hands someone else the live board rather than the raw key.
+  Widget _buildShareButton({
+    required BuildContext context,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    final tk = ChokeTokens.of(context);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(11),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 11),
+        decoration: BoxDecoration(
+          color: tk.accent,
+          borderRadius: BorderRadius.circular(11),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.ios_share, color: BJJColors.white, size: 16),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: BJJColors.white,
                   fontSize: 13.5,
                   fontWeight: FontWeight.w600,
                 ),

--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -59,11 +59,26 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
     final box = context.findRenderObject() as RenderBox?;
     final origin = box != null ? box.localToGlobal(Offset.zero) & box.size : null;
 
-    await Share.share(
-      '${l10n.shareLiveBoardMessage}\n$url',
-      subject: l10n.shareLiveBoard,
-      sharePositionOrigin: origin,
-    );
+    try {
+      await Share.share(
+        '${l10n.shareLiveBoardMessage}\n$url',
+        subject: l10n.shareLiveBoard,
+        sharePositionOrigin: origin,
+      );
+    } on PlatformException catch (e) {
+      // The platform share sheet can fail to open (no handler registered, a
+      // transient platform error). Surface it instead of letting the failure
+      // escape this tap callback as an unhandled async error. Only the code is
+      // logged — never the message, which could echo shared content back out.
+      debugPrint('AccountScreen: share sheet failed (${e.code})');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.shareFailed),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    }
   }
 
   Future<void> _showImportDialog() async {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -112,6 +112,10 @@
   "@shareLiveBoardMessage": {
     "description": "Message shown before the shared bjjscore.live link in the share sheet"
   },
+  "shareFailed": "Couldn't open the share sheet",
+  "@shareFailed": {
+    "description": "Error snackbar when the platform share sheet fails to open"
+  },
   "keyUnavailable": "Key unavailable",
   "@keyUnavailable": {
     "description": "Message when key is not available"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -104,6 +104,14 @@
   "@showQr": {
     "description": "Show QR code button label"
   },
+  "shareLiveBoard": "Share live board",
+  "@shareLiveBoard": {
+    "description": "Button and share-sheet subject for sharing the bjjscore.live live board link"
+  },
+  "shareLiveBoardMessage": "Follow my BJJ matches live on bjjscore.live:",
+  "@shareLiveBoardMessage": {
+    "description": "Message shown before the shared bjjscore.live link in the share sheet"
+  },
   "keyUnavailable": "Key unavailable",
   "@keyUnavailable": {
     "description": "Message when key is not available"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -28,6 +28,7 @@
   "showQr": "Mostrar QR",
   "shareLiveBoard": "Compartir marcador",
   "shareLiveBoardMessage": "Sigue mis combates de BJJ en vivo en bjjscore.live:",
+  "shareFailed": "No se pudo abrir el menú de compartir",
   "keyUnavailable": "Clave no disponible",
   "errorLoadingKey": "Error al cargar la clave",
   "privateKeyNsec": "Clave privada (nsec)",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -26,6 +26,8 @@
   "generating": "Generando...",
   "copy": "Copiar",
   "showQr": "Mostrar QR",
+  "shareLiveBoard": "Compartir marcador",
+  "shareLiveBoardMessage": "Sigue mis combates de BJJ en vivo en bjjscore.live:",
   "keyUnavailable": "Clave no disponible",
   "errorLoadingKey": "Error al cargar la clave",
   "privateKeyNsec": "Clave privada (nsec)",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -28,6 +28,7 @@
   "showQr": "QR表示",
   "shareLiveBoard": "スコアボードを共有",
   "shareLiveBoardMessage": "bjjscore.live で私のBJJの試合をライブでフォロー：",
+  "shareFailed": "共有メニューを開けませんでした",
   "keyUnavailable": "鍵が利用できません",
   "errorLoadingKey": "鍵の読み込みエラー",
   "privateKeyNsec": "秘密鍵（nsec）",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -26,6 +26,8 @@
   "generating": "生成中...",
   "copy": "コピー",
   "showQr": "QR表示",
+  "shareLiveBoard": "スコアボードを共有",
+  "shareLiveBoardMessage": "bjjscore.live で私のBJJの試合をライブでフォロー：",
   "keyUnavailable": "鍵が利用できません",
   "errorLoadingKey": "鍵の読み込みエラー",
   "privateKeyNsec": "秘密鍵（nsec）",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -26,6 +26,8 @@
   "generating": "Gerando...",
   "copy": "Copiar",
   "showQr": "Mostrar QR",
+  "shareLiveBoard": "Compartilhar placar",
+  "shareLiveBoardMessage": "Acompanhe minhas lutas de BJJ ao vivo no bjjscore.live:",
   "keyUnavailable": "Chave indisponível",
   "errorLoadingKey": "Erro ao carregar chave",
   "privateKeyNsec": "Chave privada (nsec)",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -28,6 +28,7 @@
   "showQr": "Mostrar QR",
   "shareLiveBoard": "Compartilhar placar",
   "shareLiveBoardMessage": "Acompanhe minhas lutas de BJJ ao vivo no bjjscore.live:",
+  "shareFailed": "Não foi possível abrir o menu de compartilhamento",
   "keyUnavailable": "Chave indisponível",
   "errorLoadingKey": "Erro ao carregar chave",
   "privateKeyNsec": "Chave privada (nsec)",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -270,6 +270,12 @@ abstract class AppLocalizations {
   /// **'Follow my BJJ matches live on bjjscore.live:'**
   String get shareLiveBoardMessage;
 
+  /// Error snackbar when the platform share sheet fails to open
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t open the share sheet'**
+  String get shareFailed;
+
   /// Message when key is not available
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -258,6 +258,18 @@ abstract class AppLocalizations {
   /// **'Show QR'**
   String get showQr;
 
+  /// Button and share-sheet subject for sharing the bjjscore.live live board link
+  ///
+  /// In en, this message translates to:
+  /// **'Share live board'**
+  String get shareLiveBoard;
+
+  /// Message shown before the shared bjjscore.live link in the share sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Follow my BJJ matches live on bjjscore.live:'**
+  String get shareLiveBoardMessage;
+
   /// Message when key is not available
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -89,6 +89,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showQr => 'Show QR';
 
   @override
+  String get shareLiveBoard => 'Share live board';
+
+  @override
+  String get shareLiveBoardMessage =>
+      'Follow my BJJ matches live on bjjscore.live:';
+
+  @override
   String get keyUnavailable => 'Key unavailable';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -96,6 +96,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Follow my BJJ matches live on bjjscore.live:';
 
   @override
+  String get shareFailed => 'Couldn\'t open the share sheet';
+
+  @override
   String get keyUnavailable => 'Key unavailable';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -90,6 +90,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showQr => 'Mostrar QR';
 
   @override
+  String get shareLiveBoard => 'Compartir marcador';
+
+  @override
+  String get shareLiveBoardMessage =>
+      'Sigue mis combates de BJJ en vivo en bjjscore.live:';
+
+  @override
   String get keyUnavailable => 'Clave no disponible';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -97,6 +97,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Sigue mis combates de BJJ en vivo en bjjscore.live:';
 
   @override
+  String get shareFailed => 'No se pudo abrir el menú de compartir';
+
+  @override
   String get keyUnavailable => 'Clave no disponible';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -94,6 +94,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareLiveBoardMessage => 'bjjscore.live で私のBJJの試合をライブでフォロー：';
 
   @override
+  String get shareFailed => '共有メニューを開けませんでした';
+
+  @override
   String get keyUnavailable => '鍵が利用できません';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -88,6 +88,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showQr => 'QR表示';
 
   @override
+  String get shareLiveBoard => 'スコアボードを共有';
+
+  @override
+  String get shareLiveBoardMessage => 'bjjscore.live で私のBJJの試合をライブでフォロー：';
+
+  @override
   String get keyUnavailable => '鍵が利用できません';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -90,6 +90,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showQr => 'Mostrar QR';
 
   @override
+  String get shareLiveBoard => 'Compartilhar placar';
+
+  @override
+  String get shareLiveBoardMessage =>
+      'Acompanhe minhas lutas de BJJ ao vivo no bjjscore.live:';
+
+  @override
   String get keyUnavailable => 'Chave indisponível';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -97,6 +97,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Acompanhe minhas lutas de BJJ ao vivo no bjjscore.live:';
 
   @override
+  String get shareFailed => 'Não foi possível abrir o menu de compartilhamento';
+
+  @override
   String get keyUnavailable => 'Chave indisponível';
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -193,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -804,6 +812,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,9 @@ dependencies:
   # URL launcher
   url_launcher: ^6.2.0
 
+  # Native share sheet (share the bjjscore.live live-board link)
+  share_plus: ^10.1.4
+
   # Still used to ping relays from the Settings screen when the user adds one.
   # Not the app's Nostr transport any more — that is the Rust crate.
   web_socket_channel: ^2.4.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
+  share_plus
   url_launcher_windows
 )
 


### PR DESCRIPTION
## Summary

Adds a **"Share live board"** button on the Account screen (under the npub, next to Copy / Show QR) that opens the **native share sheet** with a link to the public board carrying this organizer's key:

```
https://bjjscore.live/?npub=<npub>
```

Opening that link drops a spectator straight onto the user's matches — **no key to copy or paste** on the web. This is step 2 of the "share my matches" flow; the receiving half already shipped in choke-scoreboard (`readSharedPubkey` / `buildShareLink`), and the URL format here matches it, kept in one place via `kLiveBoardBaseUrl` / `liveBoardShareUrl()`.

## Changes

- **UI:** filled full-width share CTA below Copy/QR in `account_screen.dart`; calls the platform share sheet with a localized message + the link, passing a `sharePositionOrigin` so the iPad popover has an anchor.
- **Dependency:** `share_plus: ^10.1.4` (+ its Windows plugin registration, regenerated by `pub get`).
- **l10n:** `shareLiveBoard` and `shareLiveBoardMessage` added to `en/es/pt/ja` and regenerated.

## Test plan
- [x] `flutter gen-l10n` — getters generated
- [x] `flutter analyze` — no new errors/warnings from these changes (pre-existing infos/warnings live in other files)
- [ ] Manual: on a device, tap **Share live board** → the share sheet opens with the `?npub=` link; opening it on bjjscore.live auto-loads this organizer's matches

_Note: verified via gen-l10n + static analysis; the share sheet itself needs a real device/emulator (none in this environment)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Share live board” action to the account screen.
  * Users can share a live BJJ scoreboard link via the device’s system share sheet.
* **Localization**
  * Added translated share labels and messages (English, Spanish, Japanese, Portuguese), plus a localized error message for share failures.
* **Platform Support**
  * Enabled sharing support on Windows alongside other supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->