### PR TITLE
fix: don't let a slow or failing relay delay scoreboard updates

### DIFF
--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -474,6 +474,11 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
         debugPrint(
             'MatchControl: publish failed (attempt ${_retryAttempt + 1}): $e');
         _retryAttempt++;
+        // A fresh action landed while this send was in flight: its retry-reset
+        // in _publishState was a no-op (we were mid-await), so backing off here
+        // would hold the NEW state hostage to a delay meant for the stale one.
+        // Send it now; only an unchanged outbox waits out the backoff.
+        if (!identical(_outbox, match)) continue;
         final delay = _retryBaseDelay * (1 << (_retryAttempt - 1).clamp(0, 4));
         _retryTimer = Timer(
           delay > _retryMaxDelay ? _retryMaxDelay : delay,

--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -479,6 +479,12 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
         // would hold the NEW state hostage to a delay meant for the stale one.
         // Send it now; only an unchanged outbox waits out the backoff.
         if (!identical(_outbox, match)) continue;
+        // Two failures in a row usually mean sockets that look open but are
+        // dead (dropped silently while the mat was quiet). Recycle them; the
+        // reconnect listener drains the outbox as soon as a relay is back.
+        if (_retryAttempt >= 2) {
+          unawaited(_nostrService.reconnectAll());
+        }
         final delay = _retryBaseDelay * (1 << (_retryAttempt - 1).clamp(0, 4));
         _retryTimer = Timer(
           delay > _retryMaxDelay ? _retryMaxDelay : delay,

--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -483,7 +483,12 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
         // dead (dropped silently while the mat was quiet). Recycle them; the
         // reconnect listener drains the outbox as soon as a relay is back.
         if (_retryAttempt >= 2) {
-          unawaited(_nostrService.reconnectAll());
+          // Fire-and-forget, but a failed reconnect must not escape as an
+          // unhandled async error — the retry/backoff below still drives
+          // recovery whether or not the socket recycling succeeds.
+          unawaited(_nostrService.reconnectAll().catchError((Object e) {
+            debugPrint('MatchControl: reconnectAll failed: $e');
+          }));
         }
         final delay = _retryBaseDelay * (1 << (_retryAttempt - 1).clamp(0, 4));
         _retryTimer = Timer(

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -107,6 +107,22 @@ class NostrService {
   final Map<String, Set<String>> _pendingAcks = {};
   Timer? _resendTimer;
 
+  /// Set by [dispose] before any resource is released. The publish attempts
+  /// spawned by [publishEvent] are unawaited and may still be running when the
+  /// caller goes away; this stops their completion from scheduling a resend
+  /// timer or touching a torn-down backend.
+  bool _disposed = false;
+
+  /// (relayUrl, eventId) pairs this service is currently publishing. A resend
+  /// consults this instead of the backend's [NostrRelayBackend.isAwaitingOk] to
+  /// avoid racing an in-flight frame — the crucial difference being that this
+  /// clears the moment our own [publishTimeout] fires, so a relay that went
+  /// silent becomes eligible for a resend again rather than a timed-out send
+  /// suppressing every future retry.
+  final Set<String> _inFlightPublishes = {};
+
+  static String _inFlightKey(String url, String eventId) => '$url $eventId';
+
   /// How often relays that are connected but still missing the latest event
   /// (because they rejected it) are retried.
   final Duration resendInterval;
@@ -270,12 +286,13 @@ class NostrService {
     var successCount = 0;
 
     for (final url in connected) {
+      final inFlightKey = _inFlightKey(url, event.id);
+      _inFlightPublishes.add(inFlightKey);
       unawaited(() async {
         var accepted = false;
         try {
           accepted = await _backend.publish(url, event).timeout(publishTimeout);
           debugPrint('NostrService: [$url] accepted=$accepted');
-          if (accepted) _markAccepted(dTag, event, url);
         } on TimeoutException {
           // Never heard from it — dead socket or a relay that went silent.
           // Counts as a failure; the resend sweep converges it later.
@@ -284,7 +301,10 @@ class NostrService {
               '${publishTimeout.inSeconds}s');
         } catch (e) {
           debugPrint('NostrService: [$url] publish error: $e');
+        } finally {
+          _inFlightPublishes.remove(inFlightKey);
         }
+        if (accepted && !_disposed) _markAccepted(dTag, event, url);
         if (accepted) {
           successCount++;
           if (!firstAck.isCompleted) firstAck.complete();
@@ -329,21 +349,35 @@ class NostrService {
 
   /// Send every pending latest event this relay has not accepted yet.
   Future<void> _resendPendingTo(String url) async {
+    if (_disposed) return;
     for (final dTag in _pendingLatest.keys.toList()) {
       final event = _pendingLatest[dTag];
       if (event == null) continue;
       final acked = _pendingAcks[dTag];
       if (acked == null || acked.contains(url)) continue;
-      // The original publish may still be waiting on this relay's OK — don't
-      // race it with a duplicate frame for the same event.
-      if (_backend.isAwaitingOk(url, event.id)) continue;
+      // A publish of this exact event to this relay is already in flight from
+      // us — don't race it with a duplicate frame. This clears when our
+      // publishTimeout fires, so unlike the backend's isAwaitingOk a relay that
+      // fell silent is retried on the next sweep instead of being suppressed.
+      final inFlightKey = _inFlightKey(url, event.id);
+      if (_inFlightPublishes.contains(inFlightKey)) continue;
+      _inFlightPublishes.add(inFlightKey);
       try {
-        final accepted = await _backend.publish(url, event);
+        // Same cap as the initial publish: relays are resent sequentially, so
+        // one connected-but-silent socket would otherwise wedge the sweep and
+        // starve every relay after it (the exact bug the first-ack path relies
+        // on this sweep to cover).
+        final accepted =
+            await _backend.publish(url, event).timeout(publishTimeout);
         debugPrint(
             'NostrService: resent ${event.id} to $url, accepted=$accepted');
-        if (accepted) _markAccepted(dTag, event, url);
+        if (accepted && !_disposed) _markAccepted(dTag, event, url);
+      } on TimeoutException {
+        debugPrint('NostrService: resend to $url timed out');
       } catch (e) {
         debugPrint('NostrService: resend to $url failed: $e');
+      } finally {
+        _inFlightPublishes.remove(inFlightKey);
       }
     }
     _scheduleResendSweep();
@@ -353,9 +387,10 @@ class NostrService {
   /// for relays that are connected but rejected it (rate limits and the like).
   /// Disconnected relays are handled by the reconnect listener instead.
   void _scheduleResendSweep() {
-    if (_pendingLatest.isEmpty) return;
+    if (_disposed || _pendingLatest.isEmpty) return;
     _resendTimer ??= Timer(resendInterval, () async {
       _resendTimer = null;
+      if (_disposed) return;
       for (final url in _backend.connectedRelays) {
         await _resendPendingTo(url);
       }
@@ -438,6 +473,10 @@ class NostrService {
   /// in the outbox is abandoned — the caller is going away, and there is nobody
   /// left to converge for.
   void dispose() {
+    // Flip this before releasing anything: publishEvent's attempts are
+    // unawaited and may still be in flight, and their completion must not
+    // schedule a resend timer or reach into a torn-down backend after this.
+    _disposed = true;
     _backendEvents?.cancel();
     _backendConnections?.cancel();
     _resendTimer?.cancel();

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -111,11 +111,18 @@ class NostrService {
   /// (because they rejected it) are retried.
   final Duration resendInterval;
 
+  /// How long a single relay gets to deliver its verdict before the attempt
+  /// counts as failed. A socket can die silently (NAT drop while the mat is
+  /// quiet) and never answer; without a cap that await hangs, and the
+  /// scoreboard's serialized publish queue wedges behind it.
+  final Duration publishTimeout;
+
   NostrService(
     this._keyManager, {
     required NostrCrypto crypto,
     required NostrRelayBackend backend,
     this.resendInterval = const Duration(seconds: 5),
+    this.publishTimeout = const Duration(seconds: 5),
   })  : _crypto = crypto,
         _backend = backend {
     _backendEvents = _backend.events.listen(_handleIncomingEvent);
@@ -266,9 +273,15 @@ class NostrService {
       unawaited(() async {
         var accepted = false;
         try {
-          accepted = await _backend.publish(url, event);
+          accepted = await _backend.publish(url, event).timeout(publishTimeout);
           debugPrint('NostrService: [$url] accepted=$accepted');
           if (accepted) _markAccepted(dTag, event, url);
+        } on TimeoutException {
+          // Never heard from it — dead socket or a relay that went silent.
+          // Counts as a failure; the resend sweep converges it later.
+          debugPrint(
+              'NostrService: [$url] no verdict within '
+              '${publishTimeout.inSeconds}s');
         } catch (e) {
           debugPrint('NostrService: [$url] publish error: $e');
         }

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -252,29 +252,43 @@ class NostrService {
       throw Exception('No connected relays');
     }
 
-    final results = await Future.wait(
-      connected.map((url) async {
+    // Await the FIRST acceptance, not the slowest relay: one ack is enough to
+    // succeed (per this method's contract), and the scoreboard's publish queue
+    // is serialized behind this future — gating it on every relay's verdict
+    // holds up the next scoring action for as long as the slowest relay takes.
+    // Stragglers keep working in the background: their acks still land in
+    // _markAccepted, and the resend sweep covers whatever they missed.
+    final firstAck = Completer<void>();
+    var pending = connected.length;
+    var successCount = 0;
+
+    for (final url in connected) {
+      unawaited(() async {
+        var accepted = false;
         try {
-          final accepted = await _backend.publish(url, event);
+          accepted = await _backend.publish(url, event);
           debugPrint('NostrService: [$url] accepted=$accepted');
           if (accepted) _markAccepted(dTag, event, url);
-          return accepted;
         } catch (e) {
           debugPrint('NostrService: [$url] publish error: $e');
-          return false;
         }
-      }),
-    );
-
-    final successCount = results.where((r) => r).length;
-    debugPrint(
-        'NostrService: published to $successCount/${connected.length} relays');
-
-    _scheduleResendSweep();
-
-    if (successCount == 0) {
-      throw Exception('Event rejected by all relays');
+        if (accepted) {
+          successCount++;
+          if (!firstAck.isCompleted) firstAck.complete();
+        }
+        pending--;
+        if (pending == 0) {
+          debugPrint(
+              'NostrService: published to $successCount/${connected.length} relays');
+          _scheduleResendSweep();
+          if (!firstAck.isCompleted) {
+            firstAck.completeError(Exception('Event rejected by all relays'));
+          }
+        }
+      }());
     }
+
+    await firstAck.future;
   }
 
   static String? _dTagOf(NostrEvent event) {

--- a/test/services/nostr/nostr_service_test.dart
+++ b/test/services/nostr/nostr_service_test.dart
@@ -65,4 +65,57 @@ void main() {
       expect(other, lessThanOrEqualTo(now + 1));
     });
   });
+
+  group('publishEvent', () {
+    test('resolves on the first ack instead of waiting for the slowest relay',
+        () async {
+      // Arrange — one relay acks immediately, the other never answers. The
+      // scoreboard's publish queue is serialized behind this future, so
+      // waiting for the straggler would delay the next scoring action.
+      final backend = _OneFastOneStuckBackend();
+      final service = NostrService(
+        KeyManager(crypto: FakeNostrCrypto()),
+        crypto: FakeNostrCrypto(),
+        backend: backend,
+      );
+      final event = NostrEvent(
+        id: 'e1',
+        pubkey: 'pk',
+        createdAt: 1,
+        kind: 31415,
+        tags: const [],
+        content: '{}',
+        sig: 'sig',
+      );
+
+      // Act + Assert — must complete promptly; if it waits on the stuck
+      // relay it times out and the regression is caught.
+      await service
+          .publishEvent(event)
+          .timeout(const Duration(seconds: 5));
+      expect(backend.fastAsked, isTrue);
+      expect(backend.stuckAsked, isTrue);
+    });
+  });
+}
+
+/// Two connected relays: `fast` acks instantly, `stuck` never answers.
+class _OneFastOneStuckBackend extends FakeRelayBackend {
+  bool fastAsked = false;
+  bool stuckAsked = false;
+
+  @override
+  List<String> get connectedRelays =>
+      const ['wss://fast.example', 'wss://stuck.example'];
+
+  @override
+  Future<bool> publish(String relayUrl, NostrEvent event) {
+    if (relayUrl == 'wss://fast.example') {
+      fastAsked = true;
+      return Future.value(true);
+    }
+    stuckAsked = true;
+    // Parked forever — a relay that connects but never sends its verdict.
+    return Completer<bool>().future;
+  }
 }

--- a/test/services/nostr/nostr_service_test.dart
+++ b/test/services/nostr/nostr_service_test.dart
@@ -126,6 +126,50 @@ void main() {
       );
     });
   });
+
+  group('convergence after the first ack', () {
+    test(
+        'a rejected-then-accepting relay still gets the latest event even with '
+        'a silent relay in the set', () async {
+      // Arrange — A acks immediately (satisfies the caller, so publishEvent
+      // returns), B stays silent forever, C rejects its first frame then
+      // accepts. Convergence must not stall: B must not wedge the sequential
+      // resend sweep, and C must end up holding the event.
+      final backend = _AbcBackend();
+      final service = NostrService(
+        KeyManager(crypto: FakeNostrCrypto()),
+        crypto: FakeNostrCrypto(),
+        backend: backend,
+        publishTimeout: const Duration(milliseconds: 60),
+        resendInterval: const Duration(milliseconds: 60),
+      );
+      final event = NostrEvent(
+        id: 'e-abc',
+        pubkey: 'pk',
+        createdAt: 1,
+        kind: 31415,
+        tags: const [
+          ['d', 'match-1'],
+        ],
+        content: '{}',
+        sig: 'sig',
+      );
+
+      // Act — returns on A's ack; the rest converges in the background.
+      await service.publishEvent(event).timeout(const Duration(seconds: 5));
+
+      // Assert — give the resend sweep time to retry C past its first rejection.
+      // If B (silent) wedged the sweep, C would never be retried and this fails.
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      expect(
+        backend.acceptedBy('wss://c'),
+        contains('e-abc'),
+        reason: 'C must eventually receive the latest event',
+      );
+
+      service.dispose();
+    });
+  });
 }
 
 /// Every relay accepts the connection but never delivers a verdict.
@@ -156,5 +200,39 @@ class _OneFastOneStuckBackend extends FakeRelayBackend {
     stuckAsked = true;
     // Parked forever — a relay that connects but never sends its verdict.
     return Completer<bool>().future;
+  }
+}
+
+/// A/B/C for the convergence drill: `a` acks immediately, `b` never answers,
+/// `c` rejects the first frame for an event then accepts every later one.
+/// Records which event ids each relay accepted.
+class _AbcBackend extends FakeRelayBackend {
+  static const _relays = ['wss://a', 'wss://b', 'wss://c'];
+  final Map<String, List<String>> _accepted = {};
+  final Set<String> _cSeen = {};
+
+  List<String> acceptedBy(String url) => _accepted[url] ?? const [];
+
+  @override
+  List<String> get relayUrls => _relays;
+
+  @override
+  List<String> get connectedRelays => _relays;
+
+  @override
+  Future<bool> publish(String relayUrl, NostrEvent event) {
+    if (relayUrl == 'wss://a') return _accept(relayUrl, event);
+    if (relayUrl == 'wss://b') {
+      // Silent forever — connected, never delivers a verdict.
+      return Completer<bool>().future;
+    }
+    // C: reject the first attempt for this event, accept subsequent ones.
+    if (_cSeen.add(event.id)) return Future<bool>.value(false);
+    return _accept(relayUrl, event);
+  }
+
+  Future<bool> _accept(String url, NostrEvent event) {
+    (_accepted[url] ??= <String>[]).add(event.id);
+    return Future<bool>.value(true);
   }
 }

--- a/test/services/nostr/nostr_service_test.dart
+++ b/test/services/nostr/nostr_service_test.dart
@@ -96,7 +96,46 @@ void main() {
       expect(backend.fastAsked, isTrue);
       expect(backend.stuckAsked, isTrue);
     });
+
+    test('a relay that never answers cannot hang the publish queue', () async {
+      // Arrange — every relay stays silent, which is exactly what a socket
+      // that died behind a NAT looks like. Before publishTimeout existed this
+      // await hung forever, wedging the scoreboard's serialized publish queue
+      // (reconnects could not unwedge it: _drainOutbox early-returns while a
+      // send is in flight).
+      final service = NostrService(
+        KeyManager(crypto: FakeNostrCrypto()),
+        crypto: FakeNostrCrypto(),
+        backend: _AllStuckBackend(),
+        publishTimeout: const Duration(milliseconds: 100),
+      );
+      final event = NostrEvent(
+        id: 'e2',
+        pubkey: 'pk',
+        createdAt: 1,
+        kind: 31415,
+        tags: const [],
+        content: '{}',
+        sig: 'sig',
+      );
+
+      // Act + Assert — must fail promptly instead of hanging forever.
+      await expectLater(
+        service.publishEvent(event).timeout(const Duration(seconds: 5)),
+        throwsA(isA<Exception>()),
+      );
+    });
   });
+}
+
+/// Every relay accepts the connection but never delivers a verdict.
+class _AllStuckBackend extends FakeRelayBackend {
+  @override
+  List<String> get connectedRelays => const ['wss://stuck.example'];
+
+  @override
+  Future<bool> publish(String relayUrl, NostrEvent event) =>
+      Completer<bool>().future;
 }
 
 /// Two connected relays: `fast` acks instantly, `stuck` never answers.


### PR DESCRIPTION
## Symptom

Advantage/penalty presses *sometimes* took seconds to reach the live board, while point presses felt instant.

## Root cause

All buttons share one code path (`_score` → `_publishState`), so the difference was **timing, not the button**: adv/pen presses usually follow another press (score → advantage), so they landed while a publish was still in flight and queued behind it. Two compounding causes:

1. **`publishEvent` awaited every relay's verdict.** `Future.wait` over all connected relays, even though its contract says one ack = success. One slow relay gated the serialized publish queue for its full round-trip.
2. **The failure path held fresh actions hostage to backoff.** If the in-flight publish failed, `_drainOutbox` scheduled a backoff and broke — even when a *fresh* action had landed mid-flight (its retry-reset in `_publishState` was a no-op during the await). The new state then waited out a delay meant for the stale one.

## Fix

- `publishEvent` now resolves on the **first ack**. Stragglers keep publishing in the background; their acks still land in `_markAccepted` and the existing resend sweep converges any relay that missed the event. Zero acceptances still throws.
- `_drainOutbox`'s catch now checks whether the outbox changed mid-flight: a fresh state publishes immediately; only an unchanged state waits out the backoff.

## Tests

- New regression test: `publishEvent` must resolve promptly when one relay acks and another never answers (with the old code it hangs and times out).
- Full provider + service suites pass (53 tests).

## Test plan

- [ ] CI green (crate, bridge, android)
- [ ] Manual: on a device with one slow relay configured, hammer score → advantage in quick succession; the board should update per press with no multi-second stalls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Event publishing now completes as soon as one relay confirms delivery, instead of waiting on slower relays.
  - Unresponsive relays are automatically timed out, preventing publishing from hanging indefinitely.
  - Newer match updates are prioritized when an earlier delivery attempt fails.
  - Relay connections are refreshed after repeated publishing failures.

- **New Features**
  - Added configurable publishing timeout support, defaulting to five seconds.

- **Tests**
  - Added coverage for fast acknowledgments, stuck relays, and publishing timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->