### PR TITLE
fix(settings): lighten the black belt backdrop in dark theme

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -242,10 +242,13 @@ class SettingsScreen extends ConsumerWidget {
                             ),
                             decoration: isDark
                                 ? BoxDecoration(
-                                    // Subtle lighter backdrop so the black belt
-                                    // stays visible against the dark theme.
+                                    // Lighter backdrop so the black belt reads
+                                    // against the dark theme. At 0.08 the belt
+                                    // was all but invisible on the ink
+                                    // scaffold; past ~0.32 the tile becomes a
+                                    // grey block that pulls focus.
                                     color:
-                                        colors.onSurface.withValues(alpha: 0.08),
+                                        colors.onSurface.withValues(alpha: 0.24),
                                     borderRadius: BorderRadius.circular(16),
                                   )
                                 : null,


### PR DESCRIPTION
## Summary

Lightens the container behind the black belt in Settings, dark theme only, so the belt actually stands out.

Worth noting: the dark-theme-only backdrop **already existed** — this isn't new behaviour, it was just too subtle. It sat at 8% `onSurface`, which barely separates from the `ink` (`#090E1A`) scaffold, so the black belt read as a dark smudge on a dark background. Raised to **24%**.

Light theme is untouched: it still renders with `decoration: null`, as before.

## Picking the value

Composited the belt over each candidate against the real scaffold colour rather than guessing:

| alpha | resulting tile | verdict |
|---|---|---|
| 0.08 | `#1B202C` | current — belt nearly invisible |
| 0.16 | `#2D323D` | better, still muddy |
| **0.24** | **`#3F444F`** | **chosen — belt fully legible, tile still reads as a backdrop** |
| 0.32 | `#505661` | legible, but the tile starts dominating |
| 0.40 | `#626872` | a grey block that pulls focus in the footer |

## Verification

- [x] `flutter analyze` on the file — 3 warnings, all pre-existing (confirmed by stashing the change and re-running; identical output, and they're at lines 527/532, unrelated to this edit at ~248)
- [x] Confirmed the Scaffold takes the theme default `scaffoldBackgroundColor` (`BJJColors.ink`), so the composite preview used the correct backdrop
- [x] Change is scoped inside the existing `isDark ?` branch, so light theme cannot be affected
- [ ] Not viewed in the running app — the value was chosen from an exact alpha composite of the same colours Flutter blends, but nobody has looked at the real Settings screen

## Note

One judgement call: `onSurface` in dark is `#E8EEF7`, a near-white, so raising the alpha pushes the tile toward neutral grey rather than tinting it. If you'd rather the tile pick up the brand navy instead of going grey, that's a different colour source and an easy follow-up — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuLCbgDYhswiY8ApGWP7EK
