### PR TITLE
fix(create-match): show all durations at once, no horizontal scroll

### DIFF
--- a/lib/features/match/create_match_screen.dart
+++ b/lib/features/match/create_match_screen.dart
@@ -396,48 +396,45 @@ class _CreateMatchScreenState extends ConsumerState<CreateMatchScreen> {
   }
 
   Widget _buildDurationSelector(BuildContext context, ChokeTokens tk) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: defaultDurationOptions.map((seconds) {
-          final isSelected = seconds == _duration;
-          return Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: GestureDetector(
-              onTap: () => setState(() => _duration = seconds),
-              child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 15, vertical: 11),
-                decoration: BoxDecoration(
-                  gradient: isSelected ? tk.gradient : null,
-                  borderRadius: BorderRadius.circular(12),
-                  border: isSelected
-                      ? null
-                      : Border.all(color: tk.cardBorder, width: 1),
-                  boxShadow: isSelected
-                      ? [
-                          BoxShadow(
-                            color: tk.gradTop.withOpacity(.3),
-                            blurRadius: 16,
-                            offset: const Offset(0, 6),
-                          ),
-                        ]
-                      : null,
-                ),
-                child: Text(
-                  _formatDuration(seconds),
-                  style: TextStyle(
-                    color: isSelected ? tk.onGrad : tk.muted,
-                    fontWeight: isSelected ? FontWeight.w700 : FontWeight.w600,
-                    fontSize: 15,
-                    fontFamily: 'monospace',
-                  ),
-                ),
+    // Wrap (not a horizontal scroller) so every duration up to 10:00 is on
+    // screen at once — the user never has to scroll to reach the last option.
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: defaultDurationOptions.map((seconds) {
+        final isSelected = seconds == _duration;
+        return GestureDetector(
+          onTap: () => setState(() => _duration = seconds),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 11),
+            decoration: BoxDecoration(
+              gradient: isSelected ? tk.gradient : null,
+              borderRadius: BorderRadius.circular(12),
+              border: isSelected
+                  ? null
+                  : Border.all(color: tk.cardBorder, width: 1),
+              boxShadow: isSelected
+                  ? [
+                      BoxShadow(
+                        color: tk.gradTop.withOpacity(.3),
+                        blurRadius: 16,
+                        offset: const Offset(0, 6),
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Text(
+              _formatDuration(seconds),
+              style: TextStyle(
+                color: isSelected ? tk.onGrad : tk.muted,
+                fontWeight: isSelected ? FontWeight.w700 : FontWeight.w600,
+                fontSize: 15,
+                fontFamily: 'monospace',
               ),
             ),
-          );
-        }).toList(),
-      ),
+          ),
+        );
+      }).toList(),
     );
   }
 


### PR DESCRIPTION
## Summary

On the **create match** screen, the match-duration picker was a single horizontally-scrolling row (`SingleChildScrollView(scrollDirection: Axis.horizontal)`). On a phone the later options — up to **10:00** — sat off-screen, so the user had to scroll sideways to pick them.

Switched it to a **`Wrap`** so all eight durations (3:00 → 10:00) lay out across a few rows and every option is visible at once, no scrolling. The chip design (gradient on the selected one, border otherwise) and the tap-to-select behavior are unchanged; `Wrap`'s `spacing`/`runSpacing` replace the old per-chip right padding.

## Test plan
- [x] `flutter analyze` on the file — no new issues (only pre-existing `withOpacity` / color-accessor deprecation infos)
- [ ] Manual: open Create match on a phone-sized screen → all durations including 10:00 are visible without horizontal scroll; selecting one still highlights it

_Note: verified by static analysis; the visual layout needs a quick check on a device/emulator (none in this environment)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)