### PR TITLE
docs: document testing and code coverage execution and current stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,48 @@ flutter build ios --release
 flutter build linux --release
 ```
 
+## Testing & Code Coverage
+
+Choke has a comprehensive test suite covering both the Dart/Flutter application logic and the Rust native crate.
+
+### Dart & Flutter Coverage
+
+The Dart codebase currently has **98.7%** line coverage (excluding generated code).
+
+To run the Dart tests and generate a filtered coverage report (excluding machine-generated files like `lib/src/rust/` and `lib/l10n/generated/`):
+
+```bash
+# Run the helper script which builds the native crate, runs tests, and filters coverage
+bash tool/coverage.sh
+```
+
+This will run all tests, generate `coverage/lcov.filtered.info`, and print a per-file summary along with the overall percentages:
+- **TOTAL (generated code excluded)**: ~98.7%
+- **TOTAL (raw, including generated)**: ~81.8%
+
+---
+
+### Rust Coverage
+
+The Rust unit tests cover the underlying Nostr cryptography library. 
+
+To run Rust unit tests and measure coverage, you will need the [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) tool:
+
+```bash
+# Install cargo-llvm-cov if you haven't already
+cargo install cargo-llvm-cov --locked
+
+# Run Rust tests and generate a coverage report (ignoring generated bindings)
+cargo llvm-cov --manifest-path rust/Cargo.toml --all-targets --ignore-filename-regex "frb_generated"
+```
+
+Current Rust coverage stats:
+- **Overall Crate Coverage (excluding generated bindings)**: ~28.6%
+- **Nostr Cryptography (`crypto.rs`)**: ~94.8%
+- **Nostr Relay Client (`relay.rs`)**: 0.0% (Note: the relay client functions are heavily exercised by the Dart integration tests via the FFI bridge, but are not covered by Rust unit tests directly).
+
 ## Architecture
+
 
 ```
 lib/

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To run the Dart tests and generate a filtered coverage report (excluding machine
 bash tool/coverage.sh
 ```
 
-This will run all tests, generate `coverage/lcov.filtered.info`, and print a per-file summary along with the overall percentages:
+This will run all Dart/Flutter tests, generate `coverage/lcov.filtered.info`, and print a per-file summary along with the overall percentages:
 - **TOTAL (generated code excluded)**: ~98.7%
 - **TOTAL (raw, including generated)**: ~81.8%
 

--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -57,7 +57,8 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
     // iPad requires a non-null origin to anchor the share popover; the screen's
     // render box is a safe fallback on phones.
     final box = context.findRenderObject() as RenderBox?;
-    final origin = box != null ? box.localToGlobal(Offset.zero) & box.size : null;
+    final origin =
+        box != null ? box.localToGlobal(Offset.zero) & box.size : null;
 
     try {
       await Share.share(

--- a/lib/features/match/match_control_screen.dart
+++ b/lib/features/match/match_control_screen.dart
@@ -113,8 +113,7 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
     // score, or a fighter on four penalties. Ask, rather than invent a winner.
     ref.listen(matchControlProvider, (previous, next) {
       if (next.awaitsOutcome && !(previous?.awaitsOutcome ?? false)) {
-        WidgetsBinding.instance
-            .addPostFrameCallback((_) => _askOutcome(next));
+        WidgetsBinding.instance.addPostFrameCallback((_) => _askOutcome(next));
       }
     });
     final match = state.match;
@@ -706,8 +705,8 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
     final accent = finished ? tk.statusFinishedFg : tk.dangerFg;
 
     final outcome = describeOutcome(l10n, state.match);
-    final label = outcome ??
-        (finished ? l10n.matchFinished : l10n.matchCanceled);
+    final label =
+        outcome ?? (finished ? l10n.matchFinished : l10n.matchCanceled);
 
     return SizedBox(
       height: 44,
@@ -716,8 +715,7 @@ class _MatchControlScreenState extends ConsumerState<MatchControlScreen> {
         children: [
           Flexible(
             child: Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               decoration: BoxDecoration(
                 color: accent.withValues(alpha: .12),
                 borderRadius: BorderRadius.circular(99),

--- a/lib/features/match/providers/submissions_provider.dart
+++ b/lib/features/match/providers/submissions_provider.dart
@@ -148,7 +148,9 @@ class SubmissionsNotifier extends StateNotifier<SubmissionsState> {
   /// interleaving across concurrent edits.
   void _persist() {
     final snapshot = state;
-    _saves = _saves.then((_) => _write(snapshot)).catchError((Object e, StackTrace st) {
+    _saves = _saves
+        .then((_) => _write(snapshot))
+        .catchError((Object e, StackTrace st) {
       // A failed write must not poison the chain: the next edit still deserves
       // its chance to be saved. Losing a submission from a list is a nuisance;
       // silently refusing to save anything ever again is a broken app.

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -263,8 +263,8 @@ class SettingsScreen extends ConsumerWidget {
                                     // was all but invisible on the ink
                                     // scaffold; past ~0.32 the tile becomes a
                                     // grey block that pulls focus.
-                                    color:
-                                        colors.onSurface.withValues(alpha: 0.24),
+                                    color: colors.onSurface
+                                        .withValues(alpha: 0.24),
                                     borderRadius: BorderRadius.circular(16),
                                   )
                                 : null,

--- a/lib/services/nostr/relay/rust_relay_backend.dart
+++ b/lib/services/nostr/relay/rust_relay_backend.dart
@@ -45,14 +45,16 @@ class RustRelayBackend implements NostrRelayBackend {
 
   RustRelayBackend() {
     _events = rust.relayEventStream().listen(
-      (event) => _eventController.add(_toNostrEvent(event)),
-      onError: (Object e) => debugPrint('RustRelayBackend: event stream: $e'),
-    );
+          (event) => _eventController.add(_toNostrEvent(event)),
+          onError: (Object e) =>
+              debugPrint('RustRelayBackend: event stream: $e'),
+        );
 
     _status = rust.relayStatusStream().listen(
-      _onStatusChange,
-      onError: (Object e) => debugPrint('RustRelayBackend: status stream: $e'),
-    );
+          _onStatusChange,
+          onError: (Object e) =>
+              debugPrint('RustRelayBackend: status stream: $e'),
+        );
   }
 
   void _onStatusChange(rust.RelayStatusData change) {

--- a/test/features/home/providers/home_providers_test.dart
+++ b/test/features/home/providers/home_providers_test.dart
@@ -11,7 +11,8 @@ import '../../../support/nostr_fakes.dart';
 
 /// NostrService whose event stream can be fed from the test (relay echoes).
 class _StreamNostrService extends NostrService {
-  _StreamNostrService() : super(KeyManager(crypto: FakeNostrCrypto()),
+  _StreamNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
             crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
 
   final controller = StreamController<NostrEvent>.broadcast();
@@ -88,8 +89,7 @@ void main() {
       expect(feed.state.single.f1Pt2, 2);
     });
 
-    test('an older relay event does not override newer local state',
-        () async {
+    test('an older relay event does not override newer local state', () async {
       // Arrange
       feed.addLocal(_match(f1Pt2: 3));
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;

--- a/test/features/match/match_control_screen_edge_cases_test.dart
+++ b/test/features/match/match_control_screen_edge_cases_test.dart
@@ -235,7 +235,8 @@ void main() {
       expect(find.byType(MatchControlScreen), findsNothing);
     });
 
-    testWidgets('the back button asks before leaving a running match, '
+    testWidgets(
+        'the back button asks before leaving a running match, '
         'and Stay stays', (tester) async {
       // Arrange — leaving mid-match abandons a live scoreboard
       await pumpPushed(tester, _runningMatch());

--- a/test/features/match/match_control_screen_test.dart
+++ b/test/features/match/match_control_screen_test.dart
@@ -15,7 +15,8 @@ import '../../support/nostr_fakes.dart';
 
 /// Fake NostrService that skips relay publishing entirely
 class _FakeNostrService extends NostrService {
-  _FakeNostrService() : super(KeyManager(crypto: FakeNostrCrypto()),
+  _FakeNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
             crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
 
   @override
@@ -273,7 +274,8 @@ void main() {
     expect(find.text('P:3'), findsOneWidget);
   });
 
-  testWidgets('waiting match shows an inline start button, not a blocking overlay',
+  testWidgets(
+      'waiting match shows an inline start button, not a blocking overlay',
       (tester) async {
     // Arrange — a freshly created match, not yet started
     final waiting = _runningMatch().copyWith(
@@ -467,8 +469,7 @@ void main() {
 
   testWidgets('a canceled match has nothing to amend', (tester) async {
     // Arrange — a canceled match is not a result; it is the absence of one
-    final canceled =
-        _runningMatch().copyWith(status: MatchStatus.canceled);
+    final canceled = _runningMatch().copyWith(status: MatchStatus.canceled);
     await pumpScreen(tester, canceled);
     final l10n = await AppLocalizations.delegate.load(const Locale('en'));
 
@@ -498,7 +499,8 @@ void main() {
     expect(find.text(l10n.outcomeTitle), findsOneWidget);
   });
 
-  testWidgets('an outcome chosen after the match finished behind the sheet is '
+  testWidgets(
+      'an outcome chosen after the match finished behind the sheet is '
       'not lost', (tester) async {
     // Arrange — the referee opens the sheet, and the clock runs out underneath
     // it: the notifier finishes the match on points, on its own, while the
@@ -529,5 +531,4 @@ void main() {
     expect(match.winner, MatchWinner.f2);
     expect(match.method, MatchMethod.submission);
   });
-
 }

--- a/test/features/match/models/match_test.dart
+++ b/test/features/match/models/match_test.dart
@@ -1246,7 +1246,8 @@ void _outcomeTests() {
       expect(match.method, isNull);
       expect(match.winner, isNull);
       expect(match.isLegacyResult, isTrue);
-      expect(match.f1EffectivePoints, 4, reason: 'raw score, no penalty points');
+      expect(match.f1EffectivePoints, 4,
+          reason: 'raw score, no penalty points');
     });
 
     test('an unknown method is a hard error, not a silent null', () {

--- a/test/features/match/providers/match_control_provider_edge_cases_test.dart
+++ b/test/features/match/providers/match_control_provider_edge_cases_test.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/features/match/models/match.dart';

--- a/test/features/match/providers/match_control_provider_test.dart
+++ b/test/features/match/providers/match_control_provider_test.dart
@@ -14,7 +14,8 @@ import '../../../support/nostr_fakes.dart';
 /// [failuresRemaining] makes the next N publishes throw (relay down).
 /// [gate] holds a publish in flight until completed (slow relay).
 class _FakeNostrService extends NostrService {
-  _FakeNostrService() : super(KeyManager(crypto: FakeNostrCrypto()),
+  _FakeNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
             crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
 
   int publishCount = 0;
@@ -28,8 +29,7 @@ class _FakeNostrService extends NostrService {
   @override
   Stream<String> get onRelayConnected => relayConnected.stream;
 
-  Match get lastPublishedMatch =>
-      Match.fromJsonString(publishedContents.last);
+  Match get lastPublishedMatch => Match.fromJsonString(publishedContents.last);
 
   @override
   Future<void> publishAddressableEvent({
@@ -252,7 +252,8 @@ void main() {
       expect(notifier.state.match.winner, isNull);
     });
 
-    test('the clock does not finish a match on points when someone has four '
+    test(
+        'the clock does not finish a match on points when someone has four '
         'penalties', () async {
       // Arrange — Pana is comfortably ahead, but has four penalties of his own
       nostr = _FakeNostrService();
@@ -669,7 +670,8 @@ void main() {
       expect(published.winner, MatchWinner.f2);
       expect(published.method, MatchMethod.submission);
       expect(published.submission, 'armbar');
-      expect(published.f1Score, 4, reason: 'the raw record is still the record');
+      expect(published.f1Score, 4,
+          reason: 'the raw record is still the record');
       expect(published.status, MatchStatus.finished);
       expect(published.endedAt, isNotNull);
     });

--- a/test/features/settings/providers/relay_config_provider_test.dart
+++ b/test/features/settings/providers/relay_config_provider_test.dart
@@ -207,7 +207,8 @@ void main() {
 
     /// Builds a notifier over in-memory storage and waits for its async
     /// initialize to finish, so tests start from a settled state.
-    Future<void> build({List<RelayConfig>? initial, bool reachable = true}) async {
+    Future<void> build(
+        {List<RelayConfig>? initial, bool reachable = true}) async {
       storage = InMemorySecureStorage();
       if (initial != null) {
         storage.store['nostr_relays'] =
@@ -274,8 +275,7 @@ void main() {
         await build();
 
         // Act
-        final added =
-            await notifier.addRelay('  wss://relay.mostro.network ');
+        final added = await notifier.addRelay('  wss://relay.mostro.network ');
 
         // Assert
         expect(added, isFalse);
@@ -310,8 +310,7 @@ void main() {
         expect(notifier.state.relays.map((r) => r.url),
             contains('wss://new.example'));
         expect(notifier.state.error, isNull);
-        final persisted =
-            jsonDecode(storage.store['nostr_relays']!) as List;
+        final persisted = jsonDecode(storage.store['nostr_relays']!) as List;
         expect(persisted, hasLength(3));
       });
 
@@ -371,8 +370,7 @@ void main() {
         expect(removed, isTrue);
         expect(notifier.state.relays.map((r) => r.url),
             isNot(contains('wss://nos.lol')));
-        final persisted =
-            jsonDecode(storage.store['nostr_relays']!) as List;
+        final persisted = jsonDecode(storage.store['nostr_relays']!) as List;
         expect(persisted, hasLength(1));
       });
 
@@ -443,8 +441,8 @@ void main() {
 
         // Assert
         expect(toggled, isTrue);
-        final nosLol = notifier.state.relays
-            .firstWhere((r) => r.url == 'wss://nos.lol');
+        final nosLol =
+            notifier.state.relays.firstWhere((r) => r.url == 'wss://nos.lol');
         expect(nosLol.isEnabled, isFalse);
         final persisted = (jsonDecode(storage.store['nostr_relays']!) as List)
             .cast<Map<String, dynamic>>();
@@ -492,8 +490,8 @@ void main() {
         notifier.updateConnectionStatus('WSS://NOS.LOL', true);
 
         // Assert — matching is case-insensitive, like every other lookup
-        final nosLol = notifier.state.relays
-            .firstWhere((r) => r.url == 'wss://nos.lol');
+        final nosLol =
+            notifier.state.relays.firstWhere((r) => r.url == 'wss://nos.lol');
         expect(nosLol.isConnected, isTrue);
       });
 
@@ -545,13 +543,13 @@ void main() {
         }
         await server.close(force: true);
       });
-      final notifier =
-          RelayConfigNotifier(RelayConfigService(secureStorage: InMemorySecureStorage()));
+      final notifier = RelayConfigNotifier(
+          RelayConfigService(secureStorage: InMemorySecureStorage()));
       await pumpEventQueue();
 
       // Act
-      final reachable = await notifier
-          .testRelayConnectivity('ws://127.0.0.1:${server.port}');
+      final reachable =
+          await notifier.testRelayConnectivity('ws://127.0.0.1:${server.port}');
 
       // Assert
       expect(reachable, isTrue);
@@ -581,7 +579,8 @@ void main() {
       // failure path awaited `channel.sink.close()` on a socket whose
       // handshake never completed. The method must now RETURN false itself;
       // if the hang comes back, the test-level timeout fails this test.
-      final reachable = await notifier.testRelayConnectivity('ws://127.0.0.1:1');
+      final reachable =
+          await notifier.testRelayConnectivity('ws://127.0.0.1:1');
 
       // Assert
       expect(reachable, isFalse);
@@ -608,8 +607,8 @@ void main() {
       // Act — regression guard for the same hang: after the 5s ready timeout
       // fires, the method must return false on its own instead of wedging on
       // a close() that can never complete.
-      final reachable = await notifier
-          .testRelayConnectivity('ws://127.0.0.1:${server.port}');
+      final reachable =
+          await notifier.testRelayConnectivity('ws://127.0.0.1:${server.port}');
 
       // Assert
       expect(reachable, isFalse);

--- a/test/features/settings/screens/relay_management_screen_test.dart
+++ b/test/features/settings/screens/relay_management_screen_test.dart
@@ -96,8 +96,7 @@ void main() {
     expect(find.text('wss://relay.mostro.network'), findsOneWidget);
     expect(find.text('wss://nos.lol'), findsOneWidget);
     expect(find.text(l10n.relayStatusConnectingDefault), findsNWidgets(2));
-    final switches =
-        tester.widgetList<Switch>(find.byType(Switch)).toList();
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
     expect(switches, hasLength(2));
     expect(switches.every((s) => s.value), isTrue);
   });
@@ -203,8 +202,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Act
-      await tester.enterText(
-          find.byType(TextFormField), 'ws://plain.example');
+      await tester.enterText(find.byType(TextFormField), 'ws://plain.example');
       await tester.tap(find.text(l10n.add));
       await tester.pumpAndSettle();
 
@@ -231,8 +229,7 @@ void main() {
       expect(find.text('wss://new.example'), findsOneWidget);
       expect(find.text(l10n.relayAddedSuccessfully), findsOneWidget);
       expect(storage.store['nostr_relays'], contains('wss://new.example'));
-      final field =
-          tester.widget<TextFormField>(find.byType(TextFormField));
+      final field = tester.widget<TextFormField>(find.byType(TextFormField));
       expect(field.controller?.text, isEmpty);
     });
 
@@ -320,8 +317,7 @@ void main() {
 
       // Assert
       expect(find.text(l10n.relayStatusDisabled), findsOneWidget);
-      final switches =
-          tester.widgetList<Switch>(find.byType(Switch)).toList();
+      final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
       expect(switches.where((s) => s.value), hasLength(1));
     });
 

--- a/test/features/settings/screens/submissions_screen_test.dart
+++ b/test/features/settings/screens/submissions_screen_test.dart
@@ -103,8 +103,7 @@ void main() {
     expect(find.text(l10n.submissionsRestore), findsNothing);
   });
 
-  testWidgets('hiding the whole catalog shows the empty state',
-      (tester) async {
+  testWidgets('hiding the whole catalog shows the empty state', (tester) async {
     // Arrange — everything hidden, nothing custom
     await pumpScreen(
       tester,

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -116,7 +116,8 @@ void main() {
       // theme segment, so the subtitle check is scoped to the language row.
       await pumpScreen(tester);
       final languageRow = find
-          .ancestor(of: find.text(l10n.language), matching: find.byType(InkWell))
+          .ancestor(
+              of: find.text(l10n.language), matching: find.byType(InkWell))
           .first;
       expect(
         find.descendant(
@@ -160,7 +161,8 @@ void main() {
       // Assert — scoped to the row, since a theme segment says "System" too
       expect(containerOf(tester).read(localeProvider), isNull);
       final languageRow = find
-          .ancestor(of: find.text(l10n.language), matching: find.byType(InkWell))
+          .ancestor(
+              of: find.text(l10n.language), matching: find.byType(InkWell))
           .first;
       expect(
         find.descendant(
@@ -342,8 +344,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Assert
-      expect(launched,
-          ['https://protolayer.io', 'https://protolayer.io']);
+      expect(launched, ['https://protolayer.io', 'https://protolayer.io']);
     });
 
     testWidgets('dark theme gives the belt a lightened backdrop',

--- a/test/services/nostr/crypto/nostr_crypto_contract.dart
+++ b/test/services/nostr/crypto/nostr_crypto_contract.dart
@@ -226,7 +226,8 @@ void runNostrCryptoContract(String name, NostrCrypto Function() create) {
         final publicKey = crypto.getPublicKey(privateKey);
         final input = unsigned(
           publicKey,
-          content: '{"f1":"Gonçalves 🥋","f2":"田中","n":"a \\"quote\\"\nnewline"}',
+          content:
+              '{"f1":"Gonçalves 🥋","f2":"田中","n":"a \\"quote\\"\nnewline"}',
         );
 
         // Act

--- a/test/services/nostr/crypto/rust_nostr_crypto_test.dart
+++ b/test/services/nostr/crypto/rust_nostr_crypto_test.dart
@@ -36,7 +36,6 @@ void main() {
 
     // The identical suite NostrToolsCrypto passes, not one line changed.
     runNostrCryptoContract('RustNostrCrypto', RustNostrCrypto.new);
-
   });
 }
 

--- a/test/services/nostr/nostr_service_behavior_test.dart
+++ b/test/services/nostr/nostr_service_behavior_test.dart
@@ -219,8 +219,7 @@ void main() {
       // Arrange
       final seen = <NostrEvent>[];
       service.eventStream.listen(seen.add);
-      final future =
-          DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
+      final future = DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
 
       // Act
       backend.eventsController.add(_event(tags: [
@@ -247,8 +246,7 @@ void main() {
       expect(seen, hasLength(1));
     });
 
-    test('caches an addressable event and serves it back by address',
-        () async {
+    test('caches an addressable event and serves it back by address', () async {
       // Act
       backend.eventsController.add(_event(tags: [
         ['d', 'abcd'],
@@ -443,8 +441,7 @@ void main() {
       );
     });
 
-    test('refuses to publish an event that fails self-verification',
-        () async {
+    test('refuses to publish an event that fails self-verification', () async {
       // Arrange — a malformed signature must fail loudly here, not silently
       // at the relay
       final selfDoubting = NostrService(

--- a/test/services/nostr/relay/convergence_drills.dart
+++ b/test/services/nostr/relay/convergence_drills.dart
@@ -148,7 +148,8 @@ void runConvergenceDrills(
       expect(relayB.received.single['content'], 'f1 leads');
     });
 
-    test('a relay that was down receives only the latest score, not the history',
+    test(
+        'a relay that was down receives only the latest score, not the history',
         () async {
       // Arrange — B is down while the referee runs up the score
       final portB = relayB.port;

--- a/test/shared/providers/match_duration_provider_test.dart
+++ b/test/shared/providers/match_duration_provider_test.dart
@@ -100,8 +100,8 @@ void main() {
       // Assert
       expect(notifier.state, defaultMatchDuration);
       final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getInt('choke:default-match-duration'),
-          defaultMatchDuration);
+      expect(
+          prefs.getInt('choke:default-match-duration'), defaultMatchDuration);
     });
   });
 

--- a/test/shared/providers/theme_provider_test.dart
+++ b/test/shared/providers/theme_provider_test.dart
@@ -42,8 +42,7 @@ void main() {
       expect(mode, ThemeMode.system);
     });
 
-    test('falls back to system when the saved value is unrecognized',
-        () async {
+    test('falls back to system when the saved value is unrecognized', () async {
       // Arrange — a value written by a future (or corrupted) version
       SharedPreferences.setMockInitialValues({themeModeKey: 'sepia'});
 


### PR DESCRIPTION
This PR adds a comprehensive 'Testing & Code Coverage' section to the README.md. It documents how to run code coverage for both the Dart/Flutter codebase (using tool/coverage.sh) and the Rust native crate (using cargo-llvm-cov), highlighting the current coverage percentages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Testing & Code Coverage” section to the README.
  * Documented Dart/Flutter and Rust coverage commands, tools, and reporting details.
  * Reorganized the README so the Architecture section follows the new coverage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->