### PR TITLE
fix: persist the language selection across app restarts

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -499,7 +499,7 @@ class SettingsScreen extends ConsumerWidget {
                   ? Icon(Icons.check, color: colors.primary)
                   : null,
               onTap: () {
-                ref.read(localeProvider.notifier).state = null;
+                ref.read(localeProvider.notifier).setLocale(null);
                 Navigator.pop(ctx);
               },
             ),
@@ -523,7 +523,9 @@ class SettingsScreen extends ConsumerWidget {
                     ? Icon(Icons.check, color: colors.primary)
                     : null,
                 onTap: () {
-                  ref.read(localeProvider.notifier).state = Locale(entry.key);
+                  ref
+                      .read(localeProvider.notifier)
+                      .setLocale(Locale(entry.key));
                   Navigator.pop(ctx);
                 },
               );

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -498,10 +498,7 @@ class SettingsScreen extends ConsumerWidget {
               trailing: currentLocale == null
                   ? Icon(Icons.check, color: colors.primary)
                   : null,
-              onTap: () {
-                ref.read(localeProvider.notifier).setLocale(null);
-                Navigator.pop(ctx);
-              },
+              onTap: () => _applyLocale(ctx, ref, null),
             ),
             const Divider(),
             // Language options
@@ -522,18 +519,46 @@ class SettingsScreen extends ConsumerWidget {
                 trailing: isSelected
                     ? Icon(Icons.check, color: colors.primary)
                     : null,
-                onTap: () {
-                  ref
-                      .read(localeProvider.notifier)
-                      .setLocale(Locale(entry.key));
-                  Navigator.pop(ctx);
-                },
+                onTap: () => _applyLocale(ctx, ref, Locale(entry.key)),
               );
             }),
           ],
         ),
       ),
     );
