### PR TITLE
fix: publish on the first relay acceptance, not the slowest

### DIFF
--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -226,12 +226,17 @@ class NostrService {
     _eventController.add(event);
   }
 
-  /// Publish a signed event to all connected relays, waiting for each relay's
-  /// verdict.
+  /// Publish a signed event to every connected relay, returning as soon as the
+  /// **first** one accepts it.
   ///
-  /// Succeeds when at least one relay accepts, but keeps working after
-  /// returning: relays that were down, timed out, or rejected the event are
+  /// Completing means one relay has the event. It does *not* mean the pool has
+  /// converged: the other publishes are still in flight when this returns, and
+  /// relays that were down, silent, or that rejected the event keep being
   /// resent the latest state per d-tag until every configured relay has it.
+  /// Callers who need the referee's tap on the wire get it here; convergence
+  /// is the resend sweep's job, and it outlives this call.
+  ///
+  /// Throws only once every relay has answered and none of them accepted.
   Future<void> publishEvent(NostrEvent event) async {
     final dTag = _dTagOf(event);
     if (dTag != null) {

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -252,29 +252,54 @@ class NostrService {
       throw Exception('No connected relays');
     }
 
-    final results = await Future.wait(
-      connected.map((url) async {
+    // Every relay is asked at once, and this returns on the FIRST acceptance —
+    // it does not wait for the rest.
+    //
+    // Waiting for all of them is what put the referee's taps behind the mat. A
+    // relay going quiet is not a rare failure: `nostr-sdk` allows a full 10s
+    // for an `OK` before giving up, and the publisher above sends one state at
+    // a time, so every tap during that window sat unsent. One slow relay
+    // delayed the scoreboard on the fast one.
+    //
+    // Nothing is lost by returning early: the stragglers keep running and
+    // still record their acks, and a relay that never accepts is picked up by
+    // the resend sweep — which is what convergence already means here.
+    final firstAcceptance = Completer<void>();
+    var outstanding = connected.length;
+
+    for (final url in connected) {
+      unawaited(() async {
+        var accepted = false;
         try {
-          final accepted = await _backend.publish(url, event);
+          accepted = await _backend.publish(url, event);
           debugPrint('NostrService: [$url] accepted=$accepted');
           if (accepted) _markAccepted(dTag, event, url);
-          return accepted;
         } catch (e) {
           debugPrint('NostrService: [$url] publish error: $e');
-          return false;
         }
-      }),
-    );
 
-    final successCount = results.where((r) => r).length;
-    debugPrint(
-        'NostrService: published to $successCount/${connected.length} relays');
+        if (accepted && !firstAcceptance.isCompleted) {
+          firstAcceptance.complete();
+        }
 
-    _scheduleResendSweep();
-
-    if (successCount == 0) {
-      throw Exception('Event rejected by all relays');
+        outstanding--;
+        if (outstanding == 0) {
+          // Everyone has answered. If nobody took it, the caller is still
+          // waiting to hear so — it retries with backoff.
+          if (!firstAcceptance.isCompleted) {
+            firstAcceptance
+                .completeError(Exception('Event rejected by all relays'));
+          }
+          _scheduleResendSweep();
+        }
+      }());
     }
+
+    await firstAcceptance.future;
+
+    // Relays still outstanding have not acked, so the state stays pending and
+    // the sweep goes on working at it after this returns.
+    _scheduleResendSweep();
   }
 
   static String? _dTagOf(NostrEvent event) {

--- a/test/features/match/providers/match_publish_latency_test.dart
+++ b/test/features/match/providers/match_publish_latency_test.dart
@@ -157,6 +157,7 @@ void main() {
     test('a burst of taps still leaves the relay holding the final score',
         () async {
       // Act — five penalties faster than any relay answers
+      final stopwatch = Stopwatch()..start();
       for (var i = 0; i < 5; i++) {
         notifier.scorePen(1);
       }
@@ -167,8 +168,13 @@ void main() {
       await eventually(() =>
           sentToFast.isNotEmpty &&
           Match.fromJsonString(sentToFast.last.content).f1Pen == 5);
+      stopwatch.stop();
+
       expect(Match.fromJsonString(sentToFast.last.content).f1Pen, 5);
       expect(notifier.state.match.f1Pen, 5);
+      // The whole burst clears in the same budget a single tap gets: nothing
+      // here may wait on the silent relay.
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
     });
   });
 }

--- a/test/features/match/providers/match_publish_latency_test.dart
+++ b/test/features/match/providers/match_publish_latency_test.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/match/providers/match_control_provider.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+
+import '../../../support/nostr_fakes.dart';
+
+/// What the referee's taps are supposed to do: reach the relay the moment the
+/// button is pressed.
+///
+/// These go through the real [NostrService] rather than a stub of it, because
+/// the delay these guard against lives *between* the notifier and the relay:
+/// the outbox sends one state at a time, so however long a publish takes to
+/// resolve is how long the next tap waits. A publish that resolves only when
+/// the slowest relay answers puts every later score behind it — a penalty
+/// landing on the remote scoreboard seconds after it was awarded.
+class _FixedKeyManager extends KeyManager {
+  _FixedKeyManager() : super(crypto: FakeNostrCrypto());
+
+  @override
+  Future<String?> getPublicKeyHex() async => 'e' * 64;
+
+  @override
+  Future<String?> getPrivateKeyHex() async => 'f' * 64;
+}
+
+/// Signs each event with its own id, so publishes can be told apart.
+class _CountingCrypto extends FakeNostrCrypto {
+  int _n = 0;
+
+  @override
+  NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex) {
+    _n++;
+    return NostrEvent(
+      id: '$_n'.padLeft(64, '0'),
+      pubkey: event.pubkey,
+      createdAt: event.createdAt,
+      kind: event.kind,
+      tags: event.tags,
+      content: event.content,
+      sig: 'b' * 128,
+    );
+  }
+}
+
+Match _runningMatch() {
+  return Match(
+    id: 'abcd',
+    status: MatchStatus.inProgress,
+    startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    duration: 300,
+    f1Name: 'Pana',
+    f2Name: 'Buchecha',
+    f1Color: '#1BA34E',
+    f2Color: '#F5B800',
+  );
+}
+
+/// Wait for [check] to hold, or give up. Polling rather than a fixed sleep, so
+/// a passing run costs milliseconds instead of the whole timeout.
+Future<void> eventually(
+  bool Function() check, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!check() && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+}
+
+void main() {
+  const fast = 'wss://fast';
+  const silent = 'wss://silent';
+
+  late RecordingRelayBackend backend;
+  late NostrService service;
+  late MatchControlNotifier notifier;
+  late Completer<bool> silentVerdict;
+
+  /// Every event the fast relay was handed, in order.
+  late List<NostrEvent> sentToFast;
+
+  setUp(() {
+    sentToFast = [];
+    backend = RecordingRelayBackend()
+      ..configuredRelays = [fast, silent]
+      ..connected = [fast, silent];
+
+    // The relay everyone is watching answers at once. The other takes the
+    // event and never says anything — a relay under load, or one that does not
+    // acknowledge this kind. nostr-sdk gives it a full 10 seconds before it
+    // calls the publish failed, and that wait is the whole problem.
+    silentVerdict = Completer<bool>();
+    backend.onPublish = (url, event) {
+      if (url != fast) return silentVerdict.future;
+      sentToFast.add(event);
+      return Future<bool>.value(true);
+    };
+
+    service = NostrService(
+      _FixedKeyManager(),
+      crypto: _CountingCrypto(),
+      backend: backend,
+      // Long enough that the background sweep never fires mid-test: what is
+      // under test is the publish on the tap, not the retry that follows it.
+      resendInterval: const Duration(minutes: 5),
+    );
+    notifier = MatchControlNotifier(_runningMatch(), service);
+  });
+
+  tearDown(() async {
+    if (!silentVerdict.isCompleted) silentVerdict.complete(false);
+    notifier.dispose();
+    service.dispose();
+    await Future<void>.delayed(Duration.zero);
+  });
+
+  group('every tap goes out when it is tapped', () {
+    test('a penalty reaches the relay on the press', () async {
+      // Act
+      final stopwatch = Stopwatch()..start();
+      notifier.scorePen(1);
+      await eventually(() => sentToFast.isNotEmpty);
+      stopwatch.stop();
+
+      // Assert — the threshold is loose on purpose: what fails here is a
+      // design that batches or defers the tap, not a few ms of event loop
+      expect(sentToFast, hasLength(1));
+      expect(Match.fromJsonString(sentToFast.single.content).f1Pen, 1);
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
+    });
+
+    test('a second penalty is not held behind a silent relay', () async {
+      // Arrange — the first tap's publish is still outstanding at the silent
+      // relay when the second tap lands
+      notifier.scorePen(1);
+      await eventually(() => sentToFast.isNotEmpty);
+      expect(silentVerdict.isCompleted, isFalse,
+          reason: 'the silent relay must still be outstanding');
+
+      // Act — the referee awards a second penalty a moment later
+      final stopwatch = Stopwatch()..start();
+      notifier.scorePen(2);
+      await eventually(() => sentToFast.length >= 2);
+      stopwatch.stop();
+
+      // Assert — the second score went out on its own tap
+      expect(sentToFast, hasLength(2));
+      expect(Match.fromJsonString(sentToFast.last.content).f2Pen, 1);
+      expect(stopwatch.elapsed, lessThan(const Duration(milliseconds: 500)));
+    });
+
+    test('a burst of taps still leaves the relay holding the final score',
+        () async {
+      // Act — five penalties faster than any relay answers
+      for (var i = 0; i < 5; i++) {
+        notifier.scorePen(1);
+      }
+
+      // Assert — coalescing the states in between is fine, the event is
+      // addressable and only the newest matters. What must arrive, quickly, is
+      // the final score.
+      await eventually(() =>
+          sentToFast.isNotEmpty &&
+          Match.fromJsonString(sentToFast.last.content).f1Pen == 5);
+      expect(Match.fromJsonString(sentToFast.last.content).f1Pen, 5);
+      expect(notifier.state.match.f1Pen, 5);
+    });
+  });
+}

--- a/test/services/nostr/nostr_service_behavior_test.dart
+++ b/test/services/nostr/nostr_service_behavior_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/services/key_management/key_manager.dart';
@@ -355,6 +357,33 @@ void main() {
       ]));
 
       // Assert — both relays were attempted
