### PR TITLE
fix: stop shipping a rate-limited relay, and back off when refused

### DIFF
--- a/lib/features/settings/providers/relay_config_provider.dart
+++ b/lib/features/settings/providers/relay_config_provider.dart
@@ -62,9 +62,22 @@ class RelayConfig {
 /// Service for managing relay configuration persistence
 class RelayConfigService {
   static const String _relaysKey = 'nostr_relays';
+
+  /// Relays a fresh install starts with.
+  ///
+  /// `relay.mostro.network` used to be here and was removed: it answers
+  /// `rate-limited: allowed kinds: max 5 events per minute per IP`, and a match
+  /// publishes one addressable event per tap — a scoring burst blows through
+  /// five in seconds, after which the relay refuses everything and the remote
+  /// scoreboard stops moving. Measured, not guessed: 5 of 12 events accepted in
+  /// one burst. It is a Mostro P2P relay; a live scoreboard is not what it is
+  /// for.
+  ///
+  /// Existing installs keep whatever is in secure storage, so anyone who
+  /// already has mostro configured has to remove it in Relay Management.
   static const List<String> defaultRelays = [
-    'wss://relay.mostro.network',
     'wss://nos.lol',
+    'wss://relay.primal.net',
   ];
 
   final FlutterSecureStorage _secureStorage;

--- a/lib/features/settings/providers/relay_config_provider.dart
+++ b/lib/features/settings/providers/relay_config_provider.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
+import '../../../shared/nostr_relays.dart';
+
 /// Error codes emitted by [RelayConfigNotifier].
 ///
 /// Mapped to localized user-facing strings in the UI layer.
@@ -63,22 +65,13 @@ class RelayConfig {
 class RelayConfigService {
   static const String _relaysKey = 'nostr_relays';
 
-  /// Relays a fresh install starts with.
-  ///
-  /// `relay.mostro.network` used to be here and was removed: it answers
-  /// `rate-limited: allowed kinds: max 5 events per minute per IP`, and a match
-  /// publishes one addressable event per tap — a scoring burst blows through
-  /// five in seconds, after which the relay refuses everything and the remote
-  /// scoreboard stops moving. Measured, not guessed: 5 of 12 events accepted in
-  /// one burst. It is a Mostro P2P relay; a live scoreboard is not what it is
-  /// for.
+  /// Relays a fresh install starts with; [defaultNostrRelays] says which ones,
+  /// and why.
   ///
   /// Existing installs keep whatever is in secure storage, so anyone who
-  /// already has mostro configured has to remove it in Relay Management.
-  static const List<String> defaultRelays = [
-    'wss://nos.lol',
-    'wss://relay.primal.net',
-  ];
+  /// already has a dropped relay configured has to remove it in Relay
+  /// Management.
+  static const List<String> defaultRelays = defaultNostrRelays;
 
   final FlutterSecureStorage _secureStorage;
 

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../shared/nostr_relays.dart';
 import '../key_management/key_manager.dart';
 import 'crypto/nostr_crypto.dart';
 import 'relay/nostr_relay_backend.dart';
@@ -80,14 +81,6 @@ class NostrEvent {
 class NostrService {
   static const int _maxCachedEvents = 1000; // Max addressable events to cache
 
-  /// Fallback for [initialize] when no relays are configured. Kept in step
-  /// with [RelayConfigService.defaultRelays], which is where the reasoning for
-  /// this particular set lives.
-  static const List<String> _defaultRelays = [
-    'wss://nos.lol',
-    'wss://relay.primal.net',
-  ];
-
   final KeyManager _keyManager;
   final NostrRelayBackend _backend;
 
@@ -140,6 +133,18 @@ class NostrService {
       // pace starts over.
       _sweepFailures = 0;
       await _resendPendingTo(url);
+
+      // Resetting the counter is not enough on its own. Any sweep already
+      // scheduled was timed against the OLD, backed-off pace — up to
+      // [maxResendInterval] away — and [_scheduleResendSweep] keeps whatever
+      // timer it finds. The relay that just came back would then wait out a
+      // backoff earned by a relay that is still refusing. Drop the stale timer
+      // so the reschedule below uses the reset interval.
+      //
+      // Only this reconnect-driven reset cancels; publishes still reuse a
+      // pending timer, which is what keeps a burst of scores cheap.
+      _resendTimer?.cancel();
+      _resendTimer = null;
       _scheduleResendSweep();
     });
   }
@@ -156,7 +161,7 @@ class NostrService {
 
   /// Connect to configured relays on app start
   Future<void> initialize({List<String>? relayUrls}) async {
-    for (final url in relayUrls ?? _defaultRelays) {
+    for (final url in relayUrls ?? defaultNostrRelays) {
       await addRelay(url);
     }
   }

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -80,9 +80,12 @@ class NostrEvent {
 class NostrService {
   static const int _maxCachedEvents = 1000; // Max addressable events to cache
 
+  /// Fallback for [initialize] when no relays are configured. Kept in step
+  /// with [RelayConfigService.defaultRelays], which is where the reasoning for
+  /// this particular set lives.
   static const List<String> _defaultRelays = [
-    'wss://relay.mostro.network',
     'wss://nos.lol',
+    'wss://relay.primal.net',
   ];
 
   final KeyManager _keyManager;
@@ -108,21 +111,36 @@ class NostrService {
   Timer? _resendTimer;
 
   /// How often relays that are connected but still missing the latest event
-  /// (because they rejected it) are retried.
+  /// (because they rejected it) are retried — the pace of a sweep that is
+  /// getting somewhere.
   final Duration resendInterval;
+
+  /// The slowest the sweep may get after repeated refusals.
+  final Duration maxResendInterval;
+
+  /// Consecutive sweeps in which no relay accepted anything. Doubles the
+  /// interval; any acceptance resets it.
+  int _sweepFailures = 0;
 
   NostrService(
     this._keyManager, {
     required NostrCrypto crypto,
     required NostrRelayBackend backend,
     this.resendInterval = const Duration(seconds: 5),
+    this.maxResendInterval = const Duration(minutes: 1),
   })  : _crypto = crypto,
         _backend = backend {
     _backendEvents = _backend.events.listen(_handleIncomingEvent);
-    _backendConnections = _backend.onRelayConnected.listen((url) {
+    _backendConnections = _backend.onRelayConnected.listen((url) async {
       // A relay that just came back may have missed events while it was away —
       // bring it up to date now, rather than on the referee's next score.
-      _resendPendingTo(url);
+      //
+      // A reconnect is also new information: whatever the sweep had been
+      // backing off from, this relay has not refused anything yet, so the
+      // pace starts over.
+      _sweepFailures = 0;
+      await _resendPendingTo(url);
+      _scheduleResendSweep();
     });
   }
 
@@ -331,7 +349,11 @@ class NostrService {
   }
 
   /// Send every pending latest event this relay has not accepted yet.
-  Future<void> _resendPendingTo(String url) async {
+  ///
+  /// Returns whether the relay took anything, which is what tells the sweep
+  /// above whether to keep its pace or back off.
+  Future<bool> _resendPendingTo(String url) async {
+    var acceptedAny = false;
     for (final dTag in _pendingLatest.keys.toList()) {
       final event = _pendingLatest[dTag];
       if (event == null) continue;
@@ -344,24 +366,45 @@ class NostrService {
         final accepted = await _backend.publish(url, event);
         debugPrint(
             'NostrService: resent ${event.id} to $url, accepted=$accepted');
-        if (accepted) _markAccepted(dTag, event, url);
+        if (accepted) {
+          _markAccepted(dTag, event, url);
+          acceptedAny = true;
+        }
       } catch (e) {
         debugPrint('NostrService: resend to $url failed: $e');
       }
     }
-    _scheduleResendSweep();
+    return acceptedAny;
   }
 
-  /// While any relay is missing the latest state, keep a slow retry loop alive
-  /// for relays that are connected but rejected it (rate limits and the like).
-  /// Disconnected relays are handled by the reconnect listener instead.
+  /// While any relay is missing the latest state, keep a retry loop alive for
+  /// relays that are connected but rejected it. Disconnected relays are handled
+  /// by the reconnect listener instead.
+  ///
+  /// Relays are swept **concurrently**: one that never answers used to hold up
+  /// every relay behind it in the loop, for as long as the transport waits for
+  /// an OK.
+  ///
+  /// The interval **doubles** each time a whole sweep goes unaccepted, up to
+  /// [maxResendInterval]. A relay that refuses is usually refusing for a
+  /// reason that a fixed heartbeat cannot fix and can actively worsen: a rate
+  /// limit like `max 5 events per minute per IP` is spent by the very retries
+  /// meant to beat it. Any acceptance — here or on a reconnect — puts the pace
+  /// straight back to [resendInterval].
   void _scheduleResendSweep() {
     if (_pendingLatest.isEmpty) return;
-    _resendTimer ??= Timer(resendInterval, () async {
+
+    final backoff = resendInterval * (1 << _sweepFailures.clamp(0, 5));
+    final delay = backoff > maxResendInterval ? maxResendInterval : backoff;
+
+    _resendTimer ??= Timer(delay, () async {
       _resendTimer = null;
-      for (final url in _backend.connectedRelays) {
-        await _resendPendingTo(url);
-      }
+      final results = await Future.wait(
+        _backend.connectedRelays.map(_resendPendingTo),
+      );
+      _sweepFailures = results.any((accepted) => accepted)
+          ? 0
+          : (_sweepFailures + 1).clamp(0, 5);
       _scheduleResendSweep();
     });
   }

--- a/lib/shared/nostr_relays.dart
+++ b/lib/shared/nostr_relays.dart
@@ -1,0 +1,22 @@
+/// The relays a fresh install starts with.
+///
+/// The canonical definition. Both the settings layer
+/// (`RelayConfigService.defaultRelays`, which seeds secure storage) and the
+/// transport (`NostrService.initialize`, which falls back to this when nothing
+/// is configured) read it from here — they used to hold separate literals kept
+/// in step by a comment, which is the arrangement that quietly drifts.
+///
+/// `relay.mostro.network` used to be on this list and was removed: it answers
+/// `rate-limited: allowed kinds: max 5 events per minute per IP`, and a match
+/// publishes one addressable event per tap — a scoring burst blows through five
+/// in seconds, after which the relay refuses everything and the remote
+/// scoreboard stops moving. Measured, not guessed: 5 of 12 events accepted in
+/// one burst, against 25 of 25 for nos.lol and 12 of 12 for relay.primal.net.
+/// It is a Mostro P2P relay; a live scoreboard is not what it is for.
+///
+/// Changing this list only affects fresh installs — existing ones keep whatever
+/// is in secure storage.
+const List<String> defaultNostrRelays = [
+  'wss://nos.lol',
+  'wss://relay.primal.net',
+];

--- a/test/features/settings/providers/relay_config_provider_test.dart
+++ b/test/features/settings/providers/relay_config_provider_test.dart
@@ -275,7 +275,7 @@ void main() {
         await build();
 
         // Act
-        final added = await notifier.addRelay('  wss://relay.mostro.network ');
+        final added = await notifier.addRelay('  wss://relay.primal.net ');
 
         // Assert
         expect(added, isFalse);

--- a/test/features/settings/screens/relay_management_screen_test.dart
+++ b/test/features/settings/screens/relay_management_screen_test.dart
@@ -82,7 +82,7 @@ void main() {
 
     // Assert — the list replaced the spinner
     expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(find.text('wss://relay.mostro.network'), findsOneWidget);
+    expect(find.text('wss://relay.primal.net'), findsOneWidget);
   });
 
   testWidgets('renders the default relays as connecting, with switches on',
@@ -93,7 +93,7 @@ void main() {
 
     // Assert — both defaults listed, each with an enabled switch, and the
     // status line says they are defaults still connecting
-    expect(find.text('wss://relay.mostro.network'), findsOneWidget);
+    expect(find.text('wss://relay.primal.net'), findsOneWidget);
     expect(find.text('wss://nos.lol'), findsOneWidget);
     expect(find.text(l10n.relayStatusConnectingDefault), findsNWidgets(2));
     final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
@@ -107,7 +107,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Act — the backend reports the socket opened
-    notifier.updateConnectionStatus('wss://relay.mostro.network', true);
+    notifier.updateConnectionStatus('wss://relay.primal.net', true);
     await tester.pump();
 
     // Assert — one connected, one still connecting
@@ -119,7 +119,7 @@ void main() {
       (tester) async {
     // Arrange — one custom relay alongside a default
     await pumpScreen(tester, initial: const [
-      RelayConfig(url: 'wss://relay.mostro.network'),
+      RelayConfig(url: 'wss://relay.primal.net'),
       RelayConfig(url: 'wss://custom.example'),
     ]);
     await tester.pumpAndSettle();
@@ -139,7 +139,7 @@ void main() {
       (tester) async {
     // Arrange
     await pumpScreen(tester, initial: const [
-      RelayConfig(url: 'wss://relay.mostro.network'),
+      RelayConfig(url: 'wss://relay.primal.net'),
       RelayConfig(url: 'wss://off.example', isEnabled: false),
     ]);
     await tester.pumpAndSettle();
@@ -295,7 +295,7 @@ void main() {
 
       // Act
       await tester.enterText(
-          find.byType(TextFormField), 'wss://relay.mostro.network');
+          find.byType(TextFormField), 'wss://relay.primal.net');
       await tester.tap(find.text(l10n.add));
       await tester.pumpAndSettle();
 
@@ -325,7 +325,7 @@ void main() {
         (tester) async {
       // Arrange — only one relay, enabled
       await pumpScreen(tester, initial: const [
-        RelayConfig(url: 'wss://relay.mostro.network'),
+        RelayConfig(url: 'wss://relay.primal.net'),
       ]);
       await tester.pumpAndSettle();
 
@@ -345,7 +345,7 @@ void main() {
     testWidgets('default relays cannot be swiped away', (tester) async {
       // Arrange — one default, one custom
       await pumpScreen(tester, initial: const [
-        RelayConfig(url: 'wss://relay.mostro.network'),
+        RelayConfig(url: 'wss://relay.primal.net'),
         custom,
       ]);
       await tester.pumpAndSettle();
@@ -365,7 +365,7 @@ void main() {
         (tester) async {
       // Arrange
       await pumpScreen(tester, initial: const [
-        RelayConfig(url: 'wss://relay.mostro.network'),
+        RelayConfig(url: 'wss://relay.primal.net'),
         custom,
       ]);
       await tester.pumpAndSettle();
@@ -386,7 +386,7 @@ void main() {
         (tester) async {
       // Arrange
       await pumpScreen(tester, initial: const [
-        RelayConfig(url: 'wss://relay.mostro.network'),
+        RelayConfig(url: 'wss://relay.primal.net'),
         custom,
       ]);
       await tester.pumpAndSettle();
@@ -444,7 +444,7 @@ void main() {
         (tester) async {
       // Arrange
       await pumpScreen(tester, initial: const [
-        RelayConfig(url: 'wss://relay.mostro.network'),
+        RelayConfig(url: 'wss://relay.primal.net'),
         RelayConfig(url: 'wss://custom.example'),
       ]);
       await tester.pumpAndSettle();
@@ -466,7 +466,7 @@ void main() {
         (tester) async {
       // Arrange — the custom relay is the only enabled one
       await pumpScreen(tester, initial: const [
-        RelayConfig(url: 'wss://relay.mostro.network', isEnabled: false),
+        RelayConfig(url: 'wss://relay.primal.net', isEnabled: false),
         RelayConfig(url: 'wss://custom.example'),
       ]);
       await tester.pumpAndSettle();

--- a/test/services/nostr/nostr_service_behavior_test.dart
+++ b/test/services/nostr/nostr_service_behavior_test.dart
@@ -442,6 +442,43 @@ void main() {
       expect(sweeps, greaterThan(0), reason: 'sweep never ran at all');
     });
 
+    test('a reconnect brings the backed-off sweep back to full pace', () async {
+      // Arrange — b refuses everything, so the sweep backs off: at a 100ms
+      // base the intervals run 100, 200, 400, and by ~750ms the next sweep is
+      // already 800ms away. a accepts, so the publish itself succeeds.
+      final sweeper = NostrService(
+        _FixedKeyManager(),
+        crypto: FakeNostrCrypto(),
+        backend: backend,
+        resendInterval: const Duration(milliseconds: 100),
+      );
+      addTearDown(sweeper.dispose);
+      backend.configuredRelays = ['wss://a', 'wss://b', 'wss://c'];
+      backend.connected = ['wss://a', 'wss://b', 'wss://c'];
+      backend.onPublish = (url, event) async => url != 'wss://b';
+
+      await sweeper.publishEvent(_event(tags: [
+        ['d', 'abcd'],
+      ]));
+      await Future<void>.delayed(const Duration(milliseconds: 750));
+      final beforeReconnect =
+          backend.publishes.where((p) => p.$1 == 'wss://b').length;
+
+      // Act — a DIFFERENT relay comes back, so what is measured is the
+      // rescheduled sweep rather than the reconnect's own immediate resend
+      backend.connectedController.add('wss://c');
+      await Future<void>.delayed(const Duration(milliseconds: 350));
+
+      // Assert — b was swept again inside the window. Left at the old pace the
+      // next sweep would still be ~750ms out, and a relay that just came back
+      // would sit unserved through a backoff it had nothing to do with.
+      final sweepsAfter =
+          backend.publishes.where((p) => p.$1 == 'wss://b').length -
+              beforeReconnect;
+      expect(sweepsAfter, greaterThan(0),
+          reason: 'the pending timer kept the backed-off delay');
+    });
+
     test('sweeps relays at once, so a silent one cannot stall the others',
         () async {
       // Arrange — the silent relay is FIRST, so a sequential sweep never

--- a/test/services/nostr/nostr_service_behavior_test.dart
+++ b/test/services/nostr/nostr_service_behavior_test.dart
@@ -102,10 +102,11 @@ void main() {
       // Act
       await service.initialize();
 
-      // Assert — the two shipped defaults, in order
+      // Assert — the two shipped defaults, in order. Neither may be a relay
+      // that rate-limits a scoring burst; see RelayConfigService.defaultRelays.
       expect(backend.addedRelays, [
-        'wss://relay.mostro.network',
         'wss://nos.lol',
+        'wss://relay.primal.net',
       ]);
     });
 
@@ -376,12 +377,14 @@ void main() {
 
       // Act + Assert — one acceptance is the documented success condition, so
       // the call must come back on it rather than on the slowest relay
-      await service.publishEvent(_event(tags: [
-        ['d', 'abcd'],
-      ])).timeout(
-        const Duration(seconds: 1),
-        onTimeout: () => fail('publishEvent waited for the silent relay'),
-      );
+      await service
+          .publishEvent(_event(tags: [
+            ['d', 'abcd'],
+          ]))
+          .timeout(
+            const Duration(seconds: 1),
+            onTimeout: () => fail('publishEvent waited for the silent relay'),
+          );
 
       // Assert — b was still asked; it is simply not waited on
       expect(backend.publishes.map((p) => p.$1),
@@ -401,6 +404,76 @@ void main() {
         ])),
         throwsException,
       );
+    });
+  });
+
+  group('resend sweep', () {
+    test('backs off while a relay keeps refusing, instead of hammering it',
+        () async {
+      // Arrange — a relay that refuses everything, which is exactly what a
+      // rate-limited relay does: `max 5 events per minute per IP` is a fast,
+      // repeated no. Retrying it on a fixed heartbeat only spends the limit.
+      final sweeper = NostrService(
+        _FixedKeyManager(),
+        crypto: FakeNostrCrypto(),
+        backend: backend,
+        resendInterval: const Duration(milliseconds: 50),
+      );
+      addTearDown(sweeper.dispose);
+      backend.configuredRelays = ['wss://a', 'wss://b'];
+      backend.connected = ['wss://a', 'wss://b'];
+      // a accepts (so the publish succeeds), b never will — b keeps the state
+      // pending and the sweep alive.
+      backend.onPublish = (url, event) async => url == 'wss://a';
+
+      // Act — one publish, then let the sweep run for 400ms
+      await sweeper.publishEvent(_event(tags: [
+        ['d', 'abcd'],
+      ]));
+      final afterPublish = backend.publishes.length;
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+
+      // Assert — at a flat 50ms the sweep would have fired ~8 times; doubling
+      // (50, 100, 200, 400) gets through 3. The bound is loose enough to
+      // survive a slow machine and still fail a fixed heartbeat.
+      final sweeps = backend.publishes.length - afterPublish;
+      expect(sweeps, lessThanOrEqualTo(5),
+          reason: 'sweep did not back off: $sweeps resends in 400ms');
+      expect(sweeps, greaterThan(0), reason: 'sweep never ran at all');
+    });
+
+    test('sweeps relays at once, so a silent one cannot stall the others',
+        () async {
+      // Arrange — the silent relay is FIRST, so a sequential sweep never
+      // reaches the second one
+      final silent = Completer<bool>();
+      addTearDown(() => silent.complete(false));
+      final sweeper = NostrService(
+        _FixedKeyManager(),
+        crypto: FakeNostrCrypto(),
+        backend: backend,
+        resendInterval: const Duration(milliseconds: 50),
+      );
+      addTearDown(sweeper.dispose);
+      backend.configuredRelays = ['wss://silent', 'wss://slowpoke', 'wss://c'];
+      backend.connected = ['wss://silent', 'wss://slowpoke', 'wss://c'];
+      backend.onPublish = (url, event) {
+        if (url == 'wss://silent') return silent.future;
+        // c accepts, so the publish itself succeeds; slowpoke refuses, which
+        // keeps the state pending and the sweep running.
+        return Future<bool>.value(url == 'wss://c');
+      };
+
+      // Act
+      await sweeper.publishEvent(_event(tags: [
+        ['d', 'abcd'],
+      ]));
+      final afterPublish = backend.publishes.length;
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // Assert — slowpoke was reached even though silent never answered
+      final resent = backend.publishes.skip(afterPublish).map((p) => p.$1);
+      expect(resent, contains('wss://slowpoke'));
     });
   });
 


### PR DESCRIPTION
Follow-up to #129. That PR fixed a *silent* relay blocking the outbox; this one fixes what the relay probing actually found.

## Measured, not guessed

Bursts of kind 31415 addressable events over a single persistent connection (throwaway key, `expiration` at 1h), the same shape the app publishes:

| Relay | Accepted | Relay message |
|---|---|---|
| `wss://relay.mostro.network` | **5 / 12** | `rate-limited: allowed kinds: max 5 events per minute per IP` |
| `wss://nos.lol` | 25 / 25 | — (~340 ms/event) |
| `wss://relay.primal.net` | 12 / 12 | — |
| `wss://relay.damus.io` | 0 | `status 503`, would not connect |

A match publishes one addressable event per tap. Five is spent in seconds, after which mostro refuses everything and the remote scoreboard stops moving — which is exactly the "events are not real time" symptom.

## Changes

1. **`relay.mostro.network` out of both default lists**, `relay.primal.net` in (`relay_config_provider.dart`, `nostr_service.dart`). It is a Mostro P2P relay; a live scoreboard is not what it is for.
2. **Backoff in the resend sweep.** It retried on a flat 5s heartbeat forever, feeding a rate-limited relay the very requests that keep its limit spent. The interval now doubles per fully-unaccepted sweep, capped at the new `maxResendInterval` (1 min). Any acceptance, or a reconnect, resets it.
3. **Concurrent sweep.** `_resendPendingTo` was awaited per relay in a loop, so a relay that never answers held up every relay behind it for as long as the transport waits for an OK (10s). Relays are swept together now.

## Not changed: `nextCreatedAt` drift

Verified, and I am deliberately leaving it alone — the available fixes are worse than the issue.

`nextCreatedAt` returns `last + 1` on a same-second collision, so a burst can stamp events ahead of the wall clock. Capping the drift would produce *ties*, and NIP-01 breaks a replaceable-event tie by lowest id — so the relay could keep the **older** event, and resending the same event would never win. That is the stale-scoreboard bug the monotonic counter was introduced to prevent.

The exposure is small: publishes are serialised by the outbox and gated on a relay round trip (~340 ms measured), so drift grows ~2 s per second of *sustained* tapping and self-heals the moment the wall clock catches up. Common relay limits are far away (strfry's default `maxTimestampDelta` is 900 s).

## Caveat worth knowing

Defaults only apply to **fresh installs**. Existing installs keep the relay list already in secure storage, so anyone with mostro configured must remove it in Relay Management (or hit reset-to-defaults). A migration that strips it automatically is possible — say the word and I will add it.

## Test plan

- [x] Two new cases in `nostr_service_behavior_test.dart`. Pre-fix they failed with `sweep did not back off: 7 resends in 400ms` and `Actual: ['wss://silent']` (the concurrent sweep never reached the relay behind the silent one).
- [x] Default-relay assertions updated in `nostr_service_behavior_test.dart`, `relay_management_screen_test.dart`, `relay_config_provider_test.dart`.
- [x] `flutter test` — 506 passed.
- [x] `flutter analyze` — 61 issues, unchanged from main; none new.
- [ ] Manual: run a match, watch kind 31415 with `nostreq`, confirm scores land on each press.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the default relay selection for new installations to include Primal and Nos.lol.
  * Improved event delivery reliability by retrying missed updates across connected relays.
  * Added adaptive retry timing to reduce repeated attempts when relays are unavailable.
  * Relay reconnections now trigger prompt delivery of pending events.

* **Bug Fixes**
  * Improved handling of relays that reject or fail to receive event updates.
  * Resend attempts now continue independently across relays, preventing one unresponsive relay from blocking others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->