### PR TITLE
feat: enlarge the C mark inside the home header tile

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -56,7 +56,10 @@ class HomeScreen extends ConsumerWidget {
                   Container(
                     width: 46,
                     height: 46,
-                    padding: const EdgeInsets.all(9),
+                    // Tighter inset so the mark fills ~78% of the tile — the
+                    // usual icon-in-tile proportion. At the previous 9 it read
+                    // as a small mark floating in a large tile.
+                    padding: const EdgeInsets.all(5),
                     decoration: BoxDecoration(
                       color: BJJColors.greyLight,
                       borderRadius: BorderRadius.circular(12),


### PR DESCRIPTION
## What

Makes the C mark bigger inside the home header's gray tile, **without changing the tile itself**.

## How

Only the tile's inner padding changes — `EdgeInsets.all(9)` → `EdgeInsets.all(5)`:

| | Before | After |
|---|---|---|
| Tile | 46×46 | 46×46 (unchanged) |
| Mark | 28px | **36px** |
| Fill | 61% | **~78%** |

~78% is the usual icon-in-tile proportion; at the previous inset the mark read as small and floating inside a large tile. Tile color (`BJJColors.greyLight`), corner radius, and the surrounding `Row` layout are untouched.

## Test plan

- [ ] `flutter run` and confirm the mark is visibly larger, still centered, with comfortable clearance from the tile's rounded corners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the home screen header logo spacing for a tighter, more compact appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->