### PR TITLE
feat: add Website link to Settings > About

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -168,6 +168,19 @@ class SettingsScreen extends ConsumerWidget {
             _buildListRow(
               context: context,
               tk: tk,
+              icon: Icons.language,
+              title: l10n.website,
+              subtitle: 'protolayer.io/choke',
+              trailingIcon: Icons.open_in_new,
+              onTap: () => launchUrl(
+                Uri.parse('https://protolayer.io/choke'),
+                mode: LaunchMode.externalApplication,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _buildListRow(
+              context: context,
+              tk: tk,
               icon: Icons.code,
               title: l10n.sourceCode,
               subtitle: 'github.com/protolayer-io/choke',

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -438,6 +438,7 @@
   "@version": {
     "description": "Version tile title"
   },
+  "website": "Website",
   "sourceCode": "Source Code",
   "@sourceCode": {
     "description": "Source code tile title"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -107,6 +107,7 @@
   "fiveMinutes": "5 minutos",
   "sectionAbout": "Acerca de",
   "version": "Versión",
+  "website": "Sitio web",
   "sourceCode": "Código fuente",
   "sectionLanguage": "Idioma",
   "language": "Idioma",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -107,6 +107,7 @@
   "fiveMinutes": "5分",
   "sectionAbout": "アプリについて",
   "version": "バージョン",
+  "website": "ウェブサイト",
   "sourceCode": "ソースコード",
   "sectionLanguage": "言語",
   "language": "言語",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -107,6 +107,7 @@
   "fiveMinutes": "5 minutos",
   "sectionAbout": "Sobre",
   "version": "Versão",
+  "website": "Site",
   "sourceCode": "Código-fonte",
   "sectionLanguage": "Idioma",
   "language": "Idioma",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -744,6 +744,12 @@ abstract class AppLocalizations {
   /// **'Version'**
   String get version;
 
+  /// No description provided for @website.
+  ///
+  /// In en, this message translates to:
+  /// **'Website'**
+  String get website;
+
   /// Source code tile title
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -348,6 +348,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get version => 'Version';
 
   @override
+  String get website => 'Website';
+
+  @override
   String get sourceCode => 'Source Code';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -350,6 +350,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get version => 'Versión';
 
   @override
+  String get website => 'Sitio web';
+
+  @override
   String get sourceCode => 'Código fuente';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -335,6 +335,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get version => 'バージョン';
 
   @override
+  String get website => 'ウェブサイト';
+
+  @override
   String get sourceCode => 'ソースコード';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -350,6 +350,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get version => 'Versão';
 
   @override
+  String get website => 'Site';
+
+  @override
   String get sourceCode => 'Código-fonte';
 
   @override


### PR DESCRIPTION
## What

Adds a **Website** row as the first item in **Settings → About**, opening https://protolayer.io/choke in the browser.

## Details

- New localized string `website` (en: Website, es: Sitio web, pt: Site, ja: ウェブサイト).
- Uses the existing `_buildListRow` pattern with a globe icon (`Icons.language`) and an external-link trailing icon, matching the Source Code row below it.
- Opens via `url_launcher` in external application mode.

## Test plan

- [ ] Open Settings → About; confirm 'Website' appears first, above 'Source Code'.
- [ ] Tap it and confirm it opens https://protolayer.io/choke.
- [ ] Verify the label is translated in es/pt/ja.