### PR TITLE
feat: read-only scoreboard section, with shared links that open it

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,35 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <!-- Shared board links open the app instead of the browser.
+                 A link someone shares from Account is a plain
+                 https://bjjscore.live/?npub=... URL, so it stays useful to
+                 people who do not have the app: they get the web board, which
+                 is the behaviour this replaces only for those who do.
+
+                 android:autoVerify makes Android check
+                 https://bjjscore.live/.well-known/assetlinks.json for this
+                 package and signing certificate at install time. WITHOUT that
+                 file being served, Android 12+ will NOT open the app for these
+                 links — it falls back to the browser and the user has to enable
+                 the link manually in system settings. See
+                 docs/deep-links.md. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="bjjscore.live"/>
+            </intent-filter>
         </activity>
+
+        <!-- Hand the incoming link to the framework rather than only launching
+             the activity, which is what makes it reach the Dart side as route
+             information (WidgetsBindingObserver.didPushRouteInformation, and
+             platformDispatcher.defaultRouteName on a cold start). -->
+        <meta-data
+            android:name="flutter_deeplinking_enabled"
+            android:value="true" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,7 +42,13 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" android:host="bjjscore.live"/>
+                <!-- The root only. Without a path this would claim every URL
+                     on the site, /match/<id> included — and those the app
+                     cannot render: the parser finds no pubkey, nothing happens,
+                     and the page the user asked for is neither shown here nor
+                     handed back to the browser. -->
+                <data android:scheme="https" android:host="bjjscore.live"
+                      android:path="/"/>
             </intent-filter>
         </activity>
 

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -1,0 +1,118 @@
+# Shared board links
+
+Sharing a pubkey from Account produces an ordinary web link:
+
+```
+https://bjjscore.live/?npub=npub1…
+```
+
+One link, two destinations. Someone without the app opens the web board, which
+is what has always happened and still does. Someone **with** the app gets the
+app, on the Scoreboard section, already watching that pubkey.
+
+That is deliberate: a link that only worked for people who had already installed
+the app would be useless for sharing, which is the only reason it exists.
+
+## What the app does
+
+`lib/services/deep_links/share_link.dart` reads the pubkey out of the URL and
+`main.dart` acts on it:
+
+- **Cold start** — `platformDispatcher.defaultRouteName`, read after the first
+  frame (the providers it writes to must not be touched mid-build).
+- **Already running** — `WidgetsBindingObserver.didPushRouteInformation`.
+
+Both need the platform to hand the link to the framework rather than merely
+launching the activity, which is what `flutter_deeplinking_enabled` does in the
+Android manifest.
+
+The accepted parameters are `npub` and `pubkey`, holding either an `npub1…` or
+64-character hex — the same pair choke-scoreboard accepts (`SHARE_PUBKEY_PARAMS`
+in its `share-link.ts`), because the same URL is opened by whichever of the two
+the recipient has.
+
+A link for any other host is ignored. So is one that names no usable key: the
+app keeps whatever board the user was already watching rather than dropping them
+on an empty one.
+
+## What still has to be served — Android
+
+**Until this file exists, the feature does not work on Android 12 or newer.**
+The intent filter is marked `android:autoVerify="true"`, and Android checks it
+at install time. If the check fails, https links are *not* handed to the app —
+they open the browser, and the only way to change that is for the user to go
+into system settings and enable the link by hand. There is no error and nothing
+in the app to see; it simply never opens.
+
+Serve this at **`https://bjjscore.live/.well-known/assetlinks.json`**, as
+`application/json`, over https, with no redirect:
+
+```json
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "io.protolayer.choke",
+      "sha256_cert_fingerprints": [
+        "PUT:THE:RELEASE:FINGERPRINT:HERE"
+      ]
+    }
+  }
+]
+```
+
+The fingerprint is of the certificate the APK is **signed** with, not of
+anything in this repository:
+
+```sh
+keytool -list -v -keystore <release.keystore> -alias <alias> | grep 'SHA256:'
+```
+
+Two things that catch people out:
+
+- **Play App Signing re-signs the app.** If it is distributed through Google
+  Play, the fingerprint that matters is the one Play shows under *Release →
+  Setup → App signing*, not the upload key's. Both can be listed; the array
+  takes several.
+- **The debug build is a different package.** `applicationIdSuffix = ".debug"`
+  makes debug builds `io.protolayer.choke.debug`, which the entry above does not
+  cover. Add a second object for it, with the debug keystore's fingerprint, if
+  links need to work in a debug build.
+
+Verify on a device:
+
+```sh
+adb shell pm get-app-links io.protolayer.choke
+# force a re-check
+adb shell pm verify-app-links --re-verify io.protolayer.choke
+```
+
+`verified` is what you want. `legacy_failure` or an empty result means the JSON
+was not fetched or did not match.
+
+Manual test with the app installed:
+
+```sh
+adb shell am start -a android.intent.action.VIEW \
+  -d "https://bjjscore.live/?npub=npub1…"
+```
+
+## What still has to be done — iOS
+
+iOS is **not wired**. Nothing here touches it, and the release workflow builds
+only an APK and an App Bundle, so this was left alone rather than half-done.
+
+For the record, it needs all three:
+
+1. The `com.apple.developer.associated-domains` entitlement on the Runner target
+   with `applinks:bjjscore.live`, added through Xcode so the target and the
+   provisioning profile agree.
+2. `https://bjjscore.live/.well-known/apple-app-site-association` — JSON, no
+   file extension, `application/json`, no redirect — naming
+   `TEAMID.io.protolayer.choke`.
+3. A rebuild and reinstall. iOS fetches the association at install time and does
+   not retry on its own.
+
+The Dart side needs nothing: Universal Links arrive at
+`didPushRouteInformation` too.

--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
+
+import '../../services/nostr/nostr_service.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../services/key_management/key_manager.dart';
@@ -15,6 +17,20 @@ const String kLiveBoardBaseUrl = 'https://bjjscore.live';
 
 /// Build the share link for an organizer's npub.
 String liveBoardShareUrl(String npub) => '$kLiveBoardBaseUrl/?npub=$npub';
+
+/// Point the relays and the home feed at the identity that is now stored.
+///
+/// Best-effort on purpose. The key has already been written by the time this
+/// runs, so a relay that will not take the new subscription must not turn a
+/// successful import into a failed one — and the next launch resubscribes from
+/// scratch anyway.
+Future<void> _refreshIdentity(WidgetRef ref) async {
+  try {
+    await ref.read(nostrServiceProvider).refreshIdentity();
+  } catch (e) {
+    debugPrint('Account: identity changed but the resubscribe failed: $e');
+  }
+}
 
 class AccountScreen extends ConsumerStatefulWidget {
   const AccountScreen({super.key});
@@ -153,6 +169,12 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                         final keyManager = ref.read(keyManagerProvider);
                         final success = await keyManager.importFromNsec(nsec);
 
+                        // The relays are still following the old identity, and
+                        // the home feed still believes it is this user's. Move
+                        // both across, or the app quietly stops showing the
+                        // matches it is about to publish.
+                        if (success) await _refreshIdentity(ref);
+
                         if (!mounted || !dialogBuildContext.mounted) return;
 
                         setDialogState(() => dialogImporting = false);
@@ -244,6 +266,7 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
                         try {
                           final keyManager = ref.read(keyManagerProvider);
                           await keyManager.generateNewKeypair();
+                          await _refreshIdentity(ref);
                         } catch (_) {
                           // Not logging the exception object: it was raised
                           // while handling freshly generated key material, so

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -2,23 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../shared/theme/app_theme.dart';
+import '../../shared/widgets/match_card.dart';
 import '../match/create_match_screen.dart';
 import '../match/match_control_screen.dart';
 import '../match/models/match.dart';
-import '../match/widgets/outcome_label.dart';
 import '../match/providers/match_control_provider.dart';
 import 'providers/home_providers.dart';
-
-/// Parse hex color string (#RRGGBB) to Color with fallback
-Color _hexToColor(String hex, Color fallback) {
-  try {
-    final h = hex.replaceFirst('#', '');
-    if (h.length != 6) return fallback;
-    return Color(int.parse('FF$h', radix: 16));
-  } catch (_) {
-    return fallback;
-  }
-}
 
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
@@ -114,7 +103,20 @@ class HomeScreen extends ConsumerWidget {
                         final match = filteredMatches[index];
                         return Padding(
                           padding: const EdgeInsets.only(bottom: 11),
-                          child: _buildMatchCard(context, ref, match, tk),
+                          child: MatchCard(
+                            match: match,
+                            onTap: () {
+                              ref.read(activeMatchProvider.notifier).state =
+                                  match;
+                              ref.invalidate(matchControlProvider);
+                              Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) =>
+                                      MatchControlScreen(match: match),
+                                ),
+                              );
+                            },
+                          ),
                         );
                       },
                     ),
@@ -179,12 +181,12 @@ class HomeScreen extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     final isSelected = selected.contains(status);
     final count = allMatches.where((m) => m.status == status).length;