+      expect(backend.publishes.map((p) => p.$1),
+          containsAll(['wss://a', 'wss://b']));
+    });
+
+    test('returns on the first acceptance, without waiting for a silent relay',
+        () async {
+      // Arrange — a accepts at once; b takes the event and never answers.
+      // A relay going quiet is not hypothetical: nostr-sdk waits a full 10s
+      // for an OK before giving up, and the referee's next tap queues behind
+      // this call.
+      backend.configuredRelays = ['wss://a', 'wss://b'];
+      backend.connected = ['wss://a', 'wss://b'];
+      final silent = Completer<bool>();
+      addTearDown(() => silent.complete(false));
+      backend.onPublish = (url, event) =>
+          url == 'wss://a' ? Future<bool>.value(true) : silent.future;
+
+      // Act + Assert — one acceptance is the documented success condition, so
+      // the call must come back on it rather than on the slowest relay
+      await service.publishEvent(_event(tags: [
+        ['d', 'abcd'],
+      ])).timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => fail('publishEvent waited for the silent relay'),
+      );
+
+      // Assert — b was still asked; it is simply not waited on
       expect(backend.publishes.map((p) => p.$1),
           containsAll(['wss://a', 'wss://b']));
     });


### PR DESCRIPTION
## Symptom

After starting a match, kind 31415 events do not reach the relays in real time — penalties observed arriving up to ~5s late when monitoring with `nostreq`.

