### PR TITLE
fix(relays): unreachable relay no longer hangs addRelay forever

### DIFF
--- a/lib/features/home/providers/home_providers.dart
+++ b/lib/features/home/providers/home_providers.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../match/models/match.dart';
-import '../../match/providers/match_providers.dart';
 import '../../../services/nostr/nostr_service.dart';
 
 /// Status filter: which statuses to show on the home screen.
@@ -14,13 +13,6 @@ final statusFilterProvider = StateProvider<Set<MatchStatus>>((ref) {
     MatchStatus.inProgress,
   };
 });
-
-/// A match paired with its Nostr event created_at timestamp
-class _MatchEntry {
-  final Match match;
-  final int createdAt;
-  _MatchEntry(this.match, this.createdAt);
-}
 
 /// Collects matches from Nostr events + locally created matches.
 /// Deduplicates by match ID (latest created_at wins).

--- a/lib/features/settings/providers/relay_config_provider.dart
+++ b/lib/features/settings/providers/relay_config_provider.dart
@@ -370,13 +370,25 @@ class RelayConfigNotifier extends StateNotifier<RelayConfigState> {
       return true;
     } on TimeoutException {
       debugPrint('RelayConfigNotifier: Connection timeout to $url');
-      await channel?.sink.close();
+      _closeQuietly(channel);
       return false;
     } catch (e) {
       debugPrint('RelayConfigNotifier: Connection failed to $url: $e');
-      await channel?.sink.close();
+      _closeQuietly(channel);
       return false;
     }
+  }
+
+  /// Best-effort close that never blocks.
+  ///
+  /// When the handshake never completed (connection refused, silent host),
+  /// the sink's close future never resolves — awaiting it here is what used
+  /// to hang addRelay forever behind the "Adding…" spinner. The failure paths
+  /// fire it and move on; there is nothing to wait for on a socket that
+  /// never existed.
+  void _closeQuietly(WebSocketChannel? channel) {
+    if (channel == null) return;
+    unawaited(channel.sink.close().catchError((_) {}));
   }
 }
 

--- a/test/features/settings/providers/relay_config_provider_test.dart
+++ b/test/features/settings/providers/relay_config_provider_test.dart
@@ -571,19 +571,17 @@ void main() {
       expect(reachable, isFalse);
     });
 
-    test('reports a refused connection as unreachable', () async {
+    test('reports a refused connection as unreachable, promptly', () async {
       // Arrange — port 1 on loopback: privileged, nothing listens there
       final notifier = RelayConfigNotifier(
           RelayConfigService(secureStorage: InMemorySecureStorage()));
       await pumpEventQueue();
 
-      // Act — BUG (documented in the suite report): after a failed connect,
-      // `channel.sink.close()` never completes, so testRelayConnectivity
-      // itself never returns. The outer timeout stands in for the return
-      // value the method should have produced.
-      final reachable = await notifier
-          .testRelayConnectivity('ws://127.0.0.1:1')
-          .timeout(const Duration(seconds: 8), onTimeout: () => false);
+      // Act — regression guard: this used to hang forever, because the
+      // failure path awaited `channel.sink.close()` on a socket whose
+      // handshake never completed. The method must now RETURN false itself;
+      // if the hang comes back, the test-level timeout fails this test.
+      final reachable = await notifier.testRelayConnectivity('ws://127.0.0.1:1');
 
       // Assert
       expect(reachable, isFalse);
@@ -607,11 +605,11 @@ void main() {
           RelayConfigService(secureStorage: InMemorySecureStorage()));
       await pumpEventQueue();
 
-      // Act — same close() hang as above once the timeout fires, so the
-      // outer timeout unblocks the test after the branch under test ran
+      // Act — regression guard for the same hang: after the 5s ready timeout
+      // fires, the method must return false on its own instead of wedging on
+      // a close() that can never complete.
       final reachable = await notifier
-          .testRelayConnectivity('ws://127.0.0.1:${server.port}')
-          .timeout(const Duration(seconds: 8), onTimeout: () => false);
+          .testRelayConnectivity('ws://127.0.0.1:${server.port}');
 
       // Assert
       expect(reachable, isFalse);


### PR DESCRIPTION
## Summary

Follow-up to #121, fixing the HIGH bug its review surfaced, plus the dead-code deletion it identified.

**The bug.** `testRelayConnectivity`'s failure paths did `await channel?.sink.close()`. When the handshake never completed (connection refused, silent host), that close future **never resolves** — so the method never returned, `addRelay` never finished, and the "Adding…" spinner spun forever for any unreachable relay.

**The fix.** On the failure paths, close best-effort **without awaiting** (`unawaited(... .catchError(...))`) — there is nothing to wait for on a socket that never existed. The success path (handshake completed) still awaits its close.

**Tests.** The two suites that documented the hang via an `onTimeout` crutch now assert the method returns `false` **on its own** — real regression guards: if the hang comes back, the test-level timeout fails them. (Refused connection returns promptly; the stalled-handshake case returns right after the intended 5s ready-timeout.)

**Dead code.** Deleted the never-instantiated `_MatchEntry` class in `home_providers.dart` (+ its now-unused import) — flagged by the coverage pass and the analyzer; also clears 2 pre-existing analyzer warnings.

## Test plan
- [x] Affected suites green (52 tests), including the two rewritten regression guards
- [x] Full suite: 490/490 green
- [x] `flutter analyze` on changed files: no issues

_Stacked on `test/coverage-100` (#121); GitHub will retarget to `main` when it merges._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved relay connectivity checks so failed or timed-out connections return promptly instead of hanging while closing.
  - Preserved existing error handling and failure reporting for unavailable or unresponsive relay connections.

- **Tests**
  - Updated connectivity checks to verify reliable failure responses without depending on external timeout workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->