+  }
+
+  /// Applies a language choice made in the picker.
+  ///
+  /// The picker closes only once the choice has been stored: a selection that
+  /// could not be written would come back as the system language on the next
+  /// launch, so dismissing on it would mime an acceptance that never happened.
+  /// On failure the dialog stays put and says so in the user's current
+  /// language — the cause is logged by the notifier, not shown here.
+  Future<void> _applyLocale(
+    BuildContext pickerContext,
+    WidgetRef ref,
+    Locale? locale,
+  ) async {
+    final l10n = AppLocalizations.of(pickerContext);
+    final messenger = ScaffoldMessenger.of(pickerContext);
+    final colors = Theme.of(pickerContext).colorScheme;
+
+    try {
+      await ref.read(localeProvider.notifier).setLocale(locale);
+    } catch (_) {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(l10n.languageSaveFailed),
+          backgroundColor: colors.error,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
+
+    if (!pickerContext.mounted) return;
+    Navigator.pop(pickerContext);
   }
 
   void _showLicenseScreen(BuildContext context) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -455,6 +455,10 @@
   "@selectLanguage": {
     "description": "Language picker dialog title"
   },
+  "languageSaveFailed": "Couldn't save the language. Please try again.",
+  "@languageSaveFailed": {
+    "description": "Error snackbar when the chosen language cannot be stored"
+  },
   "relayManagement": "Relay Management",
   "@relayManagement": {
     "description": "Relay management screen title"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -112,6 +112,7 @@
   "sectionLanguage": "Idioma",
   "language": "Idioma",
   "selectLanguage": "Seleccionar idioma",
+  "languageSaveFailed": "No se pudo guardar el idioma. Inténtalo de nuevo.",
   "relayManagement": "Gestión de relays",
   "refresh": "Actualizar",
   "addCustomRelay": "Agregar relay personalizado",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -112,6 +112,7 @@
   "sectionLanguage": "言語",
   "language": "言語",
   "selectLanguage": "言語を選択",
+  "languageSaveFailed": "言語を保存できませんでした。もう一度お試しください。",
   "relayManagement": "リレー管理",
   "refresh": "更新",
   "addCustomRelay": "カスタムリレーを追加",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -112,6 +112,7 @@
   "sectionLanguage": "Idioma",
   "language": "Idioma",
   "selectLanguage": "Selecionar idioma",
+  "languageSaveFailed": "Não foi possível salvar o idioma. Tente novamente.",
   "relayManagement": "Gerenciamento de relays",
   "refresh": "Atualizar",
   "addCustomRelay": "Adicionar relay personalizado",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -774,6 +774,12 @@ abstract class AppLocalizations {
   /// **'Select Language'**
   String get selectLanguage;
 
+  /// Error snackbar when the chosen language cannot be stored
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save the language. Please try again.'**
+  String get languageSaveFailed;
+
   /// Relay management screen title
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -363,6 +363,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get selectLanguage => 'Select Language';
 
   @override
+  String get languageSaveFailed =>
+      'Couldn\'t save the language. Please try again.';
+
+  @override
   String get relayManagement => 'Relay Management';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -365,6 +365,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get selectLanguage => 'Seleccionar idioma';
 
   @override
+  String get languageSaveFailed =>
+      'No se pudo guardar el idioma. Inténtalo de nuevo.';
+
+  @override
   String get relayManagement => 'Gestión de relays';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -350,6 +350,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get selectLanguage => '言語を選択';
 
   @override
+  String get languageSaveFailed => '言語を保存できませんでした。もう一度お試しください。';
+
+  @override
   String get relayManagement => 'リレー管理';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -365,6 +365,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get selectLanguage => 'Selecionar idioma';
 
   @override
+  String get languageSaveFailed =>
+      'Não foi possível salvar o idioma. Tente novamente.';
+
+  @override
   String get relayManagement => 'Gerenciamento de relays';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,11 +81,13 @@ void main() async {
 
   // Load saved preferences before first frame to avoid flash
   final savedThemeMode = await ThemeModeNotifier.loadSavedThemeMode();
+  final savedLocale = await LocaleNotifier.loadSavedLocale();
   final savedDuration = await MatchDurationNotifier.loadSavedDuration();
   final savedSubmissions = await SubmissionsNotifier.loadSaved();
 
   // Create notifiers with hydrated values (no flash on startup)
   final themeNotifier = ThemeModeNotifier()..hydrate(savedThemeMode);
+  final localeNotifier = LocaleNotifier()..hydrate(savedLocale);
   final durationNotifier = MatchDurationNotifier()..hydrate(savedDuration);
   final submissionsNotifier = SubmissionsNotifier()..hydrate(savedSubmissions);
 
@@ -97,6 +99,7 @@ void main() async {
         nostrServiceProvider.overrideWithValue(nostrService),
         relayConfigServiceProvider.overrideWithValue(relayConfigService),
         themeModeProvider.overrideWith((_) => themeNotifier),
+        localeProvider.overrideWith((_) => localeNotifier),
         matchDurationProvider.overrideWith((_) => durationNotifier),
         submissionsProvider.overrideWith((_) => submissionsNotifier),
       ],

--- a/lib/shared/providers/locale_provider.dart
+++ b/lib/shared/providers/locale_provider.dart
@@ -1,5 +1,62 @@
 import 'dart:ui';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Provider for the app locale. null means system default.
-final localeProvider = StateProvider<Locale?>((ref) => null);
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+const _kLocaleKey = 'choke:locale';
+
+/// Provider for the app locale. null means follow the system language.
+///
+/// Persists the selection to [SharedPreferences] and hydrates synchronously
+/// at startup, the same way the theme and default-duration preferences do —
+/// so a chosen language survives the app being closed instead of snapping
+/// back to the device language.
+final localeProvider = StateNotifierProvider<LocaleNotifier, Locale?>((ref) {
+  return LocaleNotifier();
+});
+
+/// Manages the app's [Locale] state with persistence.
+///
+/// On startup, call [loadSavedLocale] to read the saved preference, then
+/// [hydrate] to set the initial value synchronously before the first frame
+/// renders — otherwise the UI flashes the system language until the read
+/// completes.
+class LocaleNotifier extends StateNotifier<Locale?> {
+  /// Creates a [LocaleNotifier] that follows the system language.
+  LocaleNotifier() : super(null);
+
+  /// Load the saved locale from [SharedPreferences]. Call before runApp().
+  ///
+  /// Returns null when nothing was stored or the stored code is no longer one
+  /// of [AppLocalizations.supportedLocales] — a language dropped between
+  /// versions must fall back to the system default rather than to a locale
+  /// the app can no longer translate.
+  static Future<Locale?> loadSavedLocale() async {
+    final prefs = await SharedPreferences.getInstance();
+    final code = prefs.getString(_kLocaleKey);
+    if (code == null) return null;
+    final isSupported = AppLocalizations.supportedLocales
+        .any((locale) => locale.languageCode == code);
+    return isSupported ? Locale(code) : null;
+  }
+
+  /// Set the initial locale synchronously (called at startup).
+  void hydrate(Locale? locale) {
+    state = locale;
+  }
+
+  /// Updates the locale and persists the choice to [SharedPreferences].
+  ///
+  /// Pass null to follow the system language; that clears the stored key so
+  /// the next launch has nothing to restore.
+  Future<void> setLocale(Locale? locale) async {
+    state = locale;
+    final prefs = await SharedPreferences.getInstance();
+    if (locale == null) {
+      await prefs.remove(_kLocaleKey);
+    } else {
+      await prefs.setString(_kLocaleKey, locale.languageCode);
+    }
+  }
+}

--- a/lib/shared/providers/locale_provider.dart
+++ b/lib/shared/providers/locale_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
@@ -50,13 +51,24 @@ class LocaleNotifier extends StateNotifier<Locale?> {
   ///
   /// Pass null to follow the system language; that clears the stored key so
   /// the next launch has nothing to restore.
+  ///
+  /// The write happens first and [state] moves only once it lands, so the
+  /// live locale never promises something a restart would take back — the
+  /// exact divergence this provider exists to prevent. A failed write is
+  /// logged and rethrown for the caller to surface; it is never swallowed.
   Future<void> setLocale(Locale? locale) async {
-    state = locale;
-    final prefs = await SharedPreferences.getInstance();
-    if (locale == null) {
-      await prefs.remove(_kLocaleKey);
-    } else {
-      await prefs.setString(_kLocaleKey, locale.languageCode);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (locale == null) {
+        await prefs.remove(_kLocaleKey);
+      } else {
+        await prefs.setString(_kLocaleKey, locale.languageCode);
+      }
+    } catch (e, st) {
+      // Safe to log: this key holds a language subtag, no key material.
+      debugPrint('Locale persistence failed: $e\n$st');
+      rethrow;
     }
+    state = locale;
   }
 }

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -132,17 +132,22 @@ void main() {
       await tester.tap(find.text(localeDisplayNames['es']!));
       await tester.pumpAndSettle();
 
-      // Assert — provider updated, dialog closed, subtitle reflects it
+      // Assert — provider updated, dialog closed, subtitle reflects it, and
+      // the choice was persisted so it survives the app being closed
       expect(containerOf(tester).read(localeProvider), const Locale('es'));
       expect(find.text(l10n.selectLanguage), findsNothing);
       expect(find.text(localeDisplayNames['es']!), findsOneWidget);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('choke:locale'), 'es');
     });
 
     testWidgets('a chosen language can be reset to system default',
         (tester) async {
-      // Arrange — Japanese already selected
+      // Arrange — Japanese already selected and stored from a prior launch
+      SharedPreferences.setMockInitialValues({'choke:locale': 'ja'});
       await pumpScreen(tester, overrides: [
-        localeProvider.overrideWith((ref) => const Locale('ja')),
+        localeProvider.overrideWith(
+            (ref) => LocaleNotifier()..hydrate(const Locale('ja'))),
       ]);
       expect(find.text(localeDisplayNames['ja']!), findsOneWidget);
 
@@ -160,6 +165,8 @@ void main() {
 
       // Assert — scoped to the row, since a theme segment says "System" too
       expect(containerOf(tester).read(localeProvider), isNull);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('choke:locale'), isNull);
       final languageRow = find
           .ancestor(
               of: find.text(l10n.language), matching: find.byType(InkWell))
@@ -175,7 +182,8 @@ void main() {
         (tester) async {
       // Arrange — a locale the display-name map has never heard of
       await pumpScreen(tester, overrides: [
-        localeProvider.overrideWith((ref) => const Locale('fr')),
+        localeProvider.overrideWith(
+            (ref) => LocaleNotifier()..hydrate(const Locale('fr'))),
       ]);
 
       // Assert — the subtitle shows the code rather than nothing

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 import 'package:choke/features/settings/screens/relay_management_screen.dart';
 import 'package:choke/features/settings/screens/submissions_screen.dart';
 import 'package:choke/features/settings/settings_screen.dart';
@@ -15,6 +16,16 @@ import 'package:choke/shared/providers/theme_provider.dart';
 import 'package:choke/shared/theme/app_theme.dart';
 
 import '../../support/relay_fakes.dart';
+
+/// A store whose writes always fail — a full disk, a broken platform channel.
+class _FailingStore extends InMemorySharedPreferencesStore {
+  _FailingStore() : super.empty();
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    throw Exception('disk full');
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -176,6 +187,30 @@ void main() {
             of: languageRow, matching: find.text(l10n.systemDefault)),
         findsOneWidget,
       );
+    });
+
+    testWidgets('a language that cannot be stored is reported, not accepted',
+        (tester) async {
+      // Arrange — every write fails. Register the restore BEFORE swapping the
+      // store, so the real backend comes back even if the test exits early.
+      SharedPreferences.setMockInitialValues({});
+      final previousStore = SharedPreferencesStorePlatform.instance;
+      addTearDown(
+          () => SharedPreferencesStorePlatform.instance = previousStore);
+      SharedPreferencesStorePlatform.instance = _FailingStore();
+      await pumpScreen(tester);
+
+      // Act — pick Spanish; the write blows up behind the scenes
+      await tester.tap(find.text(l10n.language));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(localeDisplayNames['es']!));
+      await tester.pumpAndSettle();
+
+      // Assert — the picker stays open rather than miming a saved choice,
+      // the locale is untouched, and the failure is said out loud
+      expect(containerOf(tester).read(localeProvider), isNull);
+      expect(find.text(l10n.selectLanguage), findsOneWidget);
+      expect(find.text(l10n.languageSaveFailed), findsOneWidget);
     });
 
     testWidgets('an unknown locale code falls back to the raw code',

--- a/test/shared/providers/locale_provider_test.dart
+++ b/test/shared/providers/locale_provider_test.dart
@@ -2,7 +2,23 @@ import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 import 'package:choke/shared/providers/locale_provider.dart';
+
+/// A store whose writes always fail — a full disk, a broken platform channel.
+class _FailingStore extends InMemorySharedPreferencesStore {
+  _FailingStore() : super.empty();
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    throw Exception('disk full');
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    throw Exception('disk full');
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -88,6 +104,47 @@ void main() {
       expect(notifier.debugState, isNull);
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getString(localeKey), isNull);
+    });
+
+    test('leaves the locale alone when the write fails', () async {
+      // Arrange — every write fails. Register the restore BEFORE swapping the
+      // store, so the real backend comes back even if the test exits early.
+      SharedPreferences.setMockInitialValues({});
+      final previousStore = SharedPreferencesStorePlatform.instance;
+      addTearDown(
+          () => SharedPreferencesStorePlatform.instance = previousStore);
+      SharedPreferencesStorePlatform.instance = _FailingStore();
+      final notifier = LocaleNotifier();
+
+      // Act — the write blows up, and the caller is told
+      await expectLater(
+        notifier.setLocale(const Locale('en')),
+        throwsA(isA<Exception>()),
+      );
+
+      // Assert — state never moved. Committing it would show English now and
+      // hand back the system language on the next launch: the exact bug this
+      // provider exists to prevent.
+      expect(notifier.debugState, isNull);
+    });
+
+    test('keeps the stored locale when clearing it fails', () async {
+      // Arrange — Spanish stored, and every write fails
+      SharedPreferences.setMockInitialValues({localeKey: 'es'});
+      final previousStore = SharedPreferencesStorePlatform.instance;
+      addTearDown(
+          () => SharedPreferencesStorePlatform.instance = previousStore);
+      SharedPreferencesStorePlatform.instance = _FailingStore();
+      final notifier = LocaleNotifier()..hydrate(const Locale('es'));
+
+      // Act
+      await expectLater(
+        notifier.setLocale(null),
+        throwsA(isA<Exception>()),
+      );
+
+      // Assert — still Spanish, matching what a restart would restore
+      expect(notifier.debugState, const Locale('es'));
     });
 
     test('survives a restart: a saved choice reloads as the same locale',

--- a/test/shared/providers/locale_provider_test.dart
+++ b/test/shared/providers/locale_provider_test.dart
@@ -1,0 +1,106 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/shared/providers/locale_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const localeKey = 'choke:locale';
+
+  group('loadSavedLocale', () {
+    test('returns the saved locale when one was chosen', () async {
+      // Arrange
+      SharedPreferences.setMockInitialValues({localeKey: 'es'});
+
+      // Act
+      final locale = await LocaleNotifier.loadSavedLocale();
+
+      // Assert
+      expect(locale, const Locale('es'));
+    });
+
+    test('returns null when nothing has been saved', () async {
+      // Arrange — a fresh install follows the system language
+      SharedPreferences.setMockInitialValues({});
+
+      // Act
+      final locale = await LocaleNotifier.loadSavedLocale();
+
+      // Assert
+      expect(locale, isNull);
+    });
+
+    test('returns null when the saved locale is not supported', () async {
+      // Arrange — a value written by a future (or corrupted) version
+      SharedPreferences.setMockInitialValues({localeKey: 'kl'});
+
+      // Act
+      final locale = await LocaleNotifier.loadSavedLocale();
+
+      // Assert
+      expect(locale, isNull);
+    });
+  });
+
+  group('hydrate', () {
+    test('sets the initial locale synchronously without persisting', () async {
+      // Arrange
+      SharedPreferences.setMockInitialValues({});
+      final notifier = LocaleNotifier();
+      expect(notifier.debugState, isNull);
+
+      // Act
+      notifier.hydrate(const Locale('ja'));
+
+      // Assert — state moved, storage untouched
+      expect(notifier.debugState, const Locale('ja'));
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(localeKey), isNull);
+    });
+  });
+
+  group('setLocale', () {
+    test('updates state and persists the chosen language code', () async {
+      // Arrange
+      SharedPreferences.setMockInitialValues({});
+      final notifier = LocaleNotifier();
+
+      // Act
+      await notifier.setLocale(const Locale('pt'));
+
+      // Assert — both the live state and the stored preference agree
+      expect(notifier.debugState, const Locale('pt'));
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(localeKey), 'pt');
+    });
+
+    test('clears the stored preference when reset to system default', () async {
+      // Arrange — Spanish previously chosen
+      SharedPreferences.setMockInitialValues({localeKey: 'es'});
+      final notifier = LocaleNotifier()..hydrate(const Locale('es'));
+
+      // Act
+      await notifier.setLocale(null);
+
+      // Assert — nothing left behind for the next launch to restore
+      expect(notifier.debugState, isNull);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(localeKey), isNull);
+    });
+
+    test('survives a restart: a saved choice reloads as the same locale',
+        () async {
+      // Arrange — first launch, user picks English on a Spanish device
+      SharedPreferences.setMockInitialValues({});
+      await LocaleNotifier().setLocale(const Locale('en'));
+
+      // Act — the app is killed and started again
+      final restored = await LocaleNotifier.loadSavedLocale();
+
+      // Assert
+      expect(restored, const Locale('en'));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

On a device whose system language is Spanish, choosing **English** in Settings → Language switches the app to English immediately — but fully closing and reopening the app reverts to Spanish. The theme and default-duration selections do not have this bug.

## Cause

`localeProvider` was a bare in-memory `StateProvider<Locale?>`:

```dart
final localeProvider = StateProvider<Locale?>((ref) => null);
```

Nothing was ever written to storage, so the choice died with the process. `themeModeProvider` and `matchDurationProvider` are both `StateNotifier`s that write to `SharedPreferences` and are hydrated in `main()` before the first frame — the locale simply never got that treatment.

## Fix

`LocaleNotifier` now mirrors the existing pattern exactly:

- persists the language subtag under `choke:locale` on selection;
- removes the key when the user picks **System default**, so nothing is left for the next launch to restore;
- is hydrated in `main()` alongside the theme and duration notifiers, so the app opens in the chosen language with no flash of the device language;
- `loadSavedLocale()` discards a stored code that is no longer in `AppLocalizations.supportedLocales` — if a language is dropped in a later version the fallback must be the system default, not a locale the app can no longer translate.

The settings picker now calls `setLocale(...)` instead of assigning `.state`.

## Test plan

- [x] New `test/shared/providers/locale_provider_test.dart` — load/hydrate/set round trips, unsupported stored code, reset-to-system clearing the key, and an explicit restart case (`setLocale('en')` → `loadSavedLocale()` returns `en`).
- [x] `settings_screen_test.dart` language tests extended to assert the `SharedPreferences` write on selection and its removal on reset.
- [x] `flutter test` — 497 passed.
- [x] `flutter analyze` — no new issues.
- [ ] Manual: Android device with system language Spanish → pick English → force-stop → reopen → app is still English; pick System default → force-stop → reopen → app is Spanish again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language selections now persist between app launches.
  * The app restores the saved language before displaying the interface.
  * Users can return to the system default language, which clears the saved preference.

* **Bug Fixes**
  * Improved locale selection handling and fallback behavior for unsupported saved languages.

* **Tests**
  * Added coverage for saving, restoring, clearing, and validating language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->