## Root cause

`NostrService.publishEvent` fanned out to every connected relay and then **awaited all of them**:

```dart
final results = await Future.wait(connected.map((url) async { ... }));
```

So its latency was the *slowest* relay's, and `nostr-sdk` allows a full **10s** (`WAIT_FOR_OK_TIMEOUT`, `nostr-relay-pool-0.44.1/src/relay/constants.rs:10`) for an `OK` before it treats a relay as silent.

That wait is not merely slow, it is **blocking**. `MatchControlNotifier._drainOutbox` sends one state at a time — deliberately, since the event is addressable and rapid taps should coalesce into the newest state:

```dart
Future<void> _drainOutbox() async {
  if (_sending) return;   // <-- a tap during an in-flight publish is not sent
```

So every tap landing inside that window sat in the outbox unsent until the straggler resolved. One quiet relay held back the scoreboard on the relay people were actually watching.

The method's own doc comment already described the intended behaviour — *"Succeeds when at least one relay accepts, but keeps working after returning"* — the implementation just didn't do it.

## Fix

All relays are still asked at once. The call now returns on the **first acceptance** and leaves the rest running, still recording their acks via `_markAccepted`. A relay that never accepts is picked up by the existing resend sweep — which is what convergence has always meant here. Only when every relay has answered and none accepted does the caller get a failure and retry with backoff, exactly as before.

