### PR TITLE
ci: also build and publish a Linux x64 bundle on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang cmake ninja-build pkg-config \
             libgtk-3-dev liblzma-dev libsecret-1-dev
+          # The Rust crate rides Flutter's native-assets path, which needs a
+          # COMPLETE Clang toolchain (README "Building for Linux desktop"):
+          # a linker sitting beside clang, and the libstdc++ headers matching
+          # the GCC installation Clang selects — the runtime can be present
+          # with the headers missing, and then every C++ compile fails.
+          sudo apt-get install -y lld
+          GCC_VER=$(clang++ -v 2>&1 | grep -oP 'Selected GCC installation:.*/\K[0-9]+' || true)
+          sudo apt-get install -y "libstdc++-${GCC_VER:-14}-dev"
+
+      # Fail here, with a readable error, rather than minutes later inside
+      # flutter build linux. Mirrors the README's own verification commands.
+      - name: Preflight the Clang toolchain
+        run: |
+          CLANG_DIR=$(dirname "$(readlink -f "$(which clang++)")")
+          ls "$CLANG_DIR"/clang "$CLANG_DIR"/llvm-ar "$CLANG_DIR"/ld.lld
+          printf '#include <type_traits>\nint main() { return 0; }\n' > /tmp/probe.cc
+          clang++ -c /tmp/probe.cc -o /tmp/probe.o
+          echo "Toolchain preflight OK"
 
       - name: Build Linux bundle
         env:
@@ -299,9 +317,11 @@ jobs:
         run: |
           flutter config --enable-linux-desktop
           flutter build linux --release
-          # Package the self-contained bundle as a tarball for distribution.
+          # Wrap the bundle in a versioned top-level directory so extraction
+          # yields one folder instead of spraying files into the user's cwd.
+          mv build/linux/x64/release/bundle "choke-${FULL_TAG}-linux-x64"
           tar -czf "choke-${FULL_TAG}-linux-x64.tar.gz" \
-            -C build/linux/x64/release/bundle .
+            "choke-${FULL_TAG}-linux-x64"
 
       - name: Generate release description
         id: description
@@ -338,7 +358,14 @@ jobs:
             echo "---"
             echo ""
             echo "### 📥 Install"
-            echo "Download \`choke-${TAG}.apk\` below and install on your Android device."
+            echo "**Android:** download \`choke-${TAG}.apk\` below and install it on your device."
+            echo ""
+            echo "**Linux (x64):** download \`choke-${TAG}-linux-x64.tar.gz\`, extract, and run:"
+            echo '```bash'
+            echo "tar -xzf choke-${TAG}-linux-x64.tar.gz"
+            echo "./choke-${TAG}-linux-x64/choke"
+            echo '```'
+            echo "Requires \`libgtk-3\` and \`libsecret-1\` at runtime (preinstalled on most desktops)."
             echo ""
             echo "### 📋 Full Changelog"
             echo "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for the complete history."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,26 @@ jobs:
           FULL_TAG: ${{ steps.version.outputs.full_tag }}
         run: cp build/app/outputs/bundle/release/app-release.aab "choke-${FULL_TAG}.aab"
 
+      # Linux desktop build. Choke ships the linux/ runner, so Flutter can
+      # produce a native x64 bundle. Needs the GTK + build toolchain, plus
+      # libsecret for flutter_secure_storage's Linux backend. The Rust crate is
+      # cross-compiled for the host target by Cargokit during the build.
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config \
+            libgtk-3-dev liblzma-dev libsecret-1-dev
+
+      - name: Build Linux bundle
+        env:
+          FULL_TAG: ${{ steps.version.outputs.full_tag }}
+        run: |
+          flutter config --enable-linux-desktop
+          flutter build linux --release
+          # Package the self-contained bundle as a tarball for distribution.
+          tar -czf "choke-${FULL_TAG}-linux-x64.tar.gz" \
+            -C build/linux/x64/release/bundle .
+
       - name: Generate release description
         id: description
         env:
@@ -333,6 +353,7 @@ jobs:
           files: |
             choke-${{ steps.version.outputs.full_tag }}.apk
             choke-${{ steps.version.outputs.full_tag }}.aab
+            choke-${{ steps.version.outputs.full_tag }}-linux-x64.tar.gz
           generate_release_notes: false
           draft: false
           prerelease: false


### PR DESCRIPTION
## What

Extends the release workflow so each `v*` tag also produces a **Linux x64 desktop build**, attached to the GitHub release next to the APK and AAB.

## How

- **Install Linux build dependencies:** `clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev`, plus `libsecret-1-dev` (the Linux backend for `flutter_secure_storage`, which Choke uses for keys).
- **Build:** `flutter config --enable-linux-desktop` + `flutter build linux --release`. The Rust crate is cross-compiled for the host target by Cargokit during the build.
- **Package:** the self-contained bundle in `build/linux/x64/release/bundle/` is tarred to `choke-<tag>-linux-x64.tar.gz`.
- **Publish:** the tarball is added to the release `files:` list.

Runs in the same `build-and-release` job, reusing the already-set-up Flutter + Rust environment.

## Notes

- Output is a portable tarball: users extract it and run the `choke` executable inside. (A future PR could add AppImage/Flatpak/.deb packaging if desired.)
- At runtime, a Linux user needs `libgtk-3` and `libsecret-1` installed (standard on most desktops).

## Test plan

- [ ] Push a `v*` tag and confirm the workflow builds `choke-<tag>-linux-x64.tar.gz` and attaches it to the release.
- [ ] Extract the tarball on a Linux desktop and confirm the app launches and can store/read a key (libsecret path).
- [ ] Confirm the runner does not run out of disk with the added Linux build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a downloadable Linux x64 release package alongside the existing Android APK and AAB.
  * Linux releases are provided as versioned tarballs attached to GitHub Releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->