-    final color = _statusAccent(tk, status);
+    final color = matchStatusAccent(tk, status);
 
     return Semantics(
       button: true,
       selected: isSelected,
-      label: '${_statusLabel(l10n, status)}: $count',
+      label: '${matchStatusLabel(l10n, status)}: $count',
       child: GestureDetector(
         onTap: () {
           final current = Set<MatchStatus>.from(ref.read(statusFilterProvider));
@@ -217,7 +219,7 @@ class HomeScreen extends ConsumerWidget {
               ),
               const SizedBox(width: 8),
               Text(
-                _statusLabel(l10n, status),
+                matchStatusLabel(l10n, status),
                 style: TextStyle(
                   color: isSelected ? color : tk.muted,
                   fontSize: 13,
@@ -277,298 +279,4 @@ class HomeScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildMatchCard(
-      BuildContext context, WidgetRef ref, Match match, ChokeTokens tk) {
-    final l10n = AppLocalizations.of(context);
-    final colors = Theme.of(context).colorScheme;
-    final f1Color = _hexToColor(match.f1Color, colors.outline);
-    final f2Color = _hexToColor(match.f2Color, colors.outline);
-    final isLive = match.status == MatchStatus.inProgress;
-    final isCanceled = match.status == MatchStatus.canceled;
-
-    final card = Container(
-      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
-      decoration: BoxDecoration(
-        gradient: isLive
-            ? LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  tk.accent.withOpacity(.12),
-                  tk.accent.withOpacity(.03),
-                ],
-              )
-            : null,
-        color: isLive ? null : tk.card,
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(
-          color: isLive ? tk.accent.withOpacity(.45) : tk.cardBorder,
-        ),
-      ),
-      child: Column(
-        children: [
-          // Top row: match ID + status chip
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                '#${match.id}',
-                style: TextStyle(
-                  color: tk.faint,
-                  fontSize: 12,
-                  fontFamily: 'monospace',
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              _buildStatusChip(context, match.status, tk),
-            ],
-          ),
-          const SizedBox(height: 11),
-          // Fighters + score row
-          Row(
-            children: [
-              Expanded(
-                child: Row(
-                  children: [
-                    Container(
-                      width: 9,
-                      height: 9,
-                      decoration:
-                          BoxDecoration(color: f1Color, shape: BoxShape.circle),
-                    ),
-                    const SizedBox(width: 9),
-                    Flexible(
-                      child: Text(
-                        match.f1Name,
-                        style: TextStyle(
-                          color: colors.onSurface,
-                          fontWeight: FontWeight.w600,
-                          fontSize: 16,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    if (match.f1EffectiveAdvantages > 0) ...[
-                      const SizedBox(width: 6),
-                      _buildSmallBadge(
-                        'A:${match.f1EffectiveAdvantages}',
-                        tk.goldFg,
-                      ),
-                    ],
-                    if (match.f1Pen > 0) ...[
-                      const SizedBox(width: 4),
-                      _buildSmallBadge('P:${match.f1Pen}', tk.dangerFg),
-                    ],
-                  ],
-                ),
-              ),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.baseline,
-                textBaseline: TextBaseline.alphabetic,
-                children: [
-                  Text(
-                    '${match.f1EffectivePoints}',
-                    style: TextStyle(
-                      color: _isWinning(match, MatchWinner.f1, isCanceled)
-                          ? tk.accent
-                          : tk.muted,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 27,
-                      height: 1,
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 9),
-                    child: Text(
-                      l10n.vs,
-                      style: TextStyle(fontSize: 12, color: tk.faint),
-                    ),
-                  ),
-                  Text(
-                    '${match.f2EffectivePoints}',
-                    style: TextStyle(
-                      color: _isWinning(match, MatchWinner.f2, isCanceled)
-                          ? tk.accent
-                          : tk.muted,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 27,
-                      height: 1,
-                    ),
-                  ),
-                ],
-              ),
-              Expanded(
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    if (match.f2EffectiveAdvantages > 0) ...[
-                      _buildSmallBadge(
-                        'A:${match.f2EffectiveAdvantages}',
-                        tk.goldFg,
-                      ),
-                      const SizedBox(width: 6),
-                    ],
-                    if (match.f2Pen > 0) ...[
-                      _buildSmallBadge('P:${match.f2Pen}', tk.dangerFg),
-                      const SizedBox(width: 4),
-                    ],
-                    Flexible(
-                      child: Text(
-                        match.f2Name,
-                        textAlign: TextAlign.right,
-                        style: TextStyle(
-                          color: colors.onSurface,
-                          fontWeight: FontWeight.w600,
-                          fontSize: 16,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    const SizedBox(width: 9),
-                    Container(
-                      width: 9,
-                      height: 9,
-                      decoration:
-                          BoxDecoration(color: f2Color, shape: BoxShape.circle),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-
-          // How it ended — because the scoreboard above cannot say. A match
-          // that finished on a submission shows the loser's numbers as the
-          // bigger ones, and only this line names the fighter who actually won.
-          if (describeOutcome(l10n, match) case final outcome?) ...[
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                Icon(Icons.emoji_events_outlined, size: 13, color: tk.goldFg),
-                const SizedBox(width: 6),
-                Expanded(
-                  child: Text(
-                    outcome,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w600,
-                      color: tk.goldFg,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
-    );
-
-    return InkWell(
-      onTap: () {
-        ref.read(activeMatchProvider.notifier).state = match;
-        ref.invalidate(matchControlProvider);
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (_) => MatchControlScreen(match: match),
-          ),
-        );
-      },
-      borderRadius: BorderRadius.circular(18),
-      child: isCanceled ? Opacity(opacity: .72, child: card) : card,
-    );
-  }
-
-  Widget _buildStatusChip(
-      BuildContext context, MatchStatus status, ChokeTokens tk) {
-    final l10n = AppLocalizations.of(context);
-    final (fg, bg) = switch (status) {
-      MatchStatus.waiting => (tk.goldFg, tk.goldFg.withOpacity(.14)),
-      MatchStatus.inProgress => (tk.accent, tk.accent.withOpacity(.2)),
-      MatchStatus.finished => (tk.statusFinishedFg, tk.statusFinishedBg),
-      MatchStatus.canceled => (tk.statusCanceledFg, tk.statusCanceledBg),
-    };
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 4),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(99),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (status == MatchStatus.inProgress) ...[
-            Container(
-              width: 6,
-              height: 6,
-              decoration: BoxDecoration(color: fg, shape: BoxShape.circle),
-            ),
-            const SizedBox(width: 6),
-          ],
-          Text(
-            _statusLabel(l10n, status),
-            style: TextStyle(
-              color: fg,
-              fontSize: 11.5,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Whether to light this fighter's number up.
-  ///
-  /// A finished match names its winner, and that name is the only thing worth
-  /// believing: Bob can lead 4–0 and still lose to an armbar. Only while a
-  /// match is undecided does the scoreboard get to speak for itself — and a
-  /// canceled match has no winner at all.
-  bool _isWinning(Match match, MatchWinner fighter, bool isCanceled) {
-    if (isCanceled) return false;
-
-    final winner = match.winner;
-    if (winner != null) return winner == fighter;
-    if (match.method != null) return false; // a draw: nobody won
-
-    return match.scoreboardWinner == fighter;
-  }
-
-  Widget _buildSmallBadge(String text, Color color) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(
-        color: color.withOpacity(0.14),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-          color: color,
-          fontSize: 10.5,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
-
-  Color _statusAccent(ChokeTokens tk, MatchStatus status) {
-    return switch (status) {
-      MatchStatus.waiting => tk.goldFg,
-      MatchStatus.inProgress => tk.accent,
-      MatchStatus.finished => tk.statusFinishedFg,
-      MatchStatus.canceled => tk.statusCanceledFg,
-    };
-  }
-
-  String _statusLabel(AppLocalizations l10n, MatchStatus status) {
-    return switch (status) {
-      MatchStatus.waiting => l10n.statusWaiting,
-      MatchStatus.inProgress => l10n.statusInProgress,
-      MatchStatus.finished => l10n.statusFinished,
-      MatchStatus.canceled => l10n.statusCanceled,
-    };
-  }
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
+import '../../shared/widgets/status_filter_bar.dart';
 import '../match/create_match_screen.dart';
 import '../match/match_control_screen.dart';
 import '../match/models/match.dart';
@@ -83,8 +84,11 @@ class HomeScreen extends ConsumerWidget {
             // Status filter cards
             Padding(
               padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
-              child:
-                  _buildStatusCards(context, ref, statusFilter, allMatches, tk),
+              child: StatusFilterBar(
+                matches: allMatches,
+                selected: statusFilter,
+                onToggle: (status) => _toggleStatus(ref, status),
+              ),
             ),
 
             // Match list
@@ -153,93 +157,10 @@ class HomeScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildStatusCards(
-    BuildContext context,
-    WidgetRef ref,
-    Set<MatchStatus> selected,
-    List<Match> allMatches,
-    ChokeTokens tk,
-  ) {
-    return Wrap(
-      spacing: 8,
-      runSpacing: 8,
-      children: [
-        for (final status in MatchStatus.values)
-          _buildStatusCard(context, ref, status, selected, allMatches, tk),
-      ],
-    );
-  }
-
-  Widget _buildStatusCard(
-    BuildContext context,
-    WidgetRef ref,
-    MatchStatus status,
-    Set<MatchStatus> selected,
-    List<Match> allMatches,
-    ChokeTokens tk,
-  ) {
-    final l10n = AppLocalizations.of(context);
-    final isSelected = selected.contains(status);
-    final count = allMatches.where((m) => m.status == status).length;
-    final color = matchStatusAccent(tk, status);
-
-    return Semantics(
-      button: true,
-      selected: isSelected,
-      label: '${matchStatusLabel(l10n, status)}: $count',
-      child: GestureDetector(
-        onTap: () {
-          final current = Set<MatchStatus>.from(ref.read(statusFilterProvider));
-          if (isSelected) {
-            current.remove(status);
-          } else {
-            current.add(status);
-          }
-          ref.read(statusFilterProvider.notifier).state = current;
-        },
-        child: Container(
-          // Enforce the 44px minimum interactive height for an accessible tap
-          // target; the visible layout and styling stay compact.
-          constraints: const BoxConstraints(minHeight: 44),
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          decoration: BoxDecoration(
-            color: isSelected ? color.withOpacity(.12) : tk.card,
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: isSelected ? color.withOpacity(.5) : tk.cardBorder,
-            ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 8,
-                height: 8,
-                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                matchStatusLabel(l10n, status),
-                style: TextStyle(
-                  color: isSelected ? color : tk.muted,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-              const SizedBox(width: 6),
-              Text(
-                '$count',
-                style: TextStyle(
-                  color: count > 0 ? color : tk.faint,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
+  void _toggleStatus(WidgetRef ref, MatchStatus status) {
+    final current = Set<MatchStatus>.from(ref.read(statusFilterProvider));
+    if (!current.remove(status)) current.add(status);
+    ref.read(statusFilterProvider.notifier).state = current;
   }
 
   Widget _buildEmptyState(BuildContext context) {

--- a/lib/features/home/providers/home_providers.dart
+++ b/lib/features/home/providers/home_providers.dart
@@ -33,13 +33,13 @@ class MatchFeedNotifier extends StateNotifier<List<Match>> {
     // the scoreboard section — which subscribes to whatever pubkey the user
     // pastes, on purpose — would file other people's matches in here.
     //
-    // A null pubkey means the app has not looked itself up yet, which only
-    // happens before `subscribeToUserEvents`, when this user's is the only
-    // subscription there is. Accepting during that window is safe; dropping
-    // would throw away the user's own opening events, because a relay does not
-    // send them again.
+    // Fail closed. There is no benign startup window here: main awaits
+    // subscribeToUserEvents before runApp, so by the time anything can arrive
+    // the key is either known or its lookup failed and was caught. A null
+    // pubkey is therefore the *error* path — and that is exactly when letting
+    // everything through would file a watched organizer's matches in here.
     final me = _nostrService.userPubkey;
-    if (me != null && event.pubkey != me) return;
+    if (me == null || event.pubkey != me) return;
 
     try {
       final match = Match.fromNostrEvent(event);

--- a/lib/features/home/providers/home_providers.dart
+++ b/lib/features/home/providers/home_providers.dart
@@ -28,6 +28,19 @@ class MatchFeedNotifier extends StateNotifier<List<Match>> {
   void _onEvent(NostrEvent event) {
     if (event.kind != 31415) return;
 
+    // This feed is *my* matches. The event stream is shared by every
+    // subscription and says nothing about which filter matched, so without this
+    // the scoreboard section — which subscribes to whatever pubkey the user
+    // pastes, on purpose — would file other people's matches in here.
+    //
+    // A null pubkey means the app has not looked itself up yet, which only
+    // happens before `subscribeToUserEvents`, when this user's is the only
+    // subscription there is. Accepting during that window is safe; dropping
+    // would throw away the user's own opening events, because a relay does not
+    // send them again.
+    final me = _nostrService.userPubkey;
+    if (me != null && event.pubkey != me) return;
+
     try {
       final match = Match.fromNostrEvent(event);
       _upsert(match, event.createdAt);

--- a/lib/features/match/models/match.dart
+++ b/lib/features/match/models/match.dart
@@ -441,6 +441,26 @@ class Match {
     }
   }
 
+  /// Seconds left on the clock as of [nowSeconds] (unix seconds).
+  ///
+  /// The clock is derived, never stored, so that everyone reading this match —
+  /// the referee scoring it, a spectator watching it on the scoreboard — gets
+  /// the same time out of the same event without either of them counting.
+  ///
+  /// A stoppage is charged to [startAt], which moves forward by its length, so
+  /// elapsed time is simply now minus start. While [pausedAt] is set the clock
+  /// reads what it read when it stopped.
+  int remainingSecondsAt(int nowSeconds) {
+    if (status == MatchStatus.waiting) return duration;
+    if (startAt == null || startAt == 0) return duration;
+
+    final elapsed = (pausedAt ?? nowSeconds) - startAt!;
+    return (duration - elapsed).clamp(0, duration);
+  }
+
+  /// The match is under way but its clock is stopped.
+  bool get isPaused => status == MatchStatus.inProgress && pausedAt != null;
+
   /// Calculate total score for fighter 1
   /// Formula: pt2*2 + pt3*3 + pt4*4
   int get f1Score => f1Pt2 * 2 + f1Pt3 * 3 + f1Pt4 * 4;

--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -141,18 +141,11 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
     }
   }
 
-  static int _calculateRemaining(Match match) {
-    if (match.status == MatchStatus.waiting) {
-      return match.duration;
-    }
-    if (match.startAt == null || match.startAt == 0) {
-      return match.duration;
-    }
-    // While paused the clock reads as it did at the moment it was stopped.
-    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final elapsed = (match.pausedAt ?? now) - match.startAt!;
-    return (match.duration - elapsed).clamp(0, match.duration);
-  }
+  /// The clock lives on [Match], so that this screen and the read-only
+  /// scoreboard cannot drift into telling two different times.
+  static int _calculateRemaining(Match match) => match.remainingSecondsAt(
+        DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
 
   /// Start the match: set status to inProgress, set startAt, start timer
   void startMatch() {

--- a/lib/features/scoreboard/providers/scoreboard_providers.dart
+++ b/lib/features/scoreboard/providers/scoreboard_providers.dart
@@ -101,10 +101,26 @@ class ScoreboardFeedNotifier extends StateNotifier<List<Match>> {
 
   StreamSubscription<NostrEvent>? _subscription;
 
-  /// Deliberately not the id [NostrService.subscribeToAuthor] picks by default,
-  /// so that closing this one can never close a subscription another part of the
-  /// app opened for the same author.
-  String get _subscriptionId => 'scoreboard_$_pubkey';
+  /// A NIP-01 subscription id is capped at 64 characters, and a relay that gets
+  /// a longer one rejects the whole REQ — nos.lol answers
+  /// `CLOSED … "ERROR: bad req: invalid subscription id"` and sends nothing.
+  /// `scoreboard_` plus a 64-character pubkey is 75, which is how this shipped
+  /// broken: publishing worked, the app's own `user_events` worked, and the
+  /// scoreboard silently received nothing at all.
+  ///
+  /// Still derived from the pubkey rather than a constant, so that a departing
+  /// feed cannot close the subscription an arriving one just opened. Sixteen hex
+  /// characters is 64 bits of the key — far more than enough to tell two watched
+  /// authors apart.
+  static const _idPrefix = 'sb_';
+  static const _idKeyChars = 16;
+
+  String get _subscriptionId {
+    final key = _pubkey ?? '';
+    final short =
+        key.length <= _idKeyChars ? key : key.substring(0, _idKeyChars);
+    return '$_idPrefix$short';
+  }
 
   /// Newest event seen per match, so a relay replaying an older revision of an
   /// addressable event cannot undo a newer one.

--- a/lib/features/scoreboard/providers/scoreboard_providers.dart
+++ b/lib/features/scoreboard/providers/scoreboard_providers.dart
@@ -32,13 +32,21 @@ class WatchedPubkeyNotifier extends StateNotifier<String?> {
     unawaited(_restore());
   }
 
+  /// Whether the user has chosen anything yet — including choosing to stop.
+  ///
+  /// Tracked rather than inferred from [state] being null, because "nobody has
+  /// chosen" and "somebody chose to stop watching" are both null, and a restore
+  /// still in flight would read the second as the first and put the board they
+  /// just closed back on the screen.
+  bool _userHasChosen = false;
+
   Future<void> _restore() async {
     try {
       final prefs = await SharedPreferences.getInstance();
       final saved = prefs.getString(_kScoreboardPubkeyKey);
       // Only if nothing has been chosen in the meantime: restoring asynchronously
       // must never overwrite a key the user pasted while it was in flight.
-      if (saved != null && saved.isNotEmpty && state == null) {
+      if (saved != null && saved.isNotEmpty && !_userHasChosen) {
         state = saved;
       }
     } catch (e) {
@@ -50,6 +58,7 @@ class WatchedPubkeyNotifier extends StateNotifier<String?> {
 
   /// Watch [hexPubkey]. Pass null to stop watching and forget it.
   Future<void> watch(String? hexPubkey) async {
+    _userHasChosen = true;
     state = hexPubkey;
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -91,6 +100,17 @@ class ScoreboardFeedNotifier extends StateNotifier<List<Match>> {
 
     _subscription = _nostrService.eventStream.listen(_onEvent);
     _nostrService.subscribeToAuthor(_pubkey, subscriptionId: _subscriptionId);
+
+    // Start from what the app has already seen of this author.
+    //
+    // Watching someone, leaving, and watching them again used to show an empty
+    // board forever: the relay replays their latest state, but the service has
+    // it cached and drops a replay it considers no newer, so nothing reached a
+    // feed that had just started from nothing. It would stay empty until that
+    // author happened to score again.
+    for (final event in _nostrService.cachedEventsOf(31415, _pubkey)) {
+      _onEvent(event);
+    }
   }
 
   final NostrService _nostrService;

--- a/lib/features/scoreboard/providers/scoreboard_providers.dart
+++ b/lib/features/scoreboard/providers/scoreboard_providers.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../services/nostr/crypto/nostr_crypto.dart';
+import '../../../services/nostr/nostr_service.dart';
+import '../../match/models/match.dart';
+
+const _kScoreboardPubkeyKey = 'choke:scoreboard-pubkey';
+
+/// How old a match may be and still be worth showing, matching the home feed.
+///
+/// A scoreboard is about what is happening on the mats now. Yesterday's matches
+/// are history, and history belongs to whoever refereed it.
+const scoreboardMaxAgeSeconds = 86400;
+
+/// The pubkey whose matches the scoreboard is watching, in hex, or null when the
+/// user has not named one yet.
+///
+/// Persisted, because someone watching a tournament reopens the app between
+/// matches and should not have to paste the same key again.
+final watchedPubkeyProvider =
+    StateNotifierProvider<WatchedPubkeyNotifier, String?>((ref) {
+  return WatchedPubkeyNotifier();
+});
+
+/// Holds the watched pubkey and remembers it across launches.
+class WatchedPubkeyNotifier extends StateNotifier<String?> {
+  WatchedPubkeyNotifier() : super(null) {
+    unawaited(_restore());
+  }
+
+  Future<void> _restore() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final saved = prefs.getString(_kScoreboardPubkeyKey);
+      // Only if nothing has been chosen in the meantime: restoring asynchronously
+      // must never overwrite a key the user pasted while it was in flight.
+      if (saved != null && saved.isNotEmpty && state == null) {
+        state = saved;
+      }
+    } catch (e) {
+      // A device whose preferences cannot be read still watches matches; it just
+      // starts by asking for the pubkey again.
+      debugPrint('Scoreboard: could not restore the watched pubkey: $e');
+    }
+  }
+
+  /// Watch [hexPubkey]. Pass null to stop watching and forget it.
+  Future<void> watch(String? hexPubkey) async {
+    state = hexPubkey;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (hexPubkey == null) {
+        await prefs.remove(_kScoreboardPubkeyKey);
+      } else {
+        await prefs.setString(_kScoreboardPubkeyKey, hexPubkey);
+      }
+    } catch (e) {
+      debugPrint('Scoreboard: could not save the watched pubkey: $e');
+    }
+  }
+}
+
+/// Whether [value] is a bare 64-character hex key.
+bool isHexPubkey(String value) =>
+    RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(value.trim());
+
+/// The hex pubkey [input] names, whether the user pasted hex or an `npub1…`, or
+/// null if it is neither.
+///
+/// Hex is checked first, and by shape. The shape is the only thing that tells
+/// the two forms apart, which is why [NostrCrypto.npubDecode] refuses to guess
+/// and this function has to decide before asking it.
+String? parsePubkey(String input, NostrCrypto crypto) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) return null;
+  if (isHexPubkey(trimmed)) return trimmed.toLowerCase();
+  return crypto.npubDecode(trimmed);
+}
+
+/// Matches published by the watched pubkey, newest first.
+///
+/// Read-only by construction: this notifier subscribes and parses, and has no
+/// way to change a match. The scoreboard is for watching somebody else's mats.
+class ScoreboardFeedNotifier extends StateNotifier<List<Match>> {
+  ScoreboardFeedNotifier(this._nostrService, this._pubkey) : super([]) {
+    if (_pubkey == null) return;
+
+    _subscription = _nostrService.eventStream.listen(_onEvent);
+    _nostrService.subscribeToAuthor(_pubkey, subscriptionId: _subscriptionId);
+  }
+
+  final NostrService _nostrService;
+
+  /// The author being watched, in hex. Null means nothing is being watched and
+  /// this notifier does nothing at all.
+  final String? _pubkey;
+
+  StreamSubscription<NostrEvent>? _subscription;
+
+  /// Deliberately not the id [NostrService.subscribeToAuthor] picks by default,
+  /// so that closing this one can never close a subscription another part of the
+  /// app opened for the same author.
+  String get _subscriptionId => 'scoreboard_$_pubkey';
+
+  /// Newest event seen per match, so a relay replaying an older revision of an
+  /// addressable event cannot undo a newer one.
+  final Map<String, int> _createdAt = {};
+
+  void _onEvent(NostrEvent event) {
+    if (event.kind != 31415) return;
+
+    // The stream is shared with the user's own subscription and with any other
+    // author, and carries no hint of which filter matched. Without this the
+    // user's own matches would appear as though the watched pubkey had refereed
+    // them.
+    if (event.pubkey != _pubkey) return;
+
+    try {
+      _upsert(Match.fromNostrEvent(event), event.createdAt);
+    } catch (e) {
+      debugPrint('Scoreboard: failed to parse event: $e');
+    }
+  }
+
+  void _upsert(Match match, int createdAt) {
+    final seen = _createdAt[match.id];
+    if (seen != null && createdAt < seen) return;
+    _createdAt[match.id] = createdAt;
+
+    final index = state.indexWhere((m) => m.id == match.id);
+    if (index >= 0) {
+      final next = List<Match>.from(state);
+      next[index] = match;
+      state = next;
+    } else {
+      state = [match, ...state];
+    }
+  }
+
+  /// When the event carrying [matchId] was published, or null if unseen.
+  int? createdAtOf(String matchId) => _createdAt[matchId];
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    // Leave the relays alone about an author nobody is watching any more. Without
+    // this, every pubkey the user ever tried keeps streaming for the rest of the
+    // session.
+    if (_pubkey != null) _nostrService.unsubscribe(_subscriptionId);
+    super.dispose();
+  }
+}
+
+/// The live feed for whichever pubkey is being watched.
+///
+/// Rebuilt when the pubkey changes, which is what tears down the old
+/// subscription and opens the new one.
+final scoreboardFeedProvider =
+    StateNotifierProvider<ScoreboardFeedNotifier, List<Match>>((ref) {
+  final nostrService = ref.watch(nostrServiceProvider);
+  final pubkey = ref.watch(watchedPubkeyProvider);
+  return ScoreboardFeedNotifier(nostrService, pubkey);
+});
+
+/// The watched pubkey's recent matches, live ones first.
+///
+/// Ordered here rather than by arrival: relays return events in whatever order
+/// they please, and a board that reshuffles itself as it loads cannot be read.
+final scoreboardMatchesProvider = Provider<List<Match>>((ref) {
+  final feed = ref.watch(scoreboardFeedProvider.notifier);
+  final matches = ref.watch(scoreboardFeedProvider);
+
+  final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  final cutoff = now - scoreboardMaxAgeSeconds;
+
+  final fresh = matches.where((m) {
+    final createdAt = feed.createdAtOf(m.id);
+    return createdAt == null || createdAt >= cutoff;
+  }).toList();
+
+  fresh.sort((a, b) {
+    // Live matches first: on a board, the fight in progress is the point.
+    final aLive = a.status == MatchStatus.inProgress;
+    final bLive = b.status == MatchStatus.inProgress;
+    if (aLive != bLive) return aLive ? -1 : 1;
+
+    final aAt = feed.createdAtOf(a.id) ?? 0;
+    final bAt = feed.createdAtOf(b.id) ?? 0;
+    return bAt.compareTo(aAt);
+  });
+
+  return fresh;
+});

--- a/lib/features/scoreboard/providers/scoreboard_providers.dart
+++ b/lib/features/scoreboard/providers/scoreboard_providers.dart
@@ -211,3 +211,29 @@ final scoreboardMatchesProvider = Provider<List<Match>>((ref) {
 
   return fresh;
 });
+
+/// Which statuses the scoreboard shows.
+///
+/// Its own, not the home feed's: hiding finished matches while watching
+/// somebody else's mats should not hide them on your own.
+///
+/// Defaults to what is happening now, the same as home — a board is about the
+/// mats in front of you, and yesterday's results are one tap away.
+final scoreboardStatusFilterProvider = StateProvider<Set<MatchStatus>>((ref) {
+  return {
+    MatchStatus.waiting,
+    MatchStatus.inProgress,
+  };
+});
+
+/// What the list actually shows: recent matches, minus the statuses filtered
+/// out.
+///
+/// Kept apart from [scoreboardMatchesProvider] because the chips count from
+/// *that* one. Counting from this would make every hidden status read zero,
+/// which is exactly the number that would talk the user out of tapping it.
+final scoreboardFilteredMatchesProvider = Provider<List<Match>>((ref) {
+  final matches = ref.watch(scoreboardMatchesProvider);
+  final allowed = ref.watch(scoreboardStatusFilterProvider);
+  return matches.where((m) => allowed.contains(m.status)).toList();
+});

--- a/lib/features/scoreboard/scoreboard_match_screen.dart
+++ b/lib/features/scoreboard/scoreboard_match_screen.dart
@@ -1,0 +1,753 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+import '../../shared/theme/app_theme.dart';
+import '../../shared/widgets/match_card.dart';
+import '../match/models/match.dart';
+import '../match/models/submission_catalog.dart';
+import '../match/widgets/outcome_label.dart';
+import 'providers/scoreboard_providers.dart';
+
+/// The wall display: one match, big enough to read from across a mat.
+///
+/// Landscape only. The layout is two halves side by side, one per fighter, and
+/// there is no honest way to fold that into a portrait phone — so the screen asks
+/// for the orientation it needs, the way a video player does, and gives it back
+/// on the way out.
+///
+/// Strictly read-only. It renders what the relays say and has no way to change
+/// it; the match belongs to whoever is refereeing it somewhere else.
+class ScoreboardMatchScreen extends ConsumerStatefulWidget {
+  const ScoreboardMatchScreen({super.key, required this.matchId});
+
+  /// Looked up by id on every build rather than passed in whole, so the screen
+  /// re-renders as revisions arrive. Handing it a [Match] would freeze the match
+  /// at the moment it was tapped.
+  final String matchId;
+
+  @override
+  ConsumerState<ScoreboardMatchScreen> createState() =>
+      _ScoreboardMatchScreenState();
+}
+
+class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
+  static const _background = Color(0xFF05070E);
+  static const _dim = Color(0x9E05070E);
+  static const _labelGrey = Color(0xFF5F6D8A);
+  static const _pillGrey = Color(0xFF8A97B2);
+
+  Timer? _ticker;
+
+  /// Now, in unix seconds, advanced once a second so the clock counts down.
+  ///
+  /// The match carries no clock — [Match.remainingSecondsAt] derives it — so
+  /// ticking "now" is the whole animation.
+  int _now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+    ]);
+
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      setState(() => _now = DateTime.now().millisecondsSinceEpoch ~/ 1000);
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    SystemChrome.setPreferredOrientations(DeviceOrientation.values);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final matches = ref.watch(scoreboardMatchesProvider);
+    final match = matches.where((m) => m.id == widget.matchId).firstOrNull;
+
+    if (match == null) return _buildGone(l10n);
+
+    return Scaffold(
+      backgroundColor: _background,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          // Everything scales off the height, so the board reads the same on a
+          // phone held sideways and on a tablet.
+          final unit = constraints.maxHeight / 100;
+          return Stack(
+            children: [
+              _buildHalf(context, l10n, match, unit, isF1: true),
+              _buildHalf(context, l10n, match, unit, isF1: false),
+              _buildLoserDim(match),
+              _buildCenter(context, l10n, match, unit),
+              _buildWinnerBanner(context, l10n, match, unit),
+              _buildBack(l10n),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  // ─── Fighter halves ─────────────────────────────────────────────────────
+
+  Widget _buildHalf(
+    BuildContext context,
+    AppLocalizations l10n,
+    Match match,
+    double unit, {
+    required bool isF1,
+  }) {
+    final colors = Theme.of(context).colorScheme;
+    final color = hexToColor(
+      isF1 ? match.f1Color : match.f2Color,
+      colors.outline,
+    );
+    final name = isF1 ? match.f1Name : match.f2Name;
+    final score = isF1 ? match.f1EffectivePoints : match.f2EffectivePoints;
+    final adv =
+        isF1 ? match.f1EffectiveAdvantages : match.f2EffectiveAdvantages;
+    final pen = isF1 ? match.f1Pen : match.f2Pen;
+    final breakdown = isF1
+        ? [match.f1Pt2, match.f1Pt3, match.f1Pt4]
+        : [match.f2Pt2, match.f2Pt3, match.f2Pt4];
+
+    return Align(
+      alignment: isF1 ? Alignment.centerLeft : Alignment.centerRight,
+      child: FractionallySizedBox(
+        widthFactor: 0.5,
+        child: Stack(
+          children: [
+            // Colour wash, fading toward the middle of the screen.
+            DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: isF1 ? Alignment.centerLeft : Alignment.centerRight,
+                  end: isF1 ? Alignment.centerRight : Alignment.centerLeft,
+                  colors: [
+                    color.withValues(alpha: .30),
+                    color.withValues(alpha: .05),
+                    Colors.transparent,
+                  ],
+                  stops: const [0, .55, .78],
+                ),
+              ),
+              child: const SizedBox.expand(),
+            ),
+            // The edge bar, and its glow.
+            Align(
+              alignment: isF1 ? Alignment.centerLeft : Alignment.centerRight,
+              child: Container(
+                width: 11,
+                decoration: BoxDecoration(
+                  color: color,
+                  boxShadow: [
+                    BoxShadow(
+                      color: color.withValues(alpha: .6),
+                      blurRadius: 50,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(
+                isF1 ? unit * 4 : unit * 2,
+                unit * 5,
+                isF1 ? unit * 2 : unit * 4,
+                unit * 5,
+              ),
+              child: Column(
+                children: [
+                  _buildName(name, color, unit),
+                  Expanded(child: Center(child: _buildScore(score, color, unit))),
+                  _buildBreakdown(l10n, breakdown, unit),
+                  SizedBox(height: unit * 2.5),
+                  _buildChips(l10n, adv, pen, unit),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildName(String name, Color color, double unit) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          width: unit * 2.6,
+          height: unit * 2.6,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(6),
+            boxShadow: [
+              BoxShadow(color: color.withValues(alpha: .6), blurRadius: 20),
+            ],
+          ),
+        ),
+        SizedBox(width: unit * 1.4),
+        Flexible(
+          child: Text(
+            name.toUpperCase(),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.w800,
+              fontSize: (unit * 7).clamp(14.0, 58.0),
+              letterSpacing: 1,
+              height: 1.1,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScore(int score, Color color, double unit) {
+    return Text(
+      '$score',
+      style: TextStyle(
+        color: Colors.white,
+        fontWeight: FontWeight.w900,
+        fontSize: (unit * 30).clamp(48.0, 232.0),
+        height: 1,
+        shadows: [Shadow(color: color.withValues(alpha: .6), blurRadius: 55)],
+      ),
+    );
+  }
+
+  Widget _buildBreakdown(AppLocalizations l10n, List<int> counts, double unit) {
+    const values = [2, 3, 4];
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        for (var i = 0; i < values.length; i++) ...[
+          if (i > 0) SizedBox(width: unit * 4),
+          Column(
+            children: [
+              Text(
+                l10n.scoreboardPointsShort(values[i]),
+                style: TextStyle(
+                  color: _labelGrey,
+                  fontWeight: FontWeight.bold,
+                  fontSize: (unit * 2).clamp(9.0, 19.0),
+                  letterSpacing: 1.6,
+                ),
+              ),
+              SizedBox(height: unit),
+              Text(
+                '${counts[i]}',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w800,
+                  fontSize: (unit * 4).clamp(16.0, 36.0),
+                  height: 1,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildChips(AppLocalizations l10n, int adv, int pen, double unit) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _buildCountChip(
+          l10n.scoreboardAdvShort,
+          adv,
+          const Color(0xFFF4B400),
+          const Color(0xFFFFD451),
+          unit,
+        ),
+        SizedBox(width: unit * 1.6),
+        _buildCountChip(
+          l10n.scoreboardPenShort,
+          pen,
+          const Color(0xFFF87171),
+          const Color(0xFFFCA5A5),
+          unit,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCountChip(
+    String label,
+    int count,
+    Color labelColor,
+    Color countColor,
+    double unit,
+  ) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: unit * 2, vertical: unit * 1.1),
+      decoration: BoxDecoration(
+        color: labelColor.withValues(alpha: .14),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: labelColor.withValues(alpha: .5)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: labelColor,
+              fontWeight: FontWeight.bold,
+              fontSize: (unit * 2.5).clamp(11.0, 24.0),
+              letterSpacing: 1,
+            ),
+          ),
+          SizedBox(width: unit * .9),
+          Text(
+            '$count',
+            style: TextStyle(
+              color: countColor,
+              fontWeight: FontWeight.w800,
+              fontSize: (unit * 2.8).clamp(12.0, 27.0),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Dim the half belonging to whoever lost, once somebody has.
+  Widget _buildLoserDim(Match match) {
+    final winner = match.winner;
+    if (winner == null || match.status != MatchStatus.finished) {
+      return const SizedBox.shrink();
+    }
+
+    return Align(
+      alignment: winner == MatchWinner.f1
+          ? Alignment.centerRight
+          : Alignment.centerLeft,
+      child: const FractionallySizedBox(
+        widthFactor: 0.5,
+        child: ColoredBox(color: _dim, child: SizedBox.expand()),
+      ),
+    );
+  }
+
+  // ─── Centre column ──────────────────────────────────────────────────────
+
+  Widget _buildCenter(
+    BuildContext context,
+    AppLocalizations l10n,
+    Match match,
+    double unit,
+  ) {
+    final showTimer = match.status == MatchStatus.waiting ||
+        match.status == MatchStatus.inProgress;
+
+    return Align(
+      alignment: Alignment.topCenter,
+      child: FractionallySizedBox(
+        widthFactor: 0.28,
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: unit * 5),
+          child: Column(
+            children: [
+              _buildStatusPill(context, l10n, match, unit),
+              Expanded(
+                child: showTimer
+                    ? Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          _buildTimerCard(l10n, match, unit),
+                          SizedBox(height: unit * 3),
+                          Text(
+                            l10n.vs.toUpperCase(),
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: .16),
+                              fontWeight: FontWeight.w800,
+                              fontSize: (unit * 3.4).clamp(14.0, 32.0),
+                              letterSpacing: 1.4,
+                            ),
+                          ),
+                        ],
+                      )
+                    : const SizedBox.shrink(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusPill(
+    BuildContext context,
+    AppLocalizations l10n,
+    Match match,
+    double unit,
+  ) {
+    final tk = ChokeTokens.of(context);
+    final colors = Theme.of(context).colorScheme;
+
+    // A finished match speaks in the winner's colour, so the pill and the banner
+    // agree with each other at a glance.
+    final (label, color) = switch (match) {
+      Match(isPaused: true) => (l10n.statusPaused, const Color(0xFFF5B800)),
+      Match(status: MatchStatus.waiting) => (l10n.statusWaiting, _pillGrey),
+      Match(status: MatchStatus.inProgress) => (
+          l10n.statusInProgress,
+          const Color(0xFF2EE08A),
+        ),
+      Match(status: MatchStatus.canceled) => (
+          l10n.statusCanceled,
+          tk.statusCanceledFg,
+        ),
+      _ => (
+          l10n.statusFinished,
+          switch (match.winner) {
+            MatchWinner.f1 => hexToColor(match.f1Color, colors.outline),
+            MatchWinner.f2 => hexToColor(match.f2Color, colors.outline),
+            null => Colors.white,
+          },
+        ),
+    };
+
+    final isRunning = match.status == MatchStatus.inProgress && !match.isPaused;
+
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: unit * 2.4, vertical: unit),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: .12),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: color.withValues(alpha: .5)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _StatusDot(color: color, blinking: isRunning, size: unit * 1.6),
+          SizedBox(width: unit * 1.2),
+          Flexible(
+            child: Text(
+              label.toUpperCase(),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: color,
+                fontWeight: FontWeight.bold,
+                fontSize: (unit * 2.5).clamp(10.0, 24.0),
+                letterSpacing: 1.6,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimerCard(AppLocalizations l10n, Match match, double unit) {
+    final remaining = match.remainingSecondsAt(_now);
+    final minutes = (remaining ~/ 60).toString().padLeft(2, '0');
+    final seconds = (remaining % 60).toString().padLeft(2, '0');
+
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: unit * 3, vertical: unit * 2.5),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: .03),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: Colors.white.withValues(alpha: .09)),
+        boxShadow: const [
+          BoxShadow(color: Color(0x73000000), blurRadius: 60),
+        ],
+      ),
+      child: Column(
+        children: [
+          Text(
+            l10n.scoreboardTime,
+            style: TextStyle(
+              color: _labelGrey,
+              fontWeight: FontWeight.bold,
+              fontSize: (unit * 1.8).clamp(9.0, 17.0),
+              letterSpacing: 3,
+            ),
+          ),
+          SizedBox(height: unit * 1.5),
+          Text(
+            '$minutes:$seconds',
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.w800,
+              fontSize: (unit * 9).clamp(28.0, 76.0),
+              height: 1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ─── Result ─────────────────────────────────────────────────────────────
+
+  /// Who won, and how, over the middle of the board.
+  ///
+  /// The winner comes from the event and is never derived from the numbers: a
+  /// fighter can lead 5–2 and lose to an armbar, and this banner is read by a
+  /// room full of people.
+  Widget _buildWinnerBanner(
+    BuildContext context,
+    AppLocalizations l10n,
+    Match match,
+    double unit,
+  ) {
+    if (match.status != MatchStatus.finished) return const SizedBox.shrink();
+
+    final method = match.method;
+    if (method == null) return const SizedBox.shrink();
+
+    final colors = Theme.of(context).colorScheme;
+    final winner = match.winner;
+    final color = switch (winner) {
+      MatchWinner.f1 => hexToColor(match.f1Color, colors.outline),
+      MatchWinner.f2 => hexToColor(match.f2Color, colors.outline),
+      null => Colors.white,
+    };
+    final detail = _detailOf(l10n, match);
+
+    return Center(
+      child: Container(
+        constraints: BoxConstraints(maxWidth: unit * 86),
+        padding:
+            EdgeInsets.symmetric(horizontal: unit * 5, vertical: unit * 3.5),
+        decoration: BoxDecoration(
+          color: const Color(0xB805070E),
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              (winner == null ? l10n.scoreboardResult : l10n.scoreboardWinner)
+                  .toUpperCase(),
+              style: TextStyle(
+                color: _pillGrey,
+                fontWeight: FontWeight.bold,
+                fontSize: (unit * 2.5).clamp(10.0, 24.0),
+                letterSpacing: 3.6,
+              ),
+            ),
+            if (winner != null) ...[
+              SizedBox(height: unit * 2),
+              Text(
+                (winner == MatchWinner.f1 ? match.f1Name : match.f2Name)
+                    .toUpperCase(),
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: color,
+                  fontWeight: FontWeight.w800,
+                  fontSize: (unit * 12).clamp(24.0, 86.0),
+                  height: 1,
+                  shadows: [
+                    Shadow(color: color.withValues(alpha: .6), blurRadius: 46),
+                  ],
+                ),
+              ),
+            ],
+            SizedBox(height: unit * 2),
+            Container(
+              padding: EdgeInsets.symmetric(
+                horizontal: unit * 3,
+                vertical: unit * 1.6,
+              ),
+              decoration: BoxDecoration(
+                color: color.withValues(alpha: .14),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: color.withValues(alpha: .5)),
+              ),
+              child: Text(
+                methodLabel(l10n, method).toUpperCase(),
+                style: TextStyle(
+                  color: color,
+                  fontWeight: FontWeight.w800,
+                  fontSize: (unit * 3.4).clamp(14.0, 32.0),
+                  letterSpacing: 1.2,
+                ),
+              ),
+            ),
+            if (detail != null) ...[
+              SizedBox(height: unit * 2),
+              Text(
+                detail,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: _pillGrey,
+                  fontWeight: FontWeight.w600,
+                  fontSize: (unit * 2.6).clamp(11.0, 25.0),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// The line under the method chip: which submission, or what the referee wrote
+  /// about a disqualification. Null when the method already says everything.
+  String? _detailOf(AppLocalizations l10n, Match match) {
+    final submission = match.submission;
+    if (submission != null && submission.isNotEmpty) {
+      return labelFor(l10n, submission);
+    }
+
+    final dqDetail = match.dqDetail;
+    if (dqDetail != null && dqDetail.isNotEmpty) return dqDetail;
+
+    return null;
+  }
+
+  // ─── Chrome ─────────────────────────────────────────────────────────────
+
+  Widget _buildBack(AppLocalizations l10n) {
+    return Positioned(
+      top: 8,
+      left: 8,
+      child: SafeArea(
+        child: TextButton.icon(
+          onPressed: () => Navigator.of(context).maybePop(),
+          icon: const Icon(Icons.chevron_left, size: 18),
+          label: Text(l10n.goBack),
+          style: TextButton.styleFrom(
+            foregroundColor: Colors.white.withValues(alpha: .6),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The match aged out of the feed, or the relays never had it.
+  ///
+  /// It can happen while this screen is open: the feed keeps a day, and a board
+  /// left running overnight will watch a match disappear out from under it.
+  Widget _buildGone(AppLocalizations l10n) {
+    return Scaffold(
+      backgroundColor: _background,
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.search_off, size: 44, color: _pillGrey),
+              const SizedBox(height: 14),
+              Text(
+                l10n.scoreboardEmptyTitle,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: _pillGrey,
+                  fontSize: 17,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextButton(
+                onPressed: () => Navigator.of(context).maybePop(),
+                child: Text(l10n.goBack),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The status dot, which pulses only while a match is actually running.
+///
+/// A paused or finished match holds still: a blinking light says "this is
+/// happening now", and it must not say that when it is not.
+class _StatusDot extends StatefulWidget {
+  const _StatusDot({
+    required this.color,
+    required this.blinking,
+    required this.size,
+  });
+
+  final Color color;
+  final bool blinking;
+  final double size;
+
+  @override
+  State<_StatusDot> createState() => _StatusDotState();
+}
+
+class _StatusDotState extends State<_StatusDot>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    // Built unconditionally, and here. A lazy `late final` would go unbuilt for a
+    // dot that never blinks — every finished match — and then be constructed by
+    // `dispose` reaching for `_controller`, which creates a ticker against an
+    // ancestor that is already gone and takes the rest of the teardown with it.
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1200),
+      vsync: this,
+    );
+    if (widget.blinking) _controller.repeat(reverse: true);
+  }
+
+  @override
+  void didUpdateWidget(_StatusDot old) {
+    super.didUpdateWidget(old);
+    if (widget.blinking == old.blinking) return;
+    if (widget.blinking) {
+      _controller.repeat(reverse: true);
+    } else {
+      _controller.stop();
+      _controller.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final size = widget.size.clamp(8.0, 14.0);
+    final dot = Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: widget.color,
+        shape: BoxShape.circle,
+        boxShadow: [BoxShadow(color: widget.color, blurRadius: 14)],
+      ),
+    );
+
+    if (!widget.blinking) return dot;
+
+    return FadeTransition(
+      opacity: Tween<double>(begin: 1, end: .35).animate(_controller),
+      child: dot,
+    );
+  }
+}

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -93,15 +93,27 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
               padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
               child: Row(
                 children: [
+                  // Filled with the accent, with the mark on it in ink — not
+                  // home's light grey plate.
+                  //
+                  // Home's grey is chosen for what sits on it: a red and black
+                  // logo, which reads well against it. A green glyph does not.
+                  // Measured against this theme's accent, that grey gives
+                  // 1.27:1 in the dark theme and 2.15:1 in the light one, where
+                  // iconography wants 3:1. Filled, the same glyph in ink gives
+                  // 9.87:1 and 5.81:1.
                   Container(
                     width: 46,
                     height: 46,
                     padding: const EdgeInsets.all(9),
                     decoration: BoxDecoration(
-                      color: BJJColors.greyLight,
+                      color: tk.accent,
                       borderRadius: BorderRadius.circular(12),
                     ),
-                    child: Icon(Icons.scoreboard_outlined, color: tk.accent),
+                    child: const Icon(
+                      Icons.scoreboard_outlined,
+                      color: BJJColors.ink,
+                    ),
                   ),
                   const SizedBox(width: 12),
                   Expanded(

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -6,6 +6,7 @@ import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../services/nostr/crypto/nostr_crypto.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
+import '../../shared/widgets/status_filter_bar.dart';
 import '../match/models/match.dart';
 import 'providers/scoreboard_providers.dart';
 import 'scoreboard_match_screen.dart';
@@ -56,6 +57,13 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
     ref.read(watchedPubkeyProvider.notifier).watch(null);
   }
 
+  void _toggleStatus(MatchStatus status) {
+    final current =
+        Set<MatchStatus>.from(ref.read(scoreboardStatusFilterProvider));
+    if (!current.remove(status)) current.add(status);
+    ref.read(scoreboardStatusFilterProvider.notifier).state = current;
+  }
+
   void _open(Match match) {
     Navigator.of(context).push(
       MaterialPageRoute(
@@ -70,7 +78,10 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
     final theme = Theme.of(context);
     final tk = ChokeTokens.of(context);
     final watched = ref.watch(watchedPubkeyProvider);
-    final matches = ref.watch(scoreboardMatchesProvider);
+    // Two lists: everything in scope, which the chips count from, and what
+    // survives the filter, which is what the list shows.
+    final allMatches = ref.watch(scoreboardMatchesProvider);
+    final matches = ref.watch(scoreboardFilteredMatchesProvider);
 
     return Scaffold(
       body: SafeArea(
@@ -123,6 +134,15 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
               padding: const EdgeInsets.fromLTRB(20, 12, 20, 8),
               child: _buildPubkeyField(l10n, tk, watched),
             ),
+            if (watched != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+                child: StatusFilterBar(
+                  matches: allMatches,
+                  selected: ref.watch(scoreboardStatusFilterProvider),
+                  onToggle: _toggleStatus,
+                ),
+              ),
             Expanded(
               child: switch ((watched, matches.isEmpty)) {
                 (null, _) => _buildWelcome(l10n, tk),

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -1,0 +1,278 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+import '../../services/nostr/crypto/nostr_crypto.dart';
+import '../../shared/theme/app_theme.dart';
+import '../../shared/widgets/match_card.dart';
+import '../match/models/match.dart';
+import 'providers/scoreboard_providers.dart';
+import 'scoreboard_match_screen.dart';
+
+/// Somebody else's matches, live, and nothing more.
+///
+/// Read-only on purpose: this exists for watching a mat you are not refereeing —
+/// a coach following their team, a competitor's family two rooms away. Nothing
+/// here can start, score or end anything, and it never mixes with the user's own
+/// matches.
+class ScoreboardScreen extends ConsumerStatefulWidget {
+  const ScoreboardScreen({super.key});
+
+  @override
+  ConsumerState<ScoreboardScreen> createState() => _ScoreboardScreenState();
+}
+
+class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
+  final _controller = TextEditingController();
+
+  /// Set when what the user typed is not a pubkey, and cleared as soon as they
+  /// edit again, so the error always describes what is in the field now.
+  bool _invalid = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _watch() {
+    final crypto = ref.read(nostrCryptoProvider);
+    final hex = parsePubkey(_controller.text, crypto);
+
+    if (hex == null) {
+      setState(() => _invalid = true);
+      return;
+    }
+
+    setState(() => _invalid = false);
+    FocusScope.of(context).unfocus();
+    ref.read(watchedPubkeyProvider.notifier).watch(hex);
+  }
+
+  void _stopWatching() {
+    _controller.clear();
+    setState(() => _invalid = false);
+    ref.read(watchedPubkeyProvider.notifier).watch(null);
+  }
+
+  void _open(Match match) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ScoreboardMatchScreen(matchId: match.id),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final tk = ChokeTokens.of(context);
+    final watched = ref.watch(watchedPubkeyProvider);
+    final matches = ref.watch(scoreboardMatchesProvider);
+
+    return Scaffold(
+      body: SafeArea(
+        bottom: false,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+              child: Row(
+                children: [
+                  Container(
+                    width: 46,
+                    height: 46,
+                    padding: const EdgeInsets.all(9),
+                    decoration: BoxDecoration(
+                      color: BJJColors.greyLight,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(Icons.scoreboard_outlined, color: tk.accent),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n.navScoreboard,
+                          style: theme.textTheme.headlineMedium?.copyWith(
+                            fontSize: 25,
+                            fontWeight: FontWeight.bold,
+                            letterSpacing: -.5,
+                            height: 1.05,
+                          ),
+                        ),
+                        Text(
+                          watched == null
+                              ? l10n.scoreboardWelcomeTitle
+                              : _shortPubkey(watched),
+                          style: TextStyle(fontSize: 12.5, color: tk.muted),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 12, 20, 8),
+              child: _buildPubkeyField(l10n, tk, watched),
+            ),
+            Expanded(
+              child: switch ((watched, matches.isEmpty)) {
+                (null, _) => _buildWelcome(l10n, tk),
+                (_, true) => _buildEmpty(l10n, tk),
+                _ => _buildList(matches),
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPubkeyField(
+      AppLocalizations l10n, ChokeTokens tk, String? watched) {
+    if (watched != null) {
+      return Row(
+        children: [
+          Icon(Icons.podcasts, size: 16, color: tk.accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              _shortPubkey(watched),
+              style: TextStyle(
+                fontSize: 12.5,
+                fontFamily: 'monospace',
+                color: tk.muted,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          TextButton(
+            onPressed: _stopWatching,
+            child: Text(l10n.scoreboardStopWatching),
+          ),
+        ],
+      );
+    }
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: TextField(
+            controller: _controller,
+            autocorrect: false,
+            enableSuggestions: false,
+            textInputAction: TextInputAction.go,
+            onSubmitted: (_) => _watch(),
+            onChanged: (_) {
+              if (_invalid) setState(() => _invalid = false);
+            },
+            // A pubkey is never a sentence, and a keyboard that capitalises one
+            // turns a valid npub into an invalid one.
+            textCapitalization: TextCapitalization.none,
+            inputFormatters: [
+              FilteringTextInputFormatter.deny(RegExp(r'\s')),
+            ],
+            style: const TextStyle(fontSize: 13, fontFamily: 'monospace'),
+            decoration: InputDecoration(
+              hintText: l10n.scoreboardPubkeyHint,
+              hintStyle: TextStyle(fontSize: 12.5, color: tk.faint),
+              errorText: _invalid ? l10n.scoreboardInvalidPubkey : null,
+              isDense: true,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: FilledButton(
+            onPressed: _watch,
+            child: Text(l10n.scoreboardWatch),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildList(List<Match> matches) {
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+      itemCount: matches.length,
+      itemBuilder: (context, index) {
+        final match = matches[index];
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 11),
+          child: MatchCard(match: match, onTap: () => _open(match)),
+        );
+      },
+    );
+  }
+
+  Widget _buildWelcome(AppLocalizations l10n, ChokeTokens tk) {
+    return _buildPlaceholder(
+      tk,
+      icon: Icons.qr_code_scanner_outlined,
+      title: l10n.scoreboardWelcomeTitle,
+      body: l10n.scoreboardWelcomeBody,
+    );
+  }
+
+  Widget _buildEmpty(AppLocalizations l10n, ChokeTokens tk) {
+    return _buildPlaceholder(
+      tk,
+      icon: Icons.hourglass_empty,
+      title: l10n.scoreboardEmptyTitle,
+      body: l10n.scoreboardEmptyBody,
+    );
+  }
+
+  Widget _buildPlaceholder(
+    ChokeTokens tk, {
+    required IconData icon,
+    required String title,
+    required String body,
+  }) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 44, color: tk.faint),
+            const SizedBox(height: 14),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w600,
+                color: tk.muted,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              body,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 13, color: tk.faint),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// A pubkey is 64 characters of hex nobody reads. Show enough of both ends to
+  /// tell which one it is.
+  String _shortPubkey(String hex) {
+    if (hex.length <= 16) return hex;
+    return '${hex.substring(0, 8)}…${hex.substring(hex.length - 8)}';
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -804,5 +804,70 @@
   "submissionsEmpty": "No submissions left. Add one, or restore the defaults.",
   "@submissionsEmpty": {
     "description": "Submissions picker/editor: every submission has been removed"
+  },
+  "navScoreboard": "Scoreboard",
+  "@navScoreboard": {
+    "description": "Bottom navigation label for the read-only Scoreboard tab"
+  },
+  "scoreboardPubkeyHint": "Organizer npub or hex pubkey",
+  "@scoreboardPubkeyHint": {
+    "description": "Placeholder in the field where the viewer pastes the organizer pubkey"
+  },
+  "scoreboardWatch": "Watch",
+  "@scoreboardWatch": {
+    "description": "Button that starts watching the entered pubkey"
+  },
+  "scoreboardStopWatching": "Stop watching",
+  "@scoreboardStopWatching": {
+    "description": "Button that stops watching and forgets the pubkey"
+  },
+  "scoreboardInvalidPubkey": "Invalid pubkey: must be an npub or 64-char hex",
+  "@scoreboardInvalidPubkey": {
+    "description": "Error shown when the pasted pubkey is neither an npub nor 64-char hex"
+  },
+  "scoreboardWelcomeTitle": "Watch somebody else’s mats",
+  "@scoreboardWelcomeTitle": {
+    "description": "Title before any pubkey has been entered"
+  },
+  "scoreboardWelcomeBody": "Paste the pubkey an organizer shared and their matches appear here live.",
+  "@scoreboardWelcomeBody": {
+    "description": "Body before any pubkey has been entered"
+  },
+  "scoreboardEmptyTitle": "No matches yet",
+  "@scoreboardEmptyTitle": {
+    "description": "Title when a pubkey is being watched but no matches have arrived"
+  },
+  "scoreboardEmptyBody": "Waiting for match events from this organizer…",
+  "@scoreboardEmptyBody": {
+    "description": "Body when a pubkey is being watched but no matches have arrived"
+  },
+  "scoreboardTime": "TIME",
+  "@scoreboardTime": {
+    "description": "Label over the clock on the full-screen scoreboard"
+  },
+  "scoreboardWinner": "WINNER",
+  "@scoreboardWinner": {
+    "description": "Label over the winner name on a finished match"
+  },
+  "scoreboardResult": "RESULT",
+  "@scoreboardResult": {
+    "description": "Label used instead of WINNER when a match was a draw"
+  },
+  "scoreboardAdvShort": "ADV",
+  "@scoreboardAdvShort": {
+    "description": "Short label on the advantages chip; kept short to fit the wall display"
+  },
+  "scoreboardPenShort": "PEN",
+  "@scoreboardPenShort": {
+    "description": "Short label on the penalties chip; kept short to fit the wall display"
+  },
+  "scoreboardPointsShort": "{points} PTS",
+  "@scoreboardPointsShort": {
+    "description": "Point-value column header in the score breakdown, e.g. 2 PTS",
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -200,5 +200,27 @@
   "submissionsRemove": "Quitar",
   "submissionsRestore": "Restaurar las predeterminadas",
   "submissionsDuplicate": "Ya está en la lista",
-  "submissionsEmpty": "No queda ninguna sumisión. Agrega una o restaura las predeterminadas."
+  "submissionsEmpty": "No queda ninguna sumisión. Agrega una o restaura las predeterminadas.",
+  "navScoreboard": "Tablero",
+  "scoreboardPubkeyHint": "npub o clave pública hex del organizador",
+  "scoreboardWatch": "Ver",
+  "scoreboardStopWatching": "Dejar de ver",
+  "scoreboardInvalidPubkey": "Clave pública inválida: debe ser npub o hex de 64 caracteres",
+  "scoreboardWelcomeTitle": "Mirá los tatamis de otros",
+  "scoreboardWelcomeBody": "Pegá la clave pública que compartió un organizador y sus luchas aparecen acá en vivo.",
+  "scoreboardEmptyTitle": "Todavía no hay luchas",
+  "scoreboardEmptyBody": "Esperando eventos de lucha de este organizador…",
+  "scoreboardTime": "TIEMPO",
+  "scoreboardWinner": "GANADOR",
+  "scoreboardResult": "RESULTADO",
+  "scoreboardAdvShort": "VENT",
+  "scoreboardPenShort": "PEN",
+  "scoreboardPointsShort": "{points} PTS",
+  "@scoreboardPointsShort": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -200,5 +200,27 @@
   "submissionsRemove": "削除",
   "submissionsRestore": "初期設定に戻す",
   "submissionsDuplicate": "すでにリストにあります",
-  "submissionsEmpty": "サブミッションがありません。追加するか、初期設定に戻してください。"
+  "submissionsEmpty": "サブミッションがありません。追加するか、初期設定に戻してください。",
+  "navScoreboard": "スコアボード",
+  "scoreboardPubkeyHint": "主催者の npub または 16 進公開鍵",
+  "scoreboardWatch": "見る",
+  "scoreboardStopWatching": "表示をやめる",
+  "scoreboardInvalidPubkey": "無効な公開鍵：npub または 64 文字の 16 進数が必要です",
+  "scoreboardWelcomeTitle": "他の会場の試合を見る",
+  "scoreboardWelcomeBody": "主催者が共有した公開鍵を貼ると、その試合がここにリアルタイムで表示されます。",
+  "scoreboardEmptyTitle": "まだ試合がありません",
+  "scoreboardEmptyBody": "この主催者の試合イベントを待っています…",
+  "scoreboardTime": "タイム",
+  "scoreboardWinner": "勝者",
+  "scoreboardResult": "結果",
+  "scoreboardAdvShort": "アド",
+  "scoreboardPenShort": "反則",
+  "scoreboardPointsShort": "{points} ポイント",
+  "@scoreboardPointsShort": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -200,5 +200,27 @@
   "submissionsRemove": "Remover",
   "submissionsRestore": "Restaurar as padrão",
   "submissionsDuplicate": "Já está na lista",
-  "submissionsEmpty": "Não resta nenhuma finalização. Adicione uma ou restaure as padrão."
+  "submissionsEmpty": "Não resta nenhuma finalização. Adicione uma ou restaure as padrão.",
+  "navScoreboard": "Placar",
+  "scoreboardPubkeyHint": "npub ou chave pública hex do organizador",
+  "scoreboardWatch": "Ver",
+  "scoreboardStopWatching": "Parar de ver",
+  "scoreboardInvalidPubkey": "Chave pública inválida: precisa ser npub ou hex de 64 caracteres",
+  "scoreboardWelcomeTitle": "Acompanhe os tatames de outros",
+  "scoreboardWelcomeBody": "Cole a chave pública que um organizador compartilhou e as lutas dele aparecem aqui ao vivo.",
+  "scoreboardEmptyTitle": "Ainda sem lutas",
+  "scoreboardEmptyBody": "Aguardando eventos de luta deste organizador…",
+  "scoreboardTime": "TEMPO",
+  "scoreboardWinner": "VENCEDOR",
+  "scoreboardResult": "RESULTADO",
+  "scoreboardAdvShort": "VANT",
+  "scoreboardPenShort": "PUN",
+  "scoreboardPointsShort": "{points} PTS",
+  "@scoreboardPointsShort": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1307,6 +1307,96 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No submissions left. Add one, or restore the defaults.'**
   String get submissionsEmpty;
+
+  /// Bottom navigation label for the read-only Scoreboard tab
+  ///
+  /// In en, this message translates to:
+  /// **'Scoreboard'**
+  String get navScoreboard;
+
+  /// Placeholder in the field where the viewer pastes the organizer pubkey
+  ///
+  /// In en, this message translates to:
+  /// **'Organizer npub or hex pubkey'**
+  String get scoreboardPubkeyHint;
+
+  /// Button that starts watching the entered pubkey
+  ///
+  /// In en, this message translates to:
+  /// **'Watch'**
+  String get scoreboardWatch;
+
+  /// Button that stops watching and forgets the pubkey
+  ///
+  /// In en, this message translates to:
+  /// **'Stop watching'**
+  String get scoreboardStopWatching;
+
+  /// Error shown when the pasted pubkey is neither an npub nor 64-char hex
+  ///
+  /// In en, this message translates to:
+  /// **'Invalid pubkey: must be an npub or 64-char hex'**
+  String get scoreboardInvalidPubkey;
+
+  /// Title before any pubkey has been entered
+  ///
+  /// In en, this message translates to:
+  /// **'Watch somebody else’s mats'**
+  String get scoreboardWelcomeTitle;
+
+  /// Body before any pubkey has been entered
+  ///
+  /// In en, this message translates to:
+  /// **'Paste the pubkey an organizer shared and their matches appear here live.'**
+  String get scoreboardWelcomeBody;
+
+  /// Title when a pubkey is being watched but no matches have arrived
+  ///
+  /// In en, this message translates to:
+  /// **'No matches yet'**
+  String get scoreboardEmptyTitle;
+
+  /// Body when a pubkey is being watched but no matches have arrived
+  ///
+  /// In en, this message translates to:
+  /// **'Waiting for match events from this organizer…'**
+  String get scoreboardEmptyBody;
+
+  /// Label over the clock on the full-screen scoreboard
+  ///
+  /// In en, this message translates to:
+  /// **'TIME'**
+  String get scoreboardTime;
+
+  /// Label over the winner name on a finished match
+  ///
+  /// In en, this message translates to:
+  /// **'WINNER'**
+  String get scoreboardWinner;
+
+  /// Label used instead of WINNER when a match was a draw
+  ///
+  /// In en, this message translates to:
+  /// **'RESULT'**
+  String get scoreboardResult;
+
+  /// Short label on the advantages chip; kept short to fit the wall display
+  ///
+  /// In en, this message translates to:
+  /// **'ADV'**
+  String get scoreboardAdvShort;
+
+  /// Short label on the penalties chip; kept short to fit the wall display
+  ///
+  /// In en, this message translates to:
+  /// **'PEN'**
+  String get scoreboardPenShort;
+
+  /// Point-value column header in the score breakdown, e.g. 2 PTS
+  ///
+  /// In en, this message translates to:
+  /// **'{points} PTS'**
+  String scoreboardPointsShort(int points);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -645,4 +645,54 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get submissionsEmpty =>
       'No submissions left. Add one, or restore the defaults.';
+
+  @override
+  String get navScoreboard => 'Scoreboard';
+
+  @override
+  String get scoreboardPubkeyHint => 'Organizer npub or hex pubkey';
+
+  @override
+  String get scoreboardWatch => 'Watch';
+
+  @override
+  String get scoreboardStopWatching => 'Stop watching';
+
+  @override
+  String get scoreboardInvalidPubkey =>
+      'Invalid pubkey: must be an npub or 64-char hex';
+
+  @override
+  String get scoreboardWelcomeTitle => 'Watch somebody else’s mats';
+
+  @override
+  String get scoreboardWelcomeBody =>
+      'Paste the pubkey an organizer shared and their matches appear here live.';
+
+  @override
+  String get scoreboardEmptyTitle => 'No matches yet';
+
+  @override
+  String get scoreboardEmptyBody =>
+      'Waiting for match events from this organizer…';
+
+  @override
+  String get scoreboardTime => 'TIME';
+
+  @override
+  String get scoreboardWinner => 'WINNER';
+
+  @override
+  String get scoreboardResult => 'RESULT';
+
+  @override
+  String get scoreboardAdvShort => 'ADV';
+
+  @override
+  String get scoreboardPenShort => 'PEN';
+
+  @override
+  String scoreboardPointsShort(int points) {
+    return '$points PTS';
+  }
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -650,4 +650,54 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get submissionsEmpty =>
       'No queda ninguna sumisión. Agrega una o restaura las predeterminadas.';
+
+  @override
+  String get navScoreboard => 'Tablero';
+
+  @override
+  String get scoreboardPubkeyHint => 'npub o clave pública hex del organizador';
+
+  @override
+  String get scoreboardWatch => 'Ver';
+
+  @override
+  String get scoreboardStopWatching => 'Dejar de ver';
+
+  @override
+  String get scoreboardInvalidPubkey =>
+      'Clave pública inválida: debe ser npub o hex de 64 caracteres';
+
+  @override
+  String get scoreboardWelcomeTitle => 'Mirá los tatamis de otros';
+
+  @override
+  String get scoreboardWelcomeBody =>
+      'Pegá la clave pública que compartió un organizador y sus luchas aparecen acá en vivo.';
+
+  @override
+  String get scoreboardEmptyTitle => 'Todavía no hay luchas';
+
+  @override
+  String get scoreboardEmptyBody =>
+      'Esperando eventos de lucha de este organizador…';
+
+  @override
+  String get scoreboardTime => 'TIEMPO';
+
+  @override
+  String get scoreboardWinner => 'GANADOR';
+
+  @override
+  String get scoreboardResult => 'RESULTADO';
+
+  @override
+  String get scoreboardAdvShort => 'VENT';
+
+  @override
+  String get scoreboardPenShort => 'PEN';
+
+  @override
+  String scoreboardPointsShort(int points) {
+    return '$points PTS';
+  }
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -624,4 +624,51 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get submissionsEmpty => 'サブミッションがありません。追加するか、初期設定に戻してください。';
+
+  @override
+  String get navScoreboard => 'スコアボード';
+
+  @override
+  String get scoreboardPubkeyHint => '主催者の npub または 16 進公開鍵';
+
+  @override
+  String get scoreboardWatch => '見る';
+
+  @override
+  String get scoreboardStopWatching => '表示をやめる';
+
+  @override
+  String get scoreboardInvalidPubkey => '無効な公開鍵：npub または 64 文字の 16 進数が必要です';
+
+  @override
+  String get scoreboardWelcomeTitle => '他の会場の試合を見る';
+
+  @override
+  String get scoreboardWelcomeBody => '主催者が共有した公開鍵を貼ると、その試合がここにリアルタイムで表示されます。';
+
+  @override
+  String get scoreboardEmptyTitle => 'まだ試合がありません';
+
+  @override
+  String get scoreboardEmptyBody => 'この主催者の試合イベントを待っています…';
+
+  @override
+  String get scoreboardTime => 'タイム';
+
+  @override
+  String get scoreboardWinner => '勝者';
+
+  @override
+  String get scoreboardResult => '結果';
+
+  @override
+  String get scoreboardAdvShort => 'アド';
+
+  @override
+  String get scoreboardPenShort => '反則';
+
+  @override
+  String scoreboardPointsShort(int points) {
+    return '$points ポイント';
+  }
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -650,4 +650,54 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get submissionsEmpty =>
       'Não resta nenhuma finalização. Adicione uma ou restaure as padrão.';
+
+  @override
+  String get navScoreboard => 'Placar';
+
+  @override
+  String get scoreboardPubkeyHint => 'npub ou chave pública hex do organizador';
+
+  @override
+  String get scoreboardWatch => 'Ver';
+
+  @override
+  String get scoreboardStopWatching => 'Parar de ver';
+
+  @override
+  String get scoreboardInvalidPubkey =>
+      'Chave pública inválida: precisa ser npub ou hex de 64 caracteres';
+
+  @override
+  String get scoreboardWelcomeTitle => 'Acompanhe os tatames de outros';
+
+  @override
+  String get scoreboardWelcomeBody =>
+      'Cole a chave pública que um organizador compartilhou e as lutas dele aparecem aqui ao vivo.';
+
+  @override
+  String get scoreboardEmptyTitle => 'Ainda sem lutas';
+
+  @override
+  String get scoreboardEmptyBody =>
+      'Aguardando eventos de luta deste organizador…';
+
+  @override
+  String get scoreboardTime => 'TEMPO';
+
+  @override
+  String get scoreboardWinner => 'VENCEDOR';
+
+  @override
+  String get scoreboardResult => 'RESULTADO';
+
+  @override
+  String get scoreboardAdvShort => 'VANT';
+
+  @override
+  String get scoreboardPenShort => 'PUN';
+
+  @override
+  String scoreboardPointsShort(int points) {
+    return '$points PTS';
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,8 @@ import 'features/home/home_screen.dart';
 
 import 'features/account/account_screen.dart';
 import 'features/scoreboard/scoreboard_screen.dart';
+import 'services/deep_links/share_link.dart';
+import 'shared/providers/navigation_provider.dart';
 import 'features/settings/settings_screen.dart';
 import 'features/match/providers/submissions_provider.dart';
 import 'features/settings/providers/relay_config_provider.dart';
@@ -137,6 +139,7 @@ class _ChokeAppState extends ConsumerState<ChokeApp>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _handleLaunchLink();
   }
 
   @override
@@ -150,6 +153,33 @@ class _ChokeAppState extends ConsumerState<ChokeApp>
     if (state == AppLifecycleState.resumed) {
       ref.read(nostrServiceProvider).reconnectAll();
     }
+  }
+
+  /// A shared board link arriving while the app is already running.
+  ///
+  /// Returning true claims the link. Returning false lets the framework carry
+  /// on treating it as a named route, which is right for anything that is not
+  /// ours — including the `/` the engine reports for an ordinary launch.
+  @override
+  Future<bool> didPushRouteInformation(RouteInformation info) async {
+    return _handleLink(info.uri);
+  }
+
+  bool _handleLink(Uri uri) {
+    if (!mounted) return false;
+    return openShareLink(uri, ref.read(nostrCryptoProvider), ref);
+  }
+
+  /// The link the app was launched by, if it was launched by one.
+  ///
+  /// Read once, after the first frame: the providers this ends up writing to
+  /// must not be modified while the tree is still building.
+  void _handleLaunchLink() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final route = WidgetsBinding.instance.platformDispatcher.defaultRouteName;
+      if (route.isEmpty || route == '/') return;
+      _handleLink(Uri.parse(route));
+    });
   }
 
   @override
@@ -171,34 +201,34 @@ class _ChokeAppState extends ConsumerState<ChokeApp>
   }
 }
 
-/// Main navigation with bottom navigation bar
-class MainNavigation extends StatefulWidget {
+/// Main navigation with bottom navigation bar.
+///
+/// The screens are kept alive in an [IndexedStack] rather than rebuilt on every
+/// tap, so the home feed and the scoreboard hold their relay subscriptions and
+/// scroll position while the user moves between them.
+class MainNavigation extends ConsumerWidget {
   const MainNavigation({super.key});
 
-  @override
-  State<MainNavigation> createState() => _MainNavigationState();
-}
-
-class _MainNavigationState extends State<MainNavigation> {
-  int _currentIndex = 0;
-
-  final List<Widget> _screens = [
-    const HomeScreen(),
-    const ScoreboardScreen(),
-    const AccountScreen(),
-    const SettingsScreen(),
+  /// In [AppTab] order, which is the order of the bar.
+  static const List<Widget> _screens = [
+    HomeScreen(),
+    ScoreboardScreen(),
+    AccountScreen(),
+    SettingsScreen(),
   ];
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
+    final tab = ref.watch(selectedTabProvider);
 
     return Scaffold(
       extendBody: true,
-      body: IndexedStack(index: _currentIndex, children: _screens),
+      body: IndexedStack(index: tab.index, children: _screens),
       bottomNavigationBar: _ChokeNavBar(
-        currentIndex: _currentIndex,
-        onTap: (index) => setState(() => _currentIndex = index),
+        currentIndex: tab.index,
+        onTap: (index) => ref.read(selectedTabProvider.notifier).state =
+            AppTab.fromIndex(index),
         items: [
           (Icons.home_outlined, l10n.navHome),
           (Icons.scoreboard_outlined, l10n.navScoreboard),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'shared/providers/match_sound_provider.dart';
 import 'features/home/home_screen.dart';
 
 import 'features/account/account_screen.dart';
+import 'features/scoreboard/scoreboard_screen.dart';
 import 'features/settings/settings_screen.dart';
 import 'features/match/providers/submissions_provider.dart';
 import 'features/settings/providers/relay_config_provider.dart';
@@ -183,6 +184,7 @@ class _MainNavigationState extends State<MainNavigation> {
 
   final List<Widget> _screens = [
     const HomeScreen(),
+    const ScoreboardScreen(),
     const AccountScreen(),
     const SettingsScreen(),
   ];
@@ -199,6 +201,7 @@ class _MainNavigationState extends State<MainNavigation> {
         onTap: (index) => setState(() => _currentIndex = index),
         items: [
           (Icons.home_outlined, l10n.navHome),
+          (Icons.scoreboard_outlined, l10n.navScoreboard),
           (Icons.person_outline, l10n.navAccount),
           (Icons.settings_outlined, l10n.navSettings),
         ],

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -52,7 +52,16 @@ String? pubkeyFromShareLink(Uri uri, NostrCrypto crypto) {
 bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
   final hex = pubkeyFromShareLink(uri, crypto);
   if (hex == null) {
-    debugPrint('DeepLink: ignoring $uri');
+    // The host and which parameters were present, never their values. A user
+    // who pastes their nsec into one of these is correctly rejected above —
+    // and must not have it written to the device log on the way out.
+    final named = kSharePubkeyParams
+        .where(uri.queryParameters.containsKey)
+        .join(',');
+    debugPrint(
+      'DeepLink: ignoring a link for ${uri.host.isEmpty ? '(no host)' : uri.host}'
+      '${named.isEmpty ? ' with no pubkey parameter' : ' whose $named did not parse'}',
+    );
     return false;
   }
 

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/scoreboard/providers/scoreboard_providers.dart';
+import '../../shared/providers/navigation_provider.dart';
+import '../nostr/crypto/nostr_crypto.dart';
+
+/// The host whose links this app answers for.
+///
+/// Must match the `android:host` in the App Links intent filter and the
+/// `applinks:` entry in the iOS entitlement. A link for any other host belongs
+/// to somebody else, and is ignored rather than guessed at.
+const String kShareLinkHost = 'bjjscore.live';
+
+/// The query parameters a shared board link may carry the pubkey in.
+///
+/// Both, and in this order, because choke-scoreboard has always accepted both
+/// (`SHARE_PUBKEY_PARAMS` in its `share-link.ts`) and one URL is shared to
+/// everyone: whichever of the two the recipient opens it in has to understand
+/// it.
+const List<String> kSharePubkeyParams = ['npub', 'pubkey'];
+
+/// The pubkey a shared board link names, in hex, or null if it names none.
+///
+/// Accepts exactly what the web board accepts: `https://bjjscore.live/?npub=…`
+/// or `?pubkey=…`, holding either an npub or bare hex.
+///
+/// Returns null rather than throwing for anything else, a link for another host
+/// included. What arrives here is whatever the OS was handed, which is not a
+/// trusted caller.
+String? pubkeyFromShareLink(Uri uri, NostrCrypto crypto) {
+  // A relative route has no authority to check; an absolute one must be ours.
+  if (uri.hasAuthority && uri.host.toLowerCase() != kShareLinkHost) return null;
+
+  for (final param in kSharePubkeyParams) {
+    final value = uri.queryParameters[param]?.trim();
+    if (value == null || value.isEmpty) continue;
+
+    final hex = parsePubkey(value, crypto);
+    if (hex != null) return hex;
+  }
+
+  return null;
+}
+
+/// Open a shared board link: watch the pubkey it names, and show the scoreboard.
+///
+/// Returns whether the link was one this app understands. One that names no
+/// usable pubkey changes nothing — dropping the user on an empty scoreboard,
+/// having silently forgotten the pubkey they were already watching, would be
+/// worse than ignoring a link that made no sense.
+bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
+  final hex = pubkeyFromShareLink(uri, crypto);
+  if (hex == null) {
+    debugPrint('DeepLink: ignoring $uri');
+    return false;
+  }
+
+  ref.read(watchedPubkeyProvider.notifier).watch(hex);
+  ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
+  return true;
+}

--- a/lib/services/nostr/crypto/nostr_crypto.dart
+++ b/lib/services/nostr/crypto/nostr_crypto.dart
@@ -51,6 +51,17 @@ abstract class NostrCrypto {
   /// can type, not a programming error.
   String? nsecDecode(String nsec);
 
+  /// The hex public key inside [npub], or null if it is not a valid npub.
+  ///
+  /// Null rather than throwing, for the same reason as [nsecDecode]: an npub is
+  /// something a user pastes.
+  ///
+  /// Strictly bech32. A bare hex key is not accepted, because the two forms
+  /// cannot be told apart once mixed — any 64 hex characters parse as a public
+  /// key, a private one included. Callers that accept either form must decide
+  /// which they were handed before calling this.
+  String? npubDecode(String npub);
+
   /// Compute [event]'s id and sign it with [privateKeyHex].
   NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex);
 

--- a/lib/services/nostr/crypto/rust_nostr_crypto.dart
+++ b/lib/services/nostr/crypto/rust_nostr_crypto.dart
@@ -33,6 +33,9 @@ class RustNostrCrypto implements NostrCrypto {
   String? nsecDecode(String nsec) => rust.nsecDecode(nsec: nsec);
 
   @override
+  String? npubDecode(String npub) => rust.npubDecode(npub: npub);
+
+  @override
   NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex) {
     final signed = rust.finishEvent(
       event: rust.UnsignedEventData(

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -205,13 +205,22 @@ class NostrService {
   /// the two disagree about whose matches they are looking at.
   String? get userPubkey => _userPubkey;
 
-  /// Subscribe to kind 31415 events from a specific author
+  /// Subscribe to kind 31415 events from a specific author.
+  ///
+  /// The default id is deliberately short. NIP-01 caps a subscription id at 64
+  /// characters and a relay refuses the whole REQ over it — nos.lol answers
+  /// `CLOSED … "ERROR: bad req: invalid subscription id"` — so `author_` plus a
+  /// 64-character pubkey would be 71 and would never receive an event.
   void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {
     _backend.subscribe(
-      subscriptionId ?? 'author_$authorPubkey',
+      subscriptionId ?? 'author_${_shortKey(authorPubkey)}',
       Filter(kinds: [31415], authors: [authorPubkey]),
     );
   }
+
+  /// Enough of a pubkey to tell two of them apart inside a subscription id.
+  static String _shortKey(String pubkey) =>
+      pubkey.length <= 16 ? pubkey : pubkey.substring(0, 16);
 
   /// Unsubscribe from a subscription
   void unsubscribe(String subscriptionId) =>

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -185,11 +185,25 @@ class NostrService {
       throw Exception('No public key available');
     }
 
+    _userPubkey = publicKey;
+
     _backend.subscribe(
       'user_events',
       Filter(kinds: [31415], authors: [publicKey]),
     );
   }
+
+  String? _userPubkey;
+
+  /// This device's own public key, once [subscribeToUserEvents] has looked it
+  /// up, and null before that.
+  ///
+  /// Exposed because [eventStream] carries the events of every subscription with
+  /// no way to tell which filter matched them, so a consumer that wants only
+  /// this user's matches — the home feed — has to be able to ask who this user
+  /// is. Threading the key in from the key manager separately would instead let
+  /// the two disagree about whose matches they are looking at.
+  String? get userPubkey => _userPubkey;
 
   /// Subscribe to kind 31415 events from a specific author
   void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -195,6 +195,17 @@ class NostrService {
 
   String? _userPubkey;
 
+  /// Re-read the identity and point the subscription at it.
+  ///
+  /// Call after the key changes. [subscribeToUserEvents] reuses the same
+  /// subscription id, and a REQ that repeats an id replaces it, so the relays
+  /// stop sending the old identity's matches and start sending the new one's.
+  ///
+  /// Without this the service keeps answering [userPubkey] with the key the app
+  /// started with, and the home feed — which believes it — throws away the
+  /// user's own matches under their new identity.
+  Future<void> refreshIdentity() => subscribeToUserEvents();
+
   /// This device's own public key, once [subscribeToUserEvents] has looked it
   /// up, and null before that.
   ///
@@ -500,6 +511,21 @@ class NostrService {
   NostrEvent? getAddressableEvent(String kind, String pubkey, String dTag) {
     final key = '$kind:$pubkey:$dTag';
     return _addressableEvents[key];
+  }
+
+  /// Every cached event of [kind] published by [pubkey].
+  ///
+  /// Exists because this service deduplicates addressable events for the whole
+  /// app: a relay replaying the state it already sent is dropped here, so a
+  /// consumer that starts later never sees it on [eventStream] and would sit
+  /// empty until the author published again. A late consumer asks for what it
+  /// missed instead.
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) {
+    final prefix = '$kind:$pubkey:';
+    return _addressableEvents.entries
+        .where((e) => e.key.startsWith(prefix))
+        .map((e) => e.value)
+        .toList();
   }
 
   /// Get list of connected relays

--- a/lib/shared/providers/navigation_provider.dart
+++ b/lib/shared/providers/navigation_provider.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The sections in the bottom bar, in the order they appear there.
+///
+/// An enum rather than the bare index the nav bar used to keep, because the
+/// index is now written from more than one place — a shared link opens the
+/// scoreboard — and a `2` at a call site says nothing about which screen it is.
+enum AppTab {
+  home,
+  scoreboard,
+  account,
+  settings;
+
+  static AppTab fromIndex(int index) => AppTab.values[index];
+}
+
+/// Which section is showing.
+///
+/// Lifted out of the navigation widget's own state so that anything holding a
+/// ref can move the user, which is what a shared board link does when the app
+/// is already open. Deliberately not persisted: the app opens on Home, not on
+/// wherever it happened to be left.
+final selectedTabProvider = StateProvider<AppTab>((ref) => AppTab.home);

--- a/lib/shared/widgets/match_card.dart
+++ b/lib/shared/widgets/match_card.dart
@@ -1,0 +1,336 @@
+import 'package:flutter/material.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+import '../../features/match/models/match.dart';
+import '../../features/match/widgets/outcome_label.dart';
+import '../theme/app_theme.dart';
+
+/// Parse a hex colour string (`#RRGGBB`) into a [Color], falling back when it is
+/// not one. Fighter colours arrive over the wire and cannot be trusted to parse.
+Color hexToColor(String hex, Color fallback) {
+  try {
+    final h = hex.replaceFirst('#', '');
+    if (h.length != 6) return fallback;
+    return Color(int.parse('FF$h', radix: 16));
+  } catch (_) {
+    return fallback;
+  }
+}
+
+/// The colour a status is spoken in.
+Color matchStatusAccent(ChokeTokens tk, MatchStatus status) {
+  return switch (status) {
+    MatchStatus.waiting => tk.goldFg,
+    MatchStatus.inProgress => tk.accent,
+    MatchStatus.finished => tk.statusFinishedFg,
+    MatchStatus.canceled => tk.statusCanceledFg,
+  };
+}
+
+/// What a status is called, in the language of the room.
+String matchStatusLabel(AppLocalizations l10n, MatchStatus status) {
+  return switch (status) {
+    MatchStatus.waiting => l10n.statusWaiting,
+    MatchStatus.inProgress => l10n.statusInProgress,
+    MatchStatus.finished => l10n.statusFinished,
+    MatchStatus.canceled => l10n.statusCanceled,
+  };
+}
+
+/// Whether to light this fighter's number up.
+///
+/// A finished match names its winner, and that name is the only thing worth
+/// believing: a fighter can lead 4–0 and still lose to an armbar. Only while a
+/// match is undecided does the scoreboard get to speak for itself — and a
+/// canceled match has no winner at all.
+bool isWinningFighter(Match match, MatchWinner fighter, bool isCanceled) {
+  if (isCanceled) return false;
+
+  final winner = match.winner;
+  if (winner != null) return winner == fighter;
+  if (match.method != null) return false; // a draw: nobody won
+
+  return match.scoreboardWinner == fighter;
+}
+
+/// The status pill: a dot that only appears while a match is running, and the
+/// status in words.
+class MatchStatusChip extends StatelessWidget {
+  const MatchStatusChip({super.key, required this.status});
+
+  final MatchStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final tk = ChokeTokens.of(context);
+    final (fg, bg) = switch (status) {
+      MatchStatus.waiting => (tk.goldFg, tk.goldFg.withValues(alpha: .14)),
+      MatchStatus.inProgress => (tk.accent, tk.accent.withValues(alpha: .2)),
+      MatchStatus.finished => (tk.statusFinishedFg, tk.statusFinishedBg),
+      MatchStatus.canceled => (tk.statusCanceledFg, tk.statusCanceledBg),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 4),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(99),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (status == MatchStatus.inProgress) ...[
+            Container(
+              width: 6,
+              height: 6,
+              decoration: BoxDecoration(color: fg, shape: BoxShape.circle),
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            matchStatusLabel(l10n, status),
+            style: TextStyle(
+              color: fg,
+              fontSize: 11.5,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A small counter badge, for advantages and penalties.
+class _SmallBadge extends StatelessWidget {
+  const _SmallBadge(this.text, this.color);
+
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          color: color,
+          fontSize: 10.5,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// One match as a row in a list: both fighters, the effective score, and how it
+/// ended once it has.
+///
+/// Shared by the home feed and the read-only scoreboard, which show the same
+/// matches and differ only in what opening one means — hence [onTap], rather
+/// than a card that knows where it is.
+class MatchCard extends StatelessWidget {
+  const MatchCard({super.key, required this.match, this.onTap});
+
+  final Match match;
+
+  /// What opening this match means here. A card with no [onTap] does not react
+  /// to being pressed.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final tk = ChokeTokens.of(context);
+    final colors = Theme.of(context).colorScheme;
+    final f1Color = hexToColor(match.f1Color, colors.outline);
+    final f2Color = hexToColor(match.f2Color, colors.outline);
+    final isLive = match.status == MatchStatus.inProgress;
+    final isCanceled = match.status == MatchStatus.canceled;
+
+    final card = Container(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+      decoration: BoxDecoration(
+        gradient: isLive
+            ? LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  tk.accent.withValues(alpha: .12),
+                  tk.accent.withValues(alpha: .03),
+                ],
+              )
+            : null,
+        color: isLive ? null : tk.card,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: isLive ? tk.accent.withValues(alpha: .45) : tk.cardBorder,
+        ),
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '#${match.id}',
+                style: TextStyle(
+                  color: tk.faint,
+                  fontSize: 12,
+                  fontFamily: 'monospace',
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              MatchStatusChip(status: match.status),
+            ],
+          ),
+          const SizedBox(height: 11),
+          Row(
+            children: [
+              Expanded(
+                child: Row(
+                  children: [
+                    Container(
+                      width: 9,
+                      height: 9,
+                      decoration:
+                          BoxDecoration(color: f1Color, shape: BoxShape.circle),
+                    ),
+                    const SizedBox(width: 9),
+                    Flexible(
+                      child: Text(
+                        match.f1Name,
+                        style: TextStyle(
+                          color: colors.onSurface,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (match.f1EffectiveAdvantages > 0) ...[
+                      const SizedBox(width: 6),
+                      _SmallBadge(
+                          'A:${match.f1EffectiveAdvantages}', tk.goldFg),
+                    ],
+                    if (match.f1Pen > 0) ...[
+                      const SizedBox(width: 4),
+                      _SmallBadge('P:${match.f1Pen}', tk.dangerFg),
+                    ],
+                  ],
+                ),
+              ),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                children: [
+                  Text(
+                    '${match.f1EffectivePoints}',
+                    style: TextStyle(
+                      color: isWinningFighter(match, MatchWinner.f1, isCanceled)
+                          ? tk.accent
+                          : tk.muted,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 27,
+                      height: 1,
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 9),
+                    child: Text(
+                      l10n.vs,
+                      style: TextStyle(fontSize: 12, color: tk.faint),
+                    ),
+                  ),
+                  Text(
+                    '${match.f2EffectivePoints}',
+                    style: TextStyle(
+                      color: isWinningFighter(match, MatchWinner.f2, isCanceled)
+                          ? tk.accent
+                          : tk.muted,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 27,
+                      height: 1,
+                    ),
+                  ),
+                ],
+              ),
+              Expanded(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    if (match.f2EffectiveAdvantages > 0) ...[
+                      _SmallBadge(
+                          'A:${match.f2EffectiveAdvantages}', tk.goldFg),
+                      const SizedBox(width: 6),
+                    ],
+                    if (match.f2Pen > 0) ...[
+                      _SmallBadge('P:${match.f2Pen}', tk.dangerFg),
+                      const SizedBox(width: 4),
+                    ],
+                    Flexible(
+                      child: Text(
+                        match.f2Name,
+                        textAlign: TextAlign.right,
+                        style: TextStyle(
+                          color: colors.onSurface,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 16,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(width: 9),
+                    Container(
+                      width: 9,
+                      height: 9,
+                      decoration:
+                          BoxDecoration(color: f2Color, shape: BoxShape.circle),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+
+          // How it ended — because the scoreboard above cannot say. A match that
+          // finished on a submission shows the loser's numbers as the bigger
+          // ones, and only this line names the fighter who actually won.
+          if (describeOutcome(l10n, match) case final outcome?) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(Icons.emoji_events_outlined, size: 13, color: tk.goldFg),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    outcome,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                      color: tk.goldFg,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(18),
+      child: isCanceled ? Opacity(opacity: .72, child: card) : card,
+    );
+  }
+}

--- a/lib/shared/widgets/status_filter_bar.dart
+++ b/lib/shared/widgets/status_filter_bar.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+import '../../features/match/models/match.dart';
+import '../theme/app_theme.dart';
+import 'match_card.dart';
+
+/// The row of status chips above a match list: one per status, each showing how
+/// many matches are in it, each toggling that status in and out of view.
+///
+/// Shared by the home feed and the read-only scoreboard. The two filter
+/// different lists and keep their choices apart — hiding finished matches on
+/// somebody else's board should not hide them on your own — so the state comes
+/// in rather than being read from a provider in here.
+class StatusFilterBar extends StatelessWidget {
+  const StatusFilterBar({
+    super.key,
+    required this.matches,
+    required this.selected,
+    required this.onToggle,
+  });
+
+  /// Everything in scope, filter or no filter. The counts describe this rather
+  /// than what survives the filter, or a chip would only ever count what it
+  /// already lets through — and read zero for everything it hides.
+  final List<Match> matches;
+
+  final Set<MatchStatus> selected;
+
+  /// Called with the status that was tapped. What a toggle means is the
+  /// caller's to decide, because the set is theirs.
+  final ValueChanged<MatchStatus> onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final tk = ChokeTokens.of(context);
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final status in MatchStatus.values)
+          _StatusChip(
+            status: status,
+            count: matches.where((m) => m.status == status).length,
+            isSelected: selected.contains(status),
+            tokens: tk,
+            onTap: () => onToggle(status),
+          ),
+      ],
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({
+    required this.status,
+    required this.count,
+    required this.isSelected,
+    required this.tokens,
+    required this.onTap,
+  });
+
+  final MatchStatus status;
+  final int count;
+  final bool isSelected;
+  final ChokeTokens tokens;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final color = matchStatusAccent(tokens, status);
+
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      label: '${matchStatusLabel(l10n, status)}: $count',
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          // Enforce the 44px minimum interactive height for an accessible tap
+          // target; the visible layout and styling stay compact.
+          constraints: const BoxConstraints(minHeight: 44),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: isSelected ? color.withValues(alpha: .12) : tokens.card,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color:
+                  isSelected ? color.withValues(alpha: .5) : tokens.cardBorder,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                matchStatusLabel(l10n, status),
+                style: TextStyle(
+                  color: isSelected ? color : tokens.muted,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(width: 6),
+              Text(
+                '$count',
+                style: TextStyle(
+                  color: count > 0 ? color : tokens.faint,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/rust/api/crypto.dart
+++ b/lib/src/rust/api/crypto.dart
@@ -32,6 +32,18 @@ String nsecEncode({required String secretHex}) =>
 String? nsecDecode({required String nsec}) =>
     RustLib.instance.api.crateApiCryptoNsecDecode(nsec: nsec);
 
+/// The hex public key inside `npub`, or `None` if it is not a valid npub.
+///
+/// `None` rather than an error, for the same reason as `nsec_decode`: an npub is
+/// something a user pastes, and getting it wrong is not a bug.
+///
+/// Strictly bech32 — a bare hex key is *not* accepted here. Callers that take
+/// either form decide which one they were handed before calling, because the two
+/// cannot be told apart afterwards: any 64 hex characters parse as a public key,
+/// including a private one.
+String? npubDecode({required String npub}) =>
+    RustLib.instance.api.crateApiCryptoNpubDecode(npub: npub);
+
 /// Compute `event`'s id and sign it with `secret_hex`.
 SignedEventData finishEvent(
         {required UnsignedEventData event, required String secretHex}) =>

--- a/lib/src/rust/api/relay.dart
+++ b/lib/src/rust/api/relay.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'crypto.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `client`, `status_tx`
+// These functions are ignored because they are not marked as `pub`: `bump_generation`, `client`, `configured`, `current_generation`, `generation`, `ops`, `relay_add_locked`, `status_tx`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`
 
 /// Register a relay with the pool and dial it.
@@ -29,6 +29,29 @@ Future<void> relayDisconnect() =>
 /// TCP timeouts. When the app resumes we already know the sockets are suspect —
 /// the OS kills them without a close frame — and the referee's next tap must
 /// not wait for the kernel to work that out.
+///
+/// ## Why this rebuilds the relays instead of calling disconnect + connect
+///
+/// `nostr-sdk` 0.44's revival races its own teardown, and losing that race
+/// **strands the relay permanently**. `disconnect()` stores a termination
+/// permit (a tokio `Notify`) and returns with the status already `Terminated`;
+/// `connect()` then flips it to `Pending` and spawns a task — which sees the
+/// OLD task still registered and declines. The old task meanwhile wakes from
+/// `connect_and_run`, reads `Pending` (not terminated, so it keeps going),
+/// marks the relay `Disconnected`, and dies in its backoff sleep by consuming
+/// the stored permit. End state: status `Disconnected`, **no task**, and
+/// `connect()` is a no-op on `Disconnected` — nothing dials again until the
+/// process restarts. That is the app's "no connection until I kill it" bug,
+/// reproduced by the `resume never strands the transport` drill.
+///
+/// Nudging stragglers back to life with more disconnect/connect pairs just
+/// re-enters the same race (the drill stayed red under a 20-round nudge loop).
+/// The only sequence that cannot lose it is the one with no revival in it at
+/// all: **remove the relay and add it back**. A removed relay's watcher ends
+/// (its channel closes), and `relay_add` builds a fresh `Relay` — new `Notify`
+/// with no stored permit, no zombie task, a new watcher — and dials. Pool
+/// subscriptions survive by design: a newly added relay inherits them
+/// (`nostr-relay-pool` inherits pool subscriptions on `add_relay`).
 Future<void> relayReconnectAll() =>
     RustLib.instance.api.crateApiRelayRelayReconnectAll();
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -71,7 +71,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -998690459;
+  int get rustContentHash => -465090834;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -89,6 +89,8 @@ abstract class RustLibApi extends BaseApi {
   String crateApiCryptoGenerateSecretKey();
 
   Future<void> crateApiCryptoInitApp();
+
+  String? crateApiCryptoNpubDecode({required String npub});
 
   String crateApiCryptoNpubEncode({required String publicKeyHex});
 
@@ -209,12 +211,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  String? crateApiCryptoNpubDecode({required String npub}) {
+    return handler.executeSync(SyncTask(
+      callFfi: () {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(npub, serializer);
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_opt_String,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiCryptoNpubDecodeConstMeta,
+      argValues: [npub],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiCryptoNpubDecodeConstMeta => const TaskConstMeta(
+        debugName: "npub_decode",
+        argNames: ["npub"],
+      );
+
+  @override
   String crateApiCryptoNpubEncode({required String publicKeyHex}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(publicKeyHex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -237,7 +262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(nsec, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_String,
@@ -260,7 +285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(secretHex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -283,7 +308,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(secretHex, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_String,
@@ -308,7 +333,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(url, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 8, port: port_);
+            funcId: 9, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -331,7 +356,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 9, port: port_);
+            funcId: 10, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -354,7 +379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 10, port: port_);
+            funcId: 11, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -378,7 +403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 11, port: port_);
+            funcId: 12, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -404,7 +429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_signed_event_data_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 12, port: port_);
+            funcId: 13, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -432,7 +457,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(url, serializer);
         sse_encode_box_autoadd_signed_event_data(event, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 13, port: port_);
+            funcId: 14, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -455,7 +480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 14, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -480,7 +505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(url, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 15, port: port_);
+            funcId: 16, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -505,7 +530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_relay_status_data_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 16, port: port_);
+            funcId: 17, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -533,7 +558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(subscriptionId, serializer);
         sse_encode_box_autoadd_filter_data(filter, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 17, port: port_);
+            funcId: 18, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -558,7 +583,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(subscriptionId, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 18, port: port_);
+            funcId: 19, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -582,7 +607,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 19, port: port_);
+            funcId: 20, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -605,7 +630,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(eventJson, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -628,7 +653,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_signed_event_data(event, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,

--- a/rust/src/api/crypto.rs
+++ b/rust/src/api/crypto.rs
@@ -75,6 +75,22 @@ pub fn nsec_decode(nsec: String) -> Option<String> {
         .map(|secret_key| secret_key.to_secret_hex())
 }
 
+/// The hex public key inside `npub`, or `None` if it is not a valid npub.
+///
+/// `None` rather than an error, for the same reason as `nsec_decode`: an npub is
+/// something a user pastes, and getting it wrong is not a bug.
+///
+/// Strictly bech32 — a bare hex key is *not* accepted here. Callers that take
+/// either form decide which one they were handed before calling, because the two
+/// cannot be told apart afterwards: any 64 hex characters parse as a public key,
+/// including a private one.
+#[flutter_rust_bridge::frb(sync)]
+pub fn npub_decode(npub: String) -> Option<String> {
+    PublicKey::from_bech32(&npub)
+        .ok()
+        .map(|public_key| public_key.to_hex())
+}
+
 /// Compute `event`'s id and sign it with `secret_hex`.
 #[flutter_rust_bridge::frb(sync)]
 pub fn finish_event(

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -998690459;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -465090834;
 
 // Section: executor
 
@@ -137,6 +137,36 @@ fn wire__crate__api__crypto__init_app_impl(
                     Ok(output_ok)
                 })())
             }
+        },
+    )
+}
+fn wire__crate__api__crypto__npub_decode_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "npub_decode",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_npub = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::crypto::npub_decode(api_npub))?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -1024,18 +1054,18 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         3 => wire__crate__api__crypto__init_app_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__relay__relay_add_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__relay__relay_connect_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__relay__relay_connected_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__relay__relay_disconnect_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__relay__relay_event_stream_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__relay__relay_publish_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__relay__relay_reconnect_all_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__relay__relay_remove_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__relay__relay_status_stream_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__relay__relay_subscribe_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__relay__relay_unsubscribe_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__relay__relay_urls_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__relay__relay_add_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__relay__relay_connect_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__relay__relay_connected_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__relay__relay_disconnect_impl(port, ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__relay__relay_event_stream_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__relay__relay_publish_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__relay__relay_reconnect_all_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__relay__relay_remove_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__relay__relay_status_stream_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__relay__relay_subscribe_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__relay__relay_unsubscribe_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__relay__relay_urls_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1050,12 +1080,13 @@ fn pde_ffi_dispatcher_sync_impl(
     match func_id {
         1 => wire__crate__api__crypto__finish_event_impl(ptr, rust_vec_len, data_len),
         2 => wire__crate__api__crypto__generate_secret_key_impl(ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__crypto__npub_encode_impl(ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__crypto__nsec_decode_impl(ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__crypto__nsec_encode_impl(ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__crypto__public_key_from_secret_impl(ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__crypto__verify_event_impl(ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__crypto__verify_event_data_impl(ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__crypto__npub_decode_impl(ptr, rust_vec_len, data_len),
+        5 => wire__crate__api__crypto__npub_encode_impl(ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__crypto__nsec_decode_impl(ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__crypto__nsec_encode_impl(ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__crypto__public_key_from_secret_impl(ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__crypto__verify_event_impl(ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__crypto__verify_event_data_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/test/features/account/account_screen_test.dart
+++ b/test/features/account/account_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/features/account/account_screen.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
 
 import '../../support/nostr_fakes.dart';
 
@@ -36,7 +37,23 @@ class _SpyKeyManager extends KeyManager {
   Future<String?> getNsec() async => 'nsec1fake';
 }
 
+/// Records whether the relays were pointed at the new identity.
+class _SpyNostrService extends NostrService {
+  _SpyNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  int refreshes = 0;
+
+  @override
+  Future<void> refreshIdentity() async => refreshes++;
+}
+
 void main() {
+  late _SpyNostrService nostr;
+
+  setUp(() => nostr = _SpyNostrService());
+
   Future<void> pumpAccountScreen(
     WidgetTester tester,
     _SpyKeyManager keyManager,
@@ -45,6 +62,7 @@ void main() {
       ProviderScope(
         overrides: [
           keyManagerProvider.overrideWithValue(keyManager),
+          nostrServiceProvider.overrideWithValue(nostr),
         ],
         child: const MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -144,6 +162,30 @@ void main() {
       expect(find.text('Your Nostr Identity'), findsOneWidget);
       expect(find.text('npub1after'), findsOneWidget);
       expect(find.text('npub1before'), findsNothing);
+    });
+  });
+
+  group('identity change', () {
+    testWidgets('generating a keypair moves the subscription with it',
+        (tester) async {
+      // A new key with the old subscription still running means the relays keep
+      // sending the previous identity's matches, and the home feed — which asks
+      // the service who this user is — throws away every match published under
+      // the new one.
+      //
+      // Arrange
+      final keyManager = _SpyKeyManager();
+      await pumpAccountScreen(tester, keyManager);
+      expect(nostr.refreshes, 0);
+
+      // Act — the same path the existing generate test takes
+      await tester.tap(find.byIcon(Icons.autorenew));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(ElevatedButton, 'Generate'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(nostr.refreshes, 1);
     });
   });
 }

--- a/test/features/home/providers/home_providers_edge_cases_test.dart
+++ b/test/features/home/providers/home_providers_edge_cases_test.dart
@@ -19,6 +19,12 @@ class _StreamNostrService extends NostrService {
 
   @override
   Stream<NostrEvent> get eventStream => controller.stream;
+
+  /// The author `_echoOf` stamps by default. The feed drops anything from
+  /// anybody else, so a service with no identity would drop every event these
+  /// tests push through it.
+  @override
+  String? get userPubkey => 'pk';
 }
 
 Match _match({String id = 'abcd'}) {

--- a/test/features/home/providers/home_providers_test.dart
+++ b/test/features/home/providers/home_providers_test.dart
@@ -21,6 +21,17 @@ class _StreamNostrService extends NostrService {
   Stream<NostrEvent> get eventStream => controller.stream;
 }
 
+/// A service that already knows who it is, as one does after
+/// `subscribeToUserEvents`.
+class _IdentifiedNostrService extends _StreamNostrService {
+  _IdentifiedNostrService(this._me);
+
+  final String _me;
+
+  @override
+  String? get userPubkey => _me;
+}
+
 Match _match({int f1Pt2 = 0, MatchStatus status = MatchStatus.inProgress}) {
   return Match(
     id: 'abcd',
@@ -35,10 +46,10 @@ Match _match({int f1Pt2 = 0, MatchStatus status = MatchStatus.inProgress}) {
   );
 }
 
-NostrEvent _echoOf(Match match, int createdAt) {
+NostrEvent _echoOf(Match match, int createdAt, {String pubkey = 'pk'}) {
   return NostrEvent(
     id: 'e1',
-    pubkey: 'pk',
+    pubkey: pubkey,
     createdAt: createdAt,
     kind: 31415,
     tags: [
@@ -61,6 +72,69 @@ void main() {
   tearDown(() async {
     feed.dispose();
     await nostr.controller.close();
+  });
+
+  group('MatchFeedNotifier author filter', () {
+    // The scoreboard section subscribes to whatever pubkey the user pastes, and
+    // every subscription shares one event stream that says nothing about which
+    // filter matched. Without an author check, watching somebody else's matches
+    // would quietly file them into this user's own feed.
+    test('ignores a match published by somebody else', () async {
+      // Arrange
+      final nostr = _IdentifiedNostrService('me');
+      final feed = MatchFeedNotifier(nostr);
+      addTearDown(() async {
+        feed.dispose();
+        await nostr.controller.close();
+      });
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act — a match arriving from the pubkey the scoreboard is watching
+      nostr.controller.add(_echoOf(_match(), now, pubkey: 'someone-else'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(feed.state, isEmpty);
+    });
+
+    test('keeps a match this user published', () async {
+      // Arrange
+      final nostr = _IdentifiedNostrService('me');
+      final feed = MatchFeedNotifier(nostr);
+      addTearDown(() async {
+        feed.dispose();
+        await nostr.controller.close();
+      });
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act
+      nostr.controller.add(_echoOf(_match(), now, pubkey: 'me'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(feed.state, hasLength(1));
+    });
+
+    test('accepts events while the app still does not know who it is', () async {
+      // Arrange — before subscribeToUserEvents there is no other subscription to
+      // confuse this feed with, and dropping here would lose the user's own
+      // opening events: a relay does not send them again.
+      final nostr = _StreamNostrService();
+      final feed = MatchFeedNotifier(nostr);
+      addTearDown(() async {
+        feed.dispose();
+        await nostr.controller.close();
+      });
+      expect(nostr.userPubkey, isNull);
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act
+      nostr.controller.add(_echoOf(_match(), now, pubkey: 'whoever'));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(feed.state, hasLength(1));
+    });
   });
 
   group('MatchFeedNotifier', () {

--- a/test/features/home/providers/home_providers_test.dart
+++ b/test/features/home/providers/home_providers_test.dart
@@ -19,6 +19,19 @@ class _StreamNostrService extends NostrService {
 
   @override
   Stream<NostrEvent> get eventStream => controller.stream;
+
+  /// The author `_echoOf` stamps by default. The feed drops anything from
+  /// anybody else, so a service with no identity would drop every event these
+  /// tests push through it.
+  @override
+  String? get userPubkey => 'pk';
+}
+
+/// A service whose identity lookup never completed — the path where
+/// `subscribeToUserEvents` threw and `main` caught it.
+class _AnonymousNostrService extends _StreamNostrService {
+  @override
+  String? get userPubkey => null;
 }
 
 /// A service that already knows who it is, as one does after
@@ -115,11 +128,14 @@ void main() {
       expect(feed.state, hasLength(1));
     });
 
-    test('accepts events while the app still does not know who it is', () async {
-      // Arrange — before subscribeToUserEvents there is no other subscription to
-      // confuse this feed with, and dropping here would lose the user's own
-      // opening events: a relay does not send them again.
-      final nostr = _StreamNostrService();
+    test('drops everything while the app does not know who it is', () async {
+      // Arrange — main awaits subscribeToUserEvents before runApp, so a null
+      // pubkey here is not an early frame: it is the path where looking the
+      // identity up failed and was caught. The app still launches, the user can
+      // still watch somebody else's board, and every subscription shares this
+      // stream — so accepting anything would file an organizer's matches as
+      // this user's own.
+      final nostr = _AnonymousNostrService();
       final feed = MatchFeedNotifier(nostr);
       addTearDown(() async {
         feed.dispose();
@@ -133,7 +149,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       // Assert
-      expect(feed.state, hasLength(1));
+      expect(feed.state, isEmpty);
     });
   });
 

--- a/test/features/scoreboard/providers/scoreboard_providers_test.dart
+++ b/test/features/scoreboard/providers/scoreboard_providers_test.dart
@@ -174,7 +174,7 @@ void main() {
       expect(feed.state, isEmpty);
     });
 
-    test('closes its subscription when it goes away', () {
+    test('closes the subscription it opened when it goes away', () {
       // Arrange
       final feed = ScoreboardFeedNotifier(nostr, watched);
 
@@ -182,7 +182,39 @@ void main() {
       feed.dispose();
 
       // Assert — otherwise every pubkey the user tried keeps streaming
-      expect(nostr.unsubscribed, ['scoreboard_$watched']);
+      expect(nostr.unsubscribed, hasLength(1));
+      expect(nostr.unsubscribed.single, startsWith('sb_'));
+    });
+
+    test('uses a subscription id a relay will actually accept', () {
+      // A NIP-01 subscription id is capped at 64 characters and a relay drops
+      // the whole REQ over it — nos.lol answers `CLOSED … "ERROR: bad req:
+      // invalid subscription id"`. `scoreboard_` plus a 64-character pubkey came
+      // to 75, and the section received nothing at all while publishing and the
+      // app's own subscription both looked fine.
+      //
+      // Arrange
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+
+      // Act
+      feed.dispose();
+
+      // Assert
+      expect(nostr.unsubscribed.single.length, lessThanOrEqualTo(64));
+    });
+
+    test('tells two watched authors apart', () {
+      // Arrange — a shared id would let one feed's teardown close the other's
+      // subscription
+      const other =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+      // Act
+      ScoreboardFeedNotifier(nostr, watched).dispose();
+      ScoreboardFeedNotifier(nostr, other).dispose();
+
+      // Assert
+      expect(nostr.unsubscribed.first, isNot(nostr.unsubscribed.last));
     });
 
     test('does not close a subscription it never opened', () {

--- a/test/features/scoreboard/providers/scoreboard_providers_test.dart
+++ b/test/features/scoreboard/providers/scoreboard_providers_test.dart
@@ -21,6 +21,14 @@ class _SpyNostrService extends NostrService {
   final subscribed = <String>[];
   final unsubscribed = <String>[];
 
+  /// What the service has already seen and would not replay on the stream.
+  final cached = <NostrEvent>[];
+
+  @override
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) => cached
+      .where((e) => e.kind == kind && e.pubkey == pubkey)
+      .toList();
+
   @override
   Stream<NostrEvent> get eventStream => controller.stream;
 
@@ -366,6 +374,76 @@ void main() {
       final matches = container.read(scoreboardMatchesProvider);
       expect(matches.map((m) => m.id), ['eee5'],
           reason: 'fff6 is a day and a minute old');
+    });
+  });
+
+  group('ScoreboardFeedNotifier hydration', () {
+    late _SpyNostrService nostr;
+
+    setUp(() => nostr = _SpyNostrService());
+    tearDown(() => nostr.controller.close());
+
+    test('starts from what the app already knows about this author', () {
+      // Arrange — watched once before, so the service holds the latest state
+      // and will drop the relay's replay of it as no newer
+      nostr.cached.add(_eventOf(_match(f1Pt2: 2), pubkey: watched));
+
+      // Act — watch that author again
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+      addTearDown(feed.dispose);
+
+      // Assert — leaving and coming back used to show an empty board until the
+      // author happened to score again
+      expect(feed.state.single.f1Pt2, 2);
+    });
+
+    test('does not take cached matches belonging to another author', () {
+      // Arrange
+      nostr.cached.add(_eventOf(_match(), pubkey: 'c' * 64));
+
+      // Act
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+      addTearDown(feed.dispose);
+
+      // Assert
+      expect(feed.state, isEmpty);
+    });
+
+    test('a live event still supersedes the cached one', () async {
+      // Arrange
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      nostr.cached
+          .add(_eventOf(_match(f1Pt2: 1), pubkey: watched, createdAt: now - 60));
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+      addTearDown(feed.dispose);
+
+      // Act
+      nostr.controller
+          .add(_eventOf(_match(f1Pt2: 3), pubkey: watched, createdAt: now));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(feed.state.single.f1Pt2, 3);
+    });
+  });
+
+  group('WatchedPubkeyNotifier stop-watching race', () {
+    test('a restore in flight does not undo an explicit stop', () async {
+      // Arrange — a saved pubkey is on its way back from disk
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': watched},
+      );
+      final notifier = WatchedPubkeyNotifier();
+      addTearDown(notifier.dispose);
+
+      // Act — the user stops watching before the restore lands. Both "nobody
+      // has chosen" and "chose to stop" are null, so the restore must not read
+      // the second as the first.
+      await notifier.watch(null);
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert — the board they just closed must not come back
+      expect(notifier.state, isNull);
     });
   });
 }

--- a/test/features/scoreboard/providers/scoreboard_providers_test.dart
+++ b/test/features/scoreboard/providers/scoreboard_providers_test.dart
@@ -1,0 +1,339 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+
+import '../../../support/nostr_fakes.dart';
+
+/// A service whose event stream the test drives, and which records what the
+/// scoreboard asked the relays for.
+class _SpyNostrService extends NostrService {
+  _SpyNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  final controller = StreamController<NostrEvent>.broadcast();
+  final subscribed = <String>[];
+  final unsubscribed = <String>[];
+
+  @override
+  Stream<NostrEvent> get eventStream => controller.stream;
+
+  @override
+  void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {
+    subscribed.add(authorPubkey);
+  }
+
+  @override
+  void unsubscribe(String subscriptionId) => unsubscribed.add(subscriptionId);
+}
+
+Match _match({String id = 'abcd', int f1Pt2 = 0}) {
+  return Match(
+    id: id,
+    status: MatchStatus.inProgress,
+    startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    duration: 300,
+    f1Name: 'Pana',
+    f2Name: 'Buchecha',
+    f1Color: '#1BA34E',
+    f2Color: '#F5B800',
+    f1Pt2: f1Pt2,
+  );
+}
+
+NostrEvent _eventOf(Match match, {required String pubkey, int? createdAt}) {
+  return NostrEvent(
+    id: 'e1',
+    pubkey: pubkey,
+    createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    kind: 31415,
+    tags: [
+      ['d', match.id],
+    ],
+    content: match.toJsonString(),
+    sig: '',
+  );
+}
+
+void main() {
+  const watched = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  group('parsePubkey', () {
+    final crypto = FakeNostrCrypto();
+
+    test('takes a bare hex key', () {
+      // Arrange
+      final hex = 'A' * 64;
+
+      // Act
+      final parsed = parsePubkey(hex, crypto);
+
+      // Assert — normalised, so one key never reads as two different ones
+      expect(parsed, 'a' * 64);
+    });
+
+    test('takes an npub and returns its hex', () {
+      // Act
+      final parsed = parsePubkey('npub1fake', crypto);
+
+      // Assert
+      expect(parsed, watched);
+    });
+
+    test('ignores the whitespace that pasting tends to bring', () {
+      // Act & Assert
+      expect(parsePubkey('  npub1fake\n', crypto), watched);
+      expect(parsePubkey(' ${'a' * 64} ', crypto), 'a' * 64);
+    });
+
+    test('refuses anything that is neither', () {
+      // Act & Assert
+      expect(parsePubkey('', crypto), isNull);
+      expect(parsePubkey('   ', crypto), isNull);
+      expect(parsePubkey('not a key', crypto), isNull);
+      expect(parsePubkey('a' * 63, crypto), isNull, reason: 'too short');
+      expect(parsePubkey('z' * 64, crypto), isNull, reason: 'not hex');
+    });
+  });
+
+  group('ScoreboardFeedNotifier', () {
+    late _SpyNostrService nostr;
+
+    setUp(() => nostr = _SpyNostrService());
+    tearDown(() => nostr.controller.close());
+
+    test('asks the relays for the watched author', () {
+      // Act
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+      addTearDown(feed.dispose);
+
+      // Assert
+      expect(nostr.subscribed, [watched]);
+    });
+
+    test('takes a match the watched author published', () async {
+      // Arrange
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+      addTearDown(feed.dispose);
+
+      // Act
+      nostr.controller.add(_eventOf(_match(f1Pt2: 1), pubkey: watched));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(feed.state.single.f1Pt2, 1);
+    });
+
+    test('ignores a match somebody else published', () async {
+      // Arrange — the user's own subscription shares this stream
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+      addTearDown(feed.dispose);
+
+      // Act
+      nostr.controller.add(_eventOf(_match(), pubkey: 'c' * 64));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(feed.state, isEmpty);
+    });
+
+    test('keeps the newest revision, not the last one to arrive', () async {
+      // Arrange — an addressable event is republished as the match is scored,
+      // and relays can replay an older revision after a newer one
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+      addTearDown(feed.dispose);
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act
+      nostr.controller
+          .add(_eventOf(_match(f1Pt2: 2), pubkey: watched, createdAt: now));
+      await Future<void>.delayed(Duration.zero);
+      nostr.controller.add(
+          _eventOf(_match(f1Pt2: 1), pubkey: watched, createdAt: now - 30));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(feed.state.single.f1Pt2, 2);
+    });
+
+    test('does nothing at all when no pubkey is being watched', () async {
+      // Act
+      final feed = ScoreboardFeedNotifier(nostr, null);
+      addTearDown(feed.dispose);
+      nostr.controller.add(_eventOf(_match(), pubkey: watched));
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(nostr.subscribed, isEmpty);
+      expect(feed.state, isEmpty);
+    });
+
+    test('closes its subscription when it goes away', () {
+      // Arrange
+      final feed = ScoreboardFeedNotifier(nostr, watched);
+
+      // Act
+      feed.dispose();
+
+      // Assert — otherwise every pubkey the user tried keeps streaming
+      expect(nostr.unsubscribed, ['scoreboard_$watched']);
+    });
+
+    test('does not close a subscription it never opened', () {
+      // Arrange
+      final feed = ScoreboardFeedNotifier(nostr, null);
+
+      // Act
+      feed.dispose();
+
+      // Assert
+      expect(nostr.unsubscribed, isEmpty);
+    });
+  });
+
+  group('WatchedPubkeyNotifier', () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    test('remembers the pubkey it was given', () async {
+      // Arrange
+      final notifier = WatchedPubkeyNotifier();
+      addTearDown(notifier.dispose);
+
+      // Act
+      await notifier.watch(watched);
+
+      // Assert
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('choke:scoreboard-pubkey'), watched);
+      expect(notifier.state, watched);
+    });
+
+    test('restores a saved pubkey, so a tournament survives a relaunch',
+        () async {
+      // Arrange
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': watched},
+      );
+
+      // Act
+      final notifier = WatchedPubkeyNotifier();
+      addTearDown(notifier.dispose);
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(notifier.state, watched);
+    });
+
+    test('a pubkey pasted while the saved one loads is not overwritten',
+        () async {
+      // Arrange
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': 'd' * 64},
+      );
+      final notifier = WatchedPubkeyNotifier();
+      addTearDown(notifier.dispose);
+
+      // Act — the user is faster than the disk
+      await notifier.watch(watched);
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(notifier.state, watched);
+    });
+
+    test('forgets the pubkey when watching stops', () async {
+      // Arrange
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': watched},
+      );
+      final notifier = WatchedPubkeyNotifier();
+      addTearDown(notifier.dispose);
+
+      // Act
+      await notifier.watch(null);
+
+      // Assert
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('choke:scoreboard-pubkey'), isNull);
+      expect(notifier.state, isNull);
+    });
+  });
+
+  group('scoreboardMatchesProvider', () {
+    late _SpyNostrService nostr;
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      nostr = _SpyNostrService();
+      container = ProviderContainer(overrides: [
+        nostrServiceProvider.overrideWithValue(nostr),
+      ]);
+      await container.read(watchedPubkeyProvider.notifier).watch(watched);
+      // Realise the feed so it is listening before any event is pushed.
+      container.read(scoreboardFeedProvider);
+    });
+
+    tearDown(() async {
+      container.dispose();
+      await nostr.controller.close();
+    });
+
+    Future<void> push(Match match, int createdAt) async {
+      nostr.controller
+          .add(_eventOf(match, pubkey: watched, createdAt: createdAt));
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    test('puts the live match first, whatever order it arrived in', () async {
+      // Arrange
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act — the finished one is newer, so newest-first alone would lead with it
+      await push(_match(id: 'aaa1'), now - 100);
+      await push(
+        _match(id: 'bbb2').copyWith(status: MatchStatus.finished),
+        now,
+      );
+
+      // Assert — on a board, the fight in progress is the point
+      final matches = container.read(scoreboardMatchesProvider);
+      expect(matches.map((m) => m.id), ['aaa1', 'bbb2'],
+          reason: 'aaa1 is live, bbb2 is finished');
+    });
+
+    test('orders matches of equal standing newest first', () async {
+      // Arrange
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act
+      await push(_match(id: 'ccc3'), now - 500);
+      await push(_match(id: 'ddd4'), now - 10);
+
+      // Assert
+      final matches = container.read(scoreboardMatchesProvider);
+      expect(matches.map((m) => m.id), ['ddd4', 'ccc3'],
+          reason: 'ddd4 is the newer of the two');
+    });
+
+    test('drops a match older than the age limit', () async {
+      // Arrange — a scoreboard is about the mats now, not yesterday
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act
+      await push(_match(id: 'eee5'), now - 60);
+      await push(_match(id: 'fff6'), now - scoreboardMaxAgeSeconds - 60);
+
+      // Assert
+      final matches = container.read(scoreboardMatchesProvider);
+      expect(matches.map((m) => m.id), ['eee5'],
+          reason: 'fff6 is a day and a minute old');
+    });
+  });
+}

--- a/test/features/scoreboard/scoreboard_screens_test.dart
+++ b/test/features/scoreboard/scoreboard_screens_test.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/features/scoreboard/scoreboard_match_screen.dart';
+import 'package:choke/features/scoreboard/scoreboard_screen.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+import 'package:choke/shared/theme/app_theme.dart';
+
+import '../../support/nostr_fakes.dart';
+
+/// The relays are not part of what these tests are about; the feed just needs
+/// something that answers.
+class _OfflineNostrService extends NostrService {
+  _OfflineNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  @override
+  void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {}
+}
+
+const _watched =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+Match _match({
+  MatchStatus status = MatchStatus.inProgress,
+  MatchWinner? winner,
+  MatchMethod? method,
+  String? submission,
+}) {
+  return Match(
+    id: 'abcd',
+    status: status,
+    startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    duration: 300,
+    f1Name: 'Buchecha',
+    f2Name: 'Roger Gracie',
+    f1Color: '#1BA34E',
+    f2Color: '#F5B800',
+    f1Pt2: 1,
+    f2Pt3: 1,
+    f1Pen: 1,
+    f2Adv: 1,
+    winner: winner,
+    method: method,
+    submission: submission,
+    endedAt: status == MatchStatus.finished
+        ? DateTime.now().millisecondsSinceEpoch ~/ 1000
+        : null,
+  );
+}
+
+Widget _wrap(Widget child, {List<Override> overrides = const []}) {
+  return ProviderScope(
+    overrides: [
+      nostrCryptoProvider.overrideWithValue(FakeNostrCrypto()),
+      nostrServiceProvider.overrideWithValue(_OfflineNostrService()),
+      ...overrides,
+    ],
+    child: MaterialApp(
+      theme: AppTheme.darkTheme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    ),
+  );
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('ScoreboardScreen', () {
+    testWidgets('asks for a pubkey before it shows anything', (tester) async {
+      // Arrange + Act
+      await tester.pumpWidget(_wrap(const ScoreboardScreen()));
+      await tester.pump();
+
+      // Assert
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.text(l10n.scoreboardWelcomeBody), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('refuses something that is not a pubkey, and watches nothing',
+        (tester) async {
+      // Arrange
+      late WidgetRef capturedRef;
+      await tester.pumpWidget(_wrap(Consumer(builder: (context, ref, _) {
+        capturedRef = ref;
+        return const ScoreboardScreen();
+      })));
+      await tester.pump();
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+      // Act
+      await tester.enterText(find.byType(TextField), 'definitely-not-a-key');
+      await tester.tap(find.text(l10n.scoreboardWatch));
+      await tester.pump();
+
+      // Assert
+      expect(find.text(l10n.scoreboardInvalidPubkey), findsOneWidget);
+      expect(capturedRef.read(watchedPubkeyProvider), isNull);
+    });
+
+    testWidgets('takes an npub and starts watching it', (tester) async {
+      // Arrange
+      late WidgetRef capturedRef;
+      await tester.pumpWidget(_wrap(Consumer(builder: (context, ref, _) {
+        capturedRef = ref;
+        return const ScoreboardScreen();
+      })));
+      await tester.pump();
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+      // Act — FakeNostrCrypto decodes this sentinel to the watched hex key
+      await tester.enterText(find.byType(TextField), 'npub1fake');
+      await tester.tap(find.text(l10n.scoreboardWatch));
+      await tester.pump();
+
+      // Assert
+      expect(capturedRef.read(watchedPubkeyProvider), _watched);
+    });
+
+    testWidgets("lists the watched pubkey's matches", (tester) async {
+      // Arrange + Act
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': _watched},
+      );
+      await tester.pumpWidget(_wrap(
+        const ScoreboardScreen(),
+        overrides: [
+          scoreboardMatchesProvider.overrideWithValue([_match()]),
+        ],
+      ));
+      await tester.pump();
+      await tester.pump(); // the saved pubkey is restored asynchronously
+
+      // Assert
+      expect(find.text('Buchecha'), findsOneWidget);
+      expect(find.text('Roger Gracie'), findsOneWidget);
+    });
+
+    testWidgets('says so when the organizer has published nothing yet',
+        (tester) async {
+      // Arrange — a pubkey is being watched, but no events have arrived
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': _watched},
+      );
+      await tester.pumpWidget(_wrap(
+        const ScoreboardScreen(),
+        overrides: [
+          scoreboardMatchesProvider.overrideWithValue(const []),
+        ],
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      // Assert
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.text(l10n.scoreboardEmptyBody), findsOneWidget);
+    });
+  });
+
+  group('ScoreboardMatchScreen', () {
+    Future<void> pumpBoard(WidgetTester tester, Match match) async {
+      // Landscape, which is the orientation this screen asks the device for.
+      tester.view.physicalSize = const Size(1600, 740);
+      tester.view.devicePixelRatio = 2.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(_wrap(
+        ScoreboardMatchScreen(matchId: match.id),
+        overrides: [
+          scoreboardMatchesProvider.overrideWithValue([match]),
+        ],
+      ));
+      await tester.pump();
+    }
+
+    testWidgets('shows both fighters and their effective scores',
+        (tester) async {
+      // Arrange + Act — f1 scored a takedown (2); f2 scored a guard pass (3)
+      // and gained 2 more from f1's third penalty… which f1 does not have, so
+      // f2 stands at 3 while f1's single penalty concedes nothing yet
+      await pumpBoard(tester, _match());
+
+      // Assert
+      expect(find.text('BUCHECHA'), findsOneWidget);
+      expect(find.text('ROGER GRACIE'), findsOneWidget);
+      expect(find.text('2'), findsWidgets, reason: "f1's takedown");
+      expect(find.text('3'), findsWidgets, reason: "f2's guard pass");
+    });
+
+    testWidgets('runs a clock while the match is live', (tester) async {
+      // Arrange + Act
+      await pumpBoard(tester, _match());
+
+      // Assert
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.text(l10n.scoreboardTime), findsOneWidget);
+      expect(find.textContaining(RegExp(r'^\d\d:\d\d$')), findsOneWidget);
+    });
+
+    testWidgets('shows the time the match itself says is left', (tester) async {
+      // Arrange — a clock is derived from the event, never counted locally, so a
+      // match that started 30 seconds ago reads 30 seconds down whoever opens it
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final started = _match().copyWith(startAt: now - 30);
+
+      // Act
+      await pumpBoard(tester, started);
+
+      // Assert — 5:00 minus 30 seconds
+      expect(find.text('04:30'), findsOneWidget);
+    });
+
+    testWidgets('names the winner and how they won, once it is over',
+        (tester) async {
+      // Arrange + Act — f2 wins by submission, which the numbers cannot say
+      await pumpBoard(
+        tester,
+        _match(
+          status: MatchStatus.finished,
+          winner: MatchWinner.f2,
+          method: MatchMethod.submission,
+          submission: 'bow_and_arrow',
+        ),
+      );
+
+      // Assert
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.text(l10n.scoreboardWinner.toUpperCase()), findsOneWidget);
+      expect(find.text('ROGER GRACIE'), findsWidgets);
+      // The clock is gone: a finished match has no time left to show.
+      expect(find.text(l10n.scoreboardTime), findsNothing);
+    });
+
+    testWidgets('a match that is no longer in the feed says so',
+        (tester) async {
+      // Arrange + Act — it can age out while this screen is open
+      tester.view.physicalSize = const Size(1600, 740);
+      tester.view.devicePixelRatio = 2.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(_wrap(
+        const ScoreboardMatchScreen(matchId: 'gone'),
+        overrides: [
+          scoreboardMatchesProvider.overrideWithValue(const []),
+        ],
+      ));
+      await tester.pump();
+
+      // Assert
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.text(l10n.scoreboardEmptyTitle), findsOneWidget);
+    });
+  });
+}

--- a/test/features/scoreboard/scoreboard_screens_test.dart
+++ b/test/features/scoreboard/scoreboard_screens_test.dart
@@ -11,6 +11,7 @@ import 'package:choke/services/key_management/key_manager.dart';
 import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
 import 'package:choke/services/nostr/nostr_service.dart';
 import 'package:choke/shared/theme/app_theme.dart';
+import 'package:choke/shared/widgets/status_filter_bar.dart';
 
 import '../../support/nostr_fakes.dart';
 
@@ -136,6 +137,7 @@ void main() {
         const ScoreboardScreen(),
         overrides: [
           scoreboardMatchesProvider.overrideWithValue([_match()]),
+          scoreboardFilteredMatchesProvider.overrideWithValue([_match()]),
         ],
       ));
       await tester.pump();
@@ -156,6 +158,7 @@ void main() {
         const ScoreboardScreen(),
         overrides: [
           scoreboardMatchesProvider.overrideWithValue(const []),
+          scoreboardFilteredMatchesProvider.overrideWithValue(const []),
         ],
       ));
       await tester.pump();
@@ -251,6 +254,7 @@ void main() {
         const ScoreboardMatchScreen(matchId: 'gone'),
         overrides: [
           scoreboardMatchesProvider.overrideWithValue(const []),
+          scoreboardFilteredMatchesProvider.overrideWithValue(const []),
         ],
       ));
       await tester.pump();
@@ -258,6 +262,106 @@ void main() {
       // Assert
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
       expect(find.text(l10n.scoreboardEmptyTitle), findsOneWidget);
+    });
+  });
+
+  group('ScoreboardScreen status filter', () {
+    testWidgets('shows a chip per status, counting everything in scope',
+        (tester) async {
+      // Arrange — counts come from the whole set, not from what survives the
+      // filter, or a hidden status would always read zero
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': _watched},
+      );
+      final live = _match();
+      final done = _match(status: MatchStatus.finished);
+
+      // Act
+      await tester.pumpWidget(_wrap(
+        const ScoreboardScreen(),
+        overrides: [
+          scoreboardMatchesProvider.overrideWithValue([live, done]),
+          scoreboardFilteredMatchesProvider.overrideWithValue([live]),
+        ],
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      // Assert — four chips, and the finished one counts its match even though
+      // the list is not showing it
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.byType(StatusFilterBar), findsOneWidget);
+
+      // Scoped to the bar: the cards carry a status chip of their own, so a
+      // bare text finder would count those too.
+      Finder inBar(String label) => find.descendant(
+            of: find.byType(StatusFilterBar),
+            matching: find.text(label),
+          );
+      expect(inBar(l10n.statusFinished), findsOneWidget);
+      expect(inBar(l10n.statusInProgress), findsOneWidget);
+      expect(inBar(l10n.statusWaiting), findsOneWidget);
+      expect(inBar(l10n.statusCanceled), findsOneWidget);
+    });
+
+    testWidgets('tapping a chip toggles that status into the filter',
+        (tester) async {
+      // Arrange
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': _watched},
+      );
+      late WidgetRef capturedRef;
+      await tester.pumpWidget(_wrap(
+        Consumer(builder: (context, ref, _) {
+          capturedRef = ref;
+          return const ScoreboardScreen();
+        }),
+        overrides: [
+          scoreboardMatchesProvider.overrideWithValue([_match()]),
+          scoreboardFilteredMatchesProvider.overrideWithValue([_match()]),
+        ],
+      ));
+      await tester.pump();
+      await tester.pump();
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(
+        capturedRef.read(scoreboardStatusFilterProvider),
+        isNot(contains(MatchStatus.finished)),
+      );
+
+      final chip = find.descendant(
+        of: find.byType(StatusFilterBar),
+        matching: find.text(l10n.statusFinished),
+      );
+
+      // Act
+      await tester.tap(chip);
+      await tester.pump();
+
+      // Assert
+      expect(
+        capturedRef.read(scoreboardStatusFilterProvider),
+        contains(MatchStatus.finished),
+      );
+
+      // Act — and off again
+      await tester.tap(chip);
+      await tester.pump();
+
+      // Assert
+      expect(
+        capturedRef.read(scoreboardStatusFilterProvider),
+        isNot(contains(MatchStatus.finished)),
+      );
+    });
+
+    testWidgets('no chips before a pubkey is being watched', (tester) async {
+      // Arrange + Act — nothing to filter yet
+      await tester.pumpWidget(_wrap(const ScoreboardScreen()));
+      await tester.pump();
+
+      // Assert
+      expect(find.byType(StatusFilterBar), findsNothing);
     });
   });
 }

--- a/test/main_lifecycle_test.dart
+++ b/test/main_lifecycle_test.dart
@@ -51,18 +51,46 @@ void main() {
     );
   }
 
+  /// Drive a lifecycle sequence the way the OS actually does.
+  ///
+  /// The states are a path, not a set: Android and iOS walk resumed → inactive →
+  /// hidden → paused on the way out and back again on the way in, and Flutter's
+  /// own AppLifecycleListener asserts on any jump that skips a step. Sending
+  /// paused → resumed directly is a transition no device performs, and any
+  /// widget in the tree that listens for lifecycle changes — a TextField, for
+  /// one — will rightly complain about it.
+  Future<void> walk(
+    WidgetTester tester,
+    List<AppLifecycleState> states,
+  ) async {
+    for (final state in states) {
+      tester.binding.handleAppLifecycleStateChanged(state);
+      await tester.pump();
+    }
+  }
+
+  /// Away and back, in full.
+  const goingAway = [
+    AppLifecycleState.inactive,
+    AppLifecycleState.hidden,
+    AppLifecycleState.paused,
+  ];
+  const comingBack = [
+    AppLifecycleState.hidden,
+    AppLifecycleState.inactive,
+    AppLifecycleState.resumed,
+  ];
+
   testWidgets('recycles every relay connection when the app resumes',
       (tester) async {
     // Arrange — backgrounding kills sockets without a close frame, so resume
     // must not trust any connection that looks open
     await pumpApp(tester);
-    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
-    await tester.pump();
+    await walk(tester, goingAway);
     expect(service.reconnectCalls, 0);
 
     // Act
-    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
-    await tester.pump();
+    await walk(tester, comingBack);
 
     // Assert
     expect(service.reconnectCalls, 1);
@@ -73,19 +101,13 @@ void main() {
     // Arrange
     await pumpApp(tester);
 
-    // Act — the transitions short of resuming
-    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
-    await tester.pump();
-    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
-    await tester.pump();
-    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
-    await tester.pump();
+    // Act — every transition short of resuming
+    await walk(tester, goingAway);
 
     // Assert — recycling sockets mid-use would drop live subscriptions
     expect(service.reconnectCalls, 0);
 
     // Restore the default state so later tests see a live app
-    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
-    await tester.pump();
+    await walk(tester, comingBack);
   });
 }

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -147,4 +147,47 @@ void main() {
       expect(ref.read(selectedTabProvider), AppTab.home);
     });
   });
+
+  group('openShareLink logging', () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    testWidgets('never writes the rejected link or its values to the log',
+        (tester) async {
+      // Arrange — somebody pastes a private key into a share link. The parser
+      // rejects it, and the log must not become the place it leaks.
+      const nsec = 'nsec1averysecretvaluethatmustnotbelogged';
+      late WidgetRef ref;
+      await tester.pumpWidget(ProviderScope(
+        child: Consumer(builder: (context, r, _) {
+          ref = r;
+          return const SizedBox();
+        }),
+      ));
+
+      final logged = <String>[];
+      final previous = debugPrint;
+      debugPrint = (String? message, {int? wrapWidth}) {
+        if (message != null) logged.add(message);
+      };
+
+      // Act — restored inside the body, not in a tearDown: the framework
+      // asserts its debug variables are untouched before tearDowns run.
+      final bool handled;
+      try {
+        handled = openShareLink(
+          Uri.parse('https://bjjscore.live/?npub=$nsec'),
+          crypto,
+          ref,
+        );
+      } finally {
+        debugPrint = previous;
+      }
+
+      // Assert
+      expect(handled, isFalse);
+      expect(logged, isNotEmpty, reason: 'it should say something');
+      expect(logged.join('\n'), isNot(contains(nsec)));
+      expect(logged.join('\n'), isNot(contains('nsec1')));
+    });
+  });
 }

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/account/account_screen.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/services/deep_links/share_link.dart';
+import 'package:choke/shared/providers/navigation_provider.dart';
+
+import '../../support/nostr_fakes.dart';
+
+const _watched =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+void main() {
+  final crypto = FakeNostrCrypto();
+
+  group('pubkeyFromShareLink', () {
+    test('reads the link Account actually shares', () {
+      // Arrange — the exact URL liveBoardShareUrl builds, so the sharer and the
+      // reader cannot drift apart without this failing
+      final uri = Uri.parse(liveBoardShareUrl('npub1fake'));
+
+      // Act + Assert
+      expect(pubkeyFromShareLink(uri, crypto), _watched);
+    });
+
+    test('reads a bare hex pubkey too', () {
+      // Arrange
+      final uri = Uri.parse('https://bjjscore.live/?npub=${'a' * 64}');
+
+      // Act + Assert
+      expect(pubkeyFromShareLink(uri, crypto), 'a' * 64);
+    });
+
+    test('accepts the pubkey parameter the web board also accepts', () {
+      // Arrange — choke-scoreboard takes either name, and one link is shared to
+      // everyone
+      final uri = Uri.parse('https://bjjscore.live/?pubkey=npub1fake');
+
+      // Act + Assert
+      expect(pubkeyFromShareLink(uri, crypto), _watched);
+    });
+
+    test('ignores whitespace around a pasted key', () {
+      // Arrange
+      final uri = Uri.parse('https://bjjscore.live/?npub=%20npub1fake%20');
+
+      // Act + Assert
+      expect(pubkeyFromShareLink(uri, crypto), _watched);
+    });
+
+    test('refuses a link belonging to somebody else', () {
+      // Arrange — the OS hands over whatever was tapped, and another host's
+      // link is not this app's to interpret
+      final uri = Uri.parse('https://evil.example/?npub=npub1fake');
+
+      // Act + Assert
+      expect(pubkeyFromShareLink(uri, crypto), isNull);
+    });
+
+    test('refuses a link that names no usable key', () {
+      // Act + Assert
+      expect(
+        pubkeyFromShareLink(Uri.parse('https://bjjscore.live/'), crypto),
+        isNull,
+      );
+      expect(
+        pubkeyFromShareLink(Uri.parse('https://bjjscore.live/?npub='), crypto),
+        isNull,
+      );
+      expect(
+        pubkeyFromShareLink(
+            Uri.parse('https://bjjscore.live/?npub=nonsense'), crypto),
+        isNull,
+      );
+    });
+  });
+
+  group('openShareLink', () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    /// Pump a widget that hands back its ref, so a link can be opened with the
+    /// same kind of ref the app uses.
+    Future<WidgetRef> pumpRef(WidgetTester tester) async {
+      late WidgetRef captured;
+      await tester.pumpWidget(ProviderScope(
+        child: Consumer(builder: (context, ref, _) {
+          captured = ref;
+          return const SizedBox();
+        }),
+      ));
+      return captured;
+    }
+
+    testWidgets('watches the shared pubkey and shows the scoreboard',
+        (tester) async {
+      // Arrange
+      final ref = await pumpRef(tester);
+      expect(ref.read(selectedTabProvider), AppTab.home);
+
+      // Act
+      final handled = openShareLink(
+        Uri.parse(liveBoardShareUrl('npub1fake')),
+        crypto,
+        ref,
+      );
+      await tester.pump();
+
+      // Assert
+      expect(handled, isTrue);
+      expect(ref.read(watchedPubkeyProvider), _watched);
+      expect(ref.read(selectedTabProvider), AppTab.scoreboard);
+    });
+
+    testWidgets('leaves everything alone for a link it does not understand',
+        (tester) async {
+      // Arrange — someone is already watching a board
+      final ref = await pumpRef(tester);
+      await ref.read(watchedPubkeyProvider.notifier).watch('c' * 64);
+
+      // Act
+      final handled = openShareLink(
+        Uri.parse('https://bjjscore.live/?npub=nonsense'),
+        crypto,
+        ref,
+      );
+      await tester.pump();
+
+      // Assert — forgetting the board they were watching, to show them an empty
+      // one, would be worse than ignoring a link that made no sense
+      expect(handled, isFalse);
+      expect(ref.read(watchedPubkeyProvider), 'c' * 64);
+      expect(ref.read(selectedTabProvider), AppTab.home);
+    });
+
+    testWidgets('ignores the plain launch route', (tester) async {
+      // Arrange — what the engine reports when the app was not opened by a link
+      final ref = await pumpRef(tester);
+
+      // Act
+      final handled = openShareLink(Uri.parse('/'), crypto, ref);
+      await tester.pump();
+
+      // Assert
+      expect(handled, isFalse);
+      expect(ref.read(selectedTabProvider), AppTab.home);
+    });
+  });
+}

--- a/test/services/key_management/key_manager_error_paths_test.dart
+++ b/test/services/key_management/key_manager_error_paths_test.dart
@@ -28,6 +28,9 @@ class _ThrowingCrypto implements NostrCrypto {
   String? nsecDecode(String nsec) => 'a' * 64;
 
   @override
+  String? npubDecode(String npub) => 'a' * 64;
+
+  @override
   NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex) =>
       throw UnimplementedError();
 

--- a/test/services/nostr/crypto/nostr_crypto_contract.dart
+++ b/test/services/nostr/crypto/nostr_crypto_contract.dart
@@ -127,6 +127,36 @@ void runNostrCryptoContract(String name, NostrCrypto Function() create) {
         // Act & Assert
         expect(crypto.nsecDecode(npub), isNull);
       });
+
+      test('round-trips a public key through npub', () {
+        // Arrange — this is the form a pubkey arrives in when somebody shares it
+        final publicKey = crypto.getPublicKey(nip19PrivateKey);
+
+        // Act
+        final decoded = crypto.npubDecode(crypto.npubEncode(publicKey));
+
+        // Assert
+        expect(decoded, publicKey);
+      });
+
+      test('returns null for an npub that is not one', () {
+        // Act & Assert — anything a user can paste into a pubkey field
+        expect(crypto.npubDecode('not an npub'), isNull);
+        expect(crypto.npubDecode(''), isNull);
+        expect(
+          crypto.npubDecode(crypto.getPublicKey(nip19PrivateKey)),
+          isNull,
+          reason: 'raw hex is not bech32; the caller decides which one it has',
+        );
+      });
+
+      test('returns null for an nsec given where an npub is expected', () {
+        // The mirror of the test above, and the one that matters more: a private
+        // key must never pass as somebody's public identity. A user who pasted
+        // the wrong thing would otherwise have it sent to the relays as an
+        // author filter, and never be told.
+        expect(crypto.npubDecode(nip19Nsec), isNull);
+      });
     });
 
     group('signing', () {

--- a/test/services/nostr/nostr_service_behavior_test.dart
+++ b/test/services/nostr/nostr_service_behavior_test.dart
@@ -186,11 +186,18 @@ void main() {
       // Act
       service.subscribeToAuthor('c' * 64);
 
-      // Assert
-      final filter = backend.subscriptions['author_${'c' * 64}'];
-      expect(filter, isNotNull);
+      // Assert — the id names the author, but only as much of it as fits: NIP-01
+      // caps a subscription id at 64 characters and a relay drops the whole REQ
+      // over it, so a full pubkey in the id would never receive an event.
+      final id = backend.subscriptions.keys.single;
+      expect(id, startsWith('author_'));
+      expect(id.length, lessThanOrEqualTo(64));
+      expect(id, contains('cccc'));
+
+      final filter = backend.subscriptions[id];
       expect(filter!.kinds, [31415]);
-      expect(filter.authors, ['c' * 64]);
+      expect(filter.authors, ['c' * 64],
+          reason: 'the filter still carries the whole key');
     });
 
     test('subscribeToAuthor honors an explicit subscription id', () {

--- a/test/support/nostr_fakes.dart
+++ b/test/support/nostr_fakes.dart
@@ -28,6 +28,9 @@ class FakeNostrCrypto implements NostrCrypto {
   String? nsecDecode(String nsec) => nsec == 'nsec1fake' ? 'f' * 64 : null;
 
   @override
+  String? npubDecode(String npub) => npub == 'npub1fake' ? 'b' * 64 : null;
+
+  @override
   NostrEvent finishEvent(UnsignedNostrEvent event, String privateKeyHex) {
     return NostrEvent(
       id: 'a' * 64,


### PR DESCRIPTION
Watch somebody else's mats. Paste a pubkey they shared — or just tap their link — and their matches appear live, exactly as `choke-scoreboard` shows them.

Read-only by construction. The feed subscribes and parses and has no way to change a match; nothing in the section can start, score or end anything.

## The section

A new tab before Account. Takes a pubkey as hex or `npub1…`, remembers it so a tournament survives a relaunch, and lists that author's recent matches using **Home's card — extracted, not copied**. You asked for the same style, and a second 150-line card would have drifted from the first within a release.

Tapping one opens the wall display: two halves washed in the fighters' colours, effective scores, the 2/3/4 breakdown, advantage and penalty chips, the loser's half dimmed once there is a winner, and a centre column with the status pill and clock. Landscape only — asked for on the way in, given back on the way out — because two halves side by side do not fold into a portrait phone.

The winner is read from the event, never inferred from the numbers. A fighter can lead 5–2 and lose to an armbar, and this screen is read by a room.

## Shared links open it

The share button in Account already produced `https://bjjscore.live/?npub=…`. That URL is unchanged, and now has two destinations: no app → the web board, as always; app installed → the app, on Scoreboard, already watching that pubkey.

No new dependency — `flutter_deeplinking_enabled` makes the link arrive as route information, so a warm start is `didPushRouteInformation` on the observer `ChokeApp` already had, and a cold start is `defaultRouteName`.

> [!IMPORTANT]
> **This half does not work until `bjjscore.live` serves `/.well-known/assetlinks.json`.** `android:autoVerify` is set and Android checks it at install time; until it passes, Android 12+ sends these links to the browser with nothing to see in the app. `docs/deep-links.md` has the file, how to get the signing fingerprint (including the Play App Signing trap), and how to verify with `adb`. iOS is deliberately untouched — the release workflow builds Android only.

## Groundwork

`npub_decode` in the Rust crate, next to `nsec_decode`, so NIP-19 stays in one place. Strictly bech32: any 64 hex characters parse as a public key, a private one included, so callers decide which form they have before asking. The contract test that matters is the mirror of the existing one — an `nsec` where an npub is expected returns null, because a private key accepted as somebody's public identity would go to the relays as an author filter without a word to the user.

The clock moved onto `Match.remainingSecondsAt`; `MatchControlNotifier` now derives its own from it. Two screens showing one match must not be able to tell two different times.

## Three bugs this turned up

**The home feed took anyone's matches.** `MatchFeedNotifier` accepted any kind-31415 event. Harmless while the user's was the only subscription — and not harmless at all once the scoreboard subscribes to an arbitrary pubkey on purpose. Fixed in its own commit (`470c78b`).

**The scoreboard received nothing at all**, found while testing it. Publishing worked, the relays held the events, the app's own feed worked. NIP-01 caps a subscription id at 64 characters and a relay rejects the whole REQ over it; `scoreboard_` plus a 64-character pubkey is 75. Against nos.lol:

```
["REQ","scoreboard_f76bbc…",{…}]
← ["CLOSED","scoreboard_f76bbc…","ERROR: bad req: invalid subscription id"]

["REQ","sb_f76bbc11701887b6",{…}]
← ["EVENT",…] ["EVENT",…] ["EOSE",…]
```

`subscribeToAuthor`'s own default had the same defect (71 characters) and a test asserted that id verbatim — which is how a broken default travels with a green suite. It is short now, and the test asserts the requirement instead of the string.

**A lifecycle test was passing for the wrong reason.** It drove `paused → resumed`, a transition no phone performs, and only passed because nothing in the tree was listening. The scoreboard's text field brought Flutter's own `AppLifecycleListener` into the tree from startup and it rightly asserted. Confirmed against a clean tree that the failure was mine before touching the test; it now walks the real sequences both ways.

## Test plan

- [x] `flutter test` — **596 passing**
- [x] `flutter analyze` — 55 issues, **down from 61** on `main`
- [x] Coverage: `match_card` 100%, match screen 94%, list 92%, providers 91%, deep links 9 tests
- [x] Subscription-id fix verified against the live relay, both lengths, before and after
- [x] Regression tests: id fits in 64 chars, distinguishes two authors, closes what it opened
- [ ] **Not verified on a device** — landscape layout, proportions, and the deep link actually opening the app
- [ ] **`assetlinks.json` not deployed** — the deep link cannot work on Android 12+ until it is

Needs `cargo build` after checkout: the Rust crate gained `npub_decode`, so the eight Rust-backed suites fail against a stale `.so` until it is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Vc375FzBtfRmyZDXEk7zh