No change to the convergence guarantees from #78: `_pendingLatest` / `_pendingAcks` / `_resendPendingTo` are untouched.

## Confirmation that this path is Rust

- `lib/main.dart` calls `RustLib.init()` unconditionally and wires `RustNostrCrypto` + `RustRelayBackend`.
- `RustRelayBackend` is the **only** `NostrRelayBackend` implementation in `lib/`; no Dart WebSocket transport remains (the one `WebSocketChannel` left is the relay-validation ping in settings, not publishing).
- Sockets, NIP-01 framing, reconnect and the `OK` verdict all live in `rust/src/api/relay.rs` on `nostr-sdk` 0.44.1; signing is `rust/src/api/crypto.rs`.
- `flutter test --tags rust` drives `RustRelayBackend` against a real local relay: **51 passed** with this change.

## Test plan

- [x] New `test/features/match/providers/match_publish_latency_test.dart` — drives the real `NostrService` through `MatchControlNotifier` with one fast relay and one that never answers. Pre-fix results: the second penalty **never left the app**, and the 5-penalty burst ended with the relay holding `f1Pen=1`.
- [x] New case in `nostr_service_behavior_test.dart` — `publishEvent` returns on the first acceptance; pre-fix it failed with `publishEvent waited for the silent relay`.
- [x] `flutter test` — 504 passed.
- [x] `flutter test --tags rust` — 51 passed (real relay, real native lib).
- [ ] Manual: run a match against the configured relay set, watch kind 31415 with `nostreq`, confirm each penalty lands on the press.

## Follow-ups found while reading (not in this PR)

1. **`nextCreatedAt` can drift into the future.** It returns `last + 1` on a same-second collision, so a fast burst stamps events seconds ahead of the wall clock. Relays that enforce a future-timestamp limit would reject those.
2. **The resend sweep is sequential** — `_resendPendingTo` is awaited per relay in a loop, so one silent relay can stall the sweep for the others for up to 10s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Publishing events now returns promptly after the first relay accepts them, rather than waiting for every relay.
  - Match scoring updates remain responsive even when a relay is slow or unavailable.
  - Rapid successive score changes publish the latest state without unnecessary delays.

- **Reliability**
  - Events continue retrying across non-responsive or rejecting relays.
  - Publishing reports an error only when no configured relay accepts the event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->