### PR TITLE
fix: say so when a shared link's pubkey cannot be read

### DIFF
--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 
+import '../../services/deep_links/share_link.dart';
 import '../../services/nostr/crypto/nostr_crypto.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
@@ -77,6 +78,7 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final tk = ChokeTokens.of(context);
+    final brokenLink = ref.watch(brokenShareLinkProvider);
     final watched = ref.watch(watchedPubkeyProvider);
     // Two lists: everything in scope, which the chips count from, and what
     // survives the filter, which is what the list shows.
@@ -142,11 +144,12 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
                 ],
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 12, 20, 8),
-              child: _buildPubkeyField(l10n, tk, watched),
-            ),
-            if (watched != null)
+            if (!brokenLink)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 8),
+                child: _buildPubkeyField(l10n, tk, watched),
+              ),
+            if (watched != null && !brokenLink)
               Padding(
                 padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
                 child: StatusFilterBar(
@@ -156,9 +159,12 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
                 ),
               ),
             Expanded(
-              child: switch ((watched, matches.isEmpty)) {
-                (null, _) => _buildWelcome(l10n, tk),
-                (_, true) => _buildEmpty(l10n, tk),
+              child: switch ((brokenLink, watched, matches.isEmpty)) {
+                // A link that named a board and could not be read outranks
+                // everything: whatever is behind this is not what was tapped.
+                (true, _, _) => _buildBrokenLink(l10n, tk),
+                (_, null, _) => _buildWelcome(l10n, tk),
+                (_, _, true) => _buildEmpty(l10n, tk),
                 _ => _buildList(matches),
               },
             ),
@@ -245,6 +251,47 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
           child: MatchCard(match: match, onTap: () => _open(match)),
         );
       },
+    );
+  }
+
+  /// The link named a board and its pubkey could not be read.
+  ///
+  /// Deliberately not a snackbar: a message that disappears on its own, over a
+  /// board belonging to somebody else, is the same silent substitution this
+  /// screen exists to avoid. The user dismisses it, so the app knows they know.
+  Widget _buildBrokenLink(AppLocalizations l10n, ChokeTokens tk) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.link_off, size: 44, color: tk.dangerFg),
+            const SizedBox(height: 14),
+            Text(
+              l10n.scoreboardBrokenLinkTitle,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w600,
+                color: tk.dangerFg,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              l10n.scoreboardBrokenLinkBody,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 13, color: tk.faint),
+            ),
+            const SizedBox(height: 18),
+            FilledButton(
+              onPressed: () =>
+                  ref.read(brokenShareLinkProvider.notifier).state = false,
+              child: Text(l10n.scoreboardBrokenLinkDismiss),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -265,37 +265,18 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   /// board belonging to somebody else, is the same silent substitution this
   /// screen exists to avoid. The user dismisses it, so the app knows they know.
   Widget _buildBrokenLink(AppLocalizations l10n, ChokeTokens tk) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 40),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.link_off, size: 44, color: tk.dangerFg),
-            const SizedBox(height: 14),
-            Text(
-              l10n.scoreboardBrokenLinkTitle,
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 17,
-                fontWeight: FontWeight.w600,
-                color: tk.dangerFg,
-              ),
-            ),
-            const SizedBox(height: 6),
-            Text(
-              l10n.scoreboardBrokenLinkBody,
-              textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 13, color: tk.faint),
-            ),
-            const SizedBox(height: 18),
-            FilledButton(
-              onPressed: () =>
-                  ref.read(brokenShareLinkProvider.notifier).state = false,
-              child: Text(l10n.scoreboardBrokenLinkDismiss),
-            ),
-          ],
-        ),
+    return _buildPlaceholder(
+      tk,
+      icon: Icons.link_off,
+      title: l10n.scoreboardBrokenLinkTitle,
+      body: l10n.scoreboardBrokenLinkBody,
+      // The one state here that is a failure rather than an absence, and the
+      // only one the user has to act on.
+      accent: tk.dangerFg,
+      action: FilledButton(
+        onPressed: () =>
+            ref.read(brokenShareLinkProvider.notifier).state = false,
+        child: Text(l10n.scoreboardBrokenLinkDismiss),
       ),
     );
   }
@@ -318,11 +299,19 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
     );
   }
 
+  /// The shape every "there is no list here" state takes: an icon, a line, and
+  /// an explanation.
+  ///
+  /// [accent] tints the icon and the title for a state that is a failure rather
+  /// than an absence; without it they stay quiet, which is right for waiting and
+  /// for having nothing to show yet. [action] appends something to do about it.
   Widget _buildPlaceholder(
     ChokeTokens tk, {
     required IconData icon,
     required String title,
     required String body,
+    Color? accent,
+    Widget? action,
   }) {
     return Center(
       child: Padding(
@@ -330,7 +319,7 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(icon, size: 44, color: tk.faint),
+            Icon(icon, size: 44, color: accent ?? tk.faint),
             const SizedBox(height: 14),
             Text(
               title,
@@ -338,7 +327,7 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
               style: TextStyle(
                 fontSize: 17,
                 fontWeight: FontWeight.w600,
-                color: tk.muted,
+                color: accent ?? tk.muted,
               ),
             ),
             const SizedBox(height: 6),
@@ -347,6 +336,10 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
               textAlign: TextAlign.center,
               style: TextStyle(fontSize: 13, color: tk.faint),
             ),
+            if (action != null) ...[
+              const SizedBox(height: 18),
+              action,
+            ],
           ],
         ),
       ),

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -132,7 +132,12 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
                           ),
                         ),
                         Text(
-                          watched == null
+                          // Not the watched pubkey while a broken link is
+                          // showing: naming an organizer one line above "that
+                          // link is broken" invites the reader to take this hex
+                          // for the link's board, which is the substitution the
+                          // whole state exists to prevent.
+                          brokenLink || watched == null
                               ? l10n.scoreboardWelcomeTitle
                               : _shortPubkey(watched),
                           style: TextStyle(fontSize: 12.5, color: tk.muted),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -869,5 +869,17 @@
         "type": "int"
       }
     }
+  },
+  "scoreboardBrokenLinkTitle": "That link is broken",
+  "@scoreboardBrokenLinkTitle": {
+    "description": "Title shown when a shared link named a board but its pubkey could not be read"
+  },
+  "scoreboardBrokenLinkBody": "It was meant for a specific board, but the pubkey in it could not be read. Ask whoever shared it to send it again.",
+  "@scoreboardBrokenLinkBody": {
+    "description": "Explanation shown with scoreboardBrokenLinkTitle"
+  },
+  "scoreboardBrokenLinkDismiss": "Show my board",
+  "@scoreboardBrokenLinkDismiss": {
+    "description": "Button that dismisses the broken-link state and returns to the board the user was already watching"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -222,5 +222,8 @@
         "type": "int"
       }
     }
-  }
+  },
+  "scoreboardBrokenLinkTitle": "Ese link está roto",
+  "scoreboardBrokenLinkBody": "Apuntaba a un tablero en particular, pero no se pudo leer la clave pública que traía. Pedile a quien te lo compartió que te lo mande de nuevo.",
+  "scoreboardBrokenLinkDismiss": "Ver mi tablero"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -222,5 +222,8 @@
         "type": "int"
       }
     }
-  }
+  },
+  "scoreboardBrokenLinkTitle": "このリンクは壊れています",
+  "scoreboardBrokenLinkBody": "特定のスコアボードを指していましたが、公開鍵を読み取れませんでした。共有した人にもう一度送ってもらってください。",
+  "scoreboardBrokenLinkDismiss": "自分のスコアボードを見る"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -222,5 +222,8 @@
         "type": "int"
       }
     }
-  }
+  },
+  "scoreboardBrokenLinkTitle": "Esse link está quebrado",
+  "scoreboardBrokenLinkBody": "Ele apontava para um placar específico, mas não foi possível ler a chave pública que trazia. Peça para quem compartilhou enviar de novo.",
+  "scoreboardBrokenLinkDismiss": "Ver meu placar"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1397,6 +1397,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{points} PTS'**
   String scoreboardPointsShort(int points);
+
+  /// Title shown when a shared link named a board but its pubkey could not be read
+  ///
+  /// In en, this message translates to:
+  /// **'That link is broken'**
+  String get scoreboardBrokenLinkTitle;
+
+  /// Explanation shown with scoreboardBrokenLinkTitle
+  ///
+  /// In en, this message translates to:
+  /// **'It was meant for a specific board, but the pubkey in it could not be read. Ask whoever shared it to send it again.'**
+  String get scoreboardBrokenLinkBody;
+
+  /// Button that dismisses the broken-link state and returns to the board the user was already watching
+  ///
+  /// In en, this message translates to:
+  /// **'Show my board'**
+  String get scoreboardBrokenLinkDismiss;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -695,4 +695,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String scoreboardPointsShort(int points) {
     return '$points PTS';
   }
+
+  @override
+  String get scoreboardBrokenLinkTitle => 'That link is broken';
+
+  @override
+  String get scoreboardBrokenLinkBody =>
+      'It was meant for a specific board, but the pubkey in it could not be read. Ask whoever shared it to send it again.';
+
+  @override
+  String get scoreboardBrokenLinkDismiss => 'Show my board';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -700,4 +700,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String scoreboardPointsShort(int points) {
     return '$points PTS';
   }
+
+  @override
+  String get scoreboardBrokenLinkTitle => 'Ese link está roto';
+
+  @override
+  String get scoreboardBrokenLinkBody =>
+      'Apuntaba a un tablero en particular, pero no se pudo leer la clave pública que traía. Pedile a quien te lo compartió que te lo mande de nuevo.';
+
+  @override
+  String get scoreboardBrokenLinkDismiss => 'Ver mi tablero';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -671,4 +671,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String scoreboardPointsShort(int points) {
     return '$points ポイント';
   }
+
+  @override
+  String get scoreboardBrokenLinkTitle => 'このリンクは壊れています';
+
+  @override
+  String get scoreboardBrokenLinkBody =>
+      '特定のスコアボードを指していましたが、公開鍵を読み取れませんでした。共有した人にもう一度送ってもらってください。';
+
+  @override
+  String get scoreboardBrokenLinkDismiss => '自分のスコアボードを見る';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -700,4 +700,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String scoreboardPointsShort(int points) {
     return '$points PTS';
   }
+
+  @override
+  String get scoreboardBrokenLinkTitle => 'Esse link está quebrado';
+
+  @override
+  String get scoreboardBrokenLinkBody =>
+      'Ele apontava para um placar específico, mas não foi possível ler a chave pública que trazia. Peça para quem compartilhou enviar de novo.';
+
+  @override
+  String get scoreboardBrokenLinkDismiss => 'Ver meu placar';
 }

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -63,8 +63,12 @@ class BrokenShareLink extends ShareLink {
 /// Never throws. What arrives here is whatever was tapped, which is not a
 /// trusted caller.
 ShareLink readShareLink(Uri uri, NostrCrypto crypto) {
-  // A relative route has no authority to check; an absolute one must be ours.
-  if (uri.hasAuthority && uri.host.toLowerCase() != kShareLinkHost) {
+  // The host has to be ours, and a URI with no authority does not have one to
+  // check — `/?npub=…` and `bjjscore.live/?npub=…` (no scheme) both parse with
+  // an empty host. Letting those through used to be harmless, because an
+  // unreadable pubkey simply did nothing; now it puts an accusing full-screen
+  // message in front of somebody over a link they never followed.
+  if (uri.host.toLowerCase() != kShareLinkHost) {
     return const NotAShareLink();
   }
 
@@ -101,7 +105,7 @@ bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
     case NotAShareLink():
       // Nothing to say. This is also the ordinary launch route, and an app that
       // complained about that would complain every time it opened.
-      _logIgnored(uri);
+      _log(uri, 'ignoring');
       return false;
 
     case SharedBoard(:final pubkeyHex):
@@ -115,7 +119,7 @@ bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
       // throwing it away would punish them for somebody else's bad link — but
       // the board stays behind the message until they choose to go back to it.
       // What must not happen is that board appearing as though the link worked.
-      _logIgnored(uri);
+      _log(uri, 'reporting as broken');
       ref.read(brokenShareLinkProvider.notifier).state = true;
       ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
       return true;
@@ -126,11 +130,14 @@ bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
 ///
 /// A user who pastes their nsec into one of these is correctly rejected by the
 /// parser — and must not have it written to the device log on the way out.
-void _logIgnored(Uri uri) {
+///
+/// [what] names the decision, because "ignoring" and "showing the user an
+/// error" read identically in a support report otherwise.
+void _log(Uri uri, String what) {
   final named =
       kSharePubkeyParams.where(uri.queryParameters.containsKey).join(',');
   debugPrint(
-    'DeepLink: ignoring a link for ${uri.host.isEmpty ? '(no host)' : uri.host}'
+    'DeepLink: $what a link for ${uri.host.isEmpty ? '(no host)' : uri.host}'
     '${named.isEmpty ? ' with no pubkey parameter' : ' whose $named did not parse'}',
   );
 }

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -20,52 +20,117 @@ const String kShareLinkHost = 'bjjscore.live';
 /// it.
 const List<String> kSharePubkeyParams = ['npub', 'pubkey'];
 
-/// The pubkey a shared board link names, in hex, or null if it names none.
+/// What a link turned out to be.
+///
+/// Three cases, not two. "This is not a share link" and "this is a share link
+/// whose pubkey is broken" both used to come back as null, and treating them
+/// alike is what left the previous organizer's board on screen as though it
+/// were the one the link named.
+sealed class ShareLink {
+  const ShareLink();
+}
+
+/// Not a shared board link: another host, or no pubkey parameter at all.
+///
+/// Includes the plain launch route, which is the case that fires every time the
+/// app opens normally. Nothing should happen, silently.
+class NotAShareLink extends ShareLink {
+  const NotAShareLink();
+}
+
+/// A shared board link naming [pubkeyHex].
+class SharedBoard extends ShareLink {
+  const SharedBoard(this.pubkeyHex);
+
+  /// The watched author, in lowercase hex.
+  final String pubkeyHex;
+}
+
+/// A shared board link whose pubkey could not be read.
+///
+/// The user followed a link meant for one particular board. Showing them any
+/// other board now is a lie they have no way to catch, so this has to be said
+/// out loud rather than absorbed.
+class BrokenShareLink extends ShareLink {
+  const BrokenShareLink();
+}
+
+/// Read a link the OS handed over.
 ///
 /// Accepts exactly what the web board accepts: `https://bjjscore.live/?npub=…`
 /// or `?pubkey=…`, holding either an npub or bare hex.
 ///
-/// Returns null rather than throwing for anything else, a link for another host
-/// included. What arrives here is whatever the OS was handed, which is not a
+/// Never throws. What arrives here is whatever was tapped, which is not a
 /// trusted caller.
-String? pubkeyFromShareLink(Uri uri, NostrCrypto crypto) {
+ShareLink readShareLink(Uri uri, NostrCrypto crypto) {
   // A relative route has no authority to check; an absolute one must be ours.
-  if (uri.hasAuthority && uri.host.toLowerCase() != kShareLinkHost) return null;
+  if (uri.hasAuthority && uri.host.toLowerCase() != kShareLinkHost) {
+    return const NotAShareLink();
+  }
+
+  var sawParameter = false;
 
   for (final param in kSharePubkeyParams) {
     final value = uri.queryParameters[param]?.trim();
+
+    // An empty value is not a broken key, it is no key — the web board skips it
+    // the same way, and a bare `?npub=` should not accuse anybody of anything.
     if (value == null || value.isEmpty) continue;
 
+    sawParameter = true;
     final hex = parsePubkey(value, crypto);
-    if (hex != null) return hex;
+    if (hex != null) return SharedBoard(hex);
   }
 
-  return null;
+  return sawParameter ? const BrokenShareLink() : const NotAShareLink();
 }
 
-/// Open a shared board link: watch the pubkey it names, and show the scoreboard.
+/// Set when a link named a board and its pubkey could not be read.
 ///
-/// Returns whether the link was one this app understands. One that names no
-/// usable pubkey changes nothing — dropping the user on an empty scoreboard,
-/// having silently forgotten the pubkey they were already watching, would be
-/// worse than ignoring a link that made no sense.
-bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
-  final hex = pubkeyFromShareLink(uri, crypto);
-  if (hex == null) {
-    // The host and which parameters were present, never their values. A user
-    // who pastes their nsec into one of these is correctly rejected above —
-    // and must not have it written to the device log on the way out.
-    final named = kSharePubkeyParams
-        .where(uri.queryParameters.containsKey)
-        .join(',');
-    debugPrint(
-      'DeepLink: ignoring a link for ${uri.host.isEmpty ? '(no host)' : uri.host}'
-      '${named.isEmpty ? ' with no pubkey parameter' : ' whose $named did not parse'}',
-    );
-    return false;
-  }
+/// The scoreboard shows this instead of a board. The app does not clear it on
+/// its own: only the user can say "fine, show me what I had", because only they
+/// know they did not get what they tapped.
+final brokenShareLinkProvider = StateProvider<bool>((ref) => false);
 
-  ref.read(watchedPubkeyProvider.notifier).watch(hex);
-  ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
-  return true;
+/// Open a shared board link.
+///
+/// Returns whether the link was one this app answers for — true both for a
+/// board it opened and for a broken one it reported, since both are ours.
+bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
+  switch (readShareLink(uri, crypto)) {
+    case NotAShareLink():
+      // Nothing to say. This is also the ordinary launch route, and an app that
+      // complained about that would complain every time it opened.
+      _logIgnored(uri);
+      return false;
+
+    case SharedBoard(:final pubkeyHex):
+      ref.read(brokenShareLinkProvider.notifier).state = false;
+      ref.read(watchedPubkeyProvider.notifier).watch(pubkeyHex);
+      ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
+      return true;
+
+    case BrokenShareLink():
+      // Fail closed. The previously watched pubkey is kept — it is theirs, and
+      // throwing it away would punish them for somebody else's bad link — but
+      // the board stays behind the message until they choose to go back to it.
+      // What must not happen is that board appearing as though the link worked.
+      _logIgnored(uri);
+      ref.read(brokenShareLinkProvider.notifier).state = true;
+      ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
+      return true;
+  }
+}
+
+/// The host and which parameters were present, never their values.
+///
+/// A user who pastes their nsec into one of these is correctly rejected by the
+/// parser — and must not have it written to the device log on the way out.
+void _logIgnored(Uri uri) {
+  final named =
+      kSharePubkeyParams.where(uri.queryParameters.containsKey).join(',');
+  debugPrint(
+    'DeepLink: ignoring a link for ${uri.host.isEmpty ? '(no host)' : uri.host}'
+    '${named.isEmpty ? ' with no pubkey parameter' : ' whose $named did not parse'}',
+  );
 }

--- a/test/features/scoreboard/scoreboard_screens_test.dart
+++ b/test/features/scoreboard/scoreboard_screens_test.dart
@@ -6,6 +6,7 @@ import 'package:choke/features/match/models/match.dart';
 import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
 import 'package:choke/features/scoreboard/scoreboard_match_screen.dart';
 import 'package:choke/features/scoreboard/scoreboard_screen.dart';
+import 'package:choke/services/deep_links/share_link.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import 'package:choke/services/key_management/key_manager.dart';
 import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
@@ -362,6 +363,49 @@ void main() {
 
       // Assert
       expect(find.byType(StatusFilterBar), findsNothing);
+    });
+  });
+
+  group('ScoreboardScreen broken link', () {
+    testWidgets('shows the board only after the user acknowledges the link',
+        (tester) async {
+      // Arrange — a board is already being watched, and a link naming a
+      // different one arrived broken. Its matches must not stand in for the
+      // board that was actually asked for.
+      SharedPreferences.setMockInitialValues(
+        {'choke:scoreboard-pubkey': _watched},
+      );
+      late WidgetRef ref;
+      await tester.pumpWidget(_wrap(
+        Consumer(builder: (context, r, _) {
+          ref = r;
+          return const ScoreboardScreen();
+        }),
+        overrides: [
+          brokenShareLinkProvider.overrideWith((ref) => true),
+          scoreboardMatchesProvider.overrideWithValue([_match()]),
+          scoreboardFilteredMatchesProvider.overrideWithValue([_match()]),
+        ],
+      ));
+      await tester.pump();
+      await tester.pump();
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+      // Assert — the message, and none of the board behind it
+      expect(find.text(l10n.scoreboardBrokenLinkTitle), findsOneWidget);
+      expect(find.text('Buchecha'), findsNothing);
+      expect(find.byType(TextField), findsNothing,
+          reason: 'nothing to type into until they have read this');
+      expect(find.byType(StatusFilterBar), findsNothing);
+
+      // Act — they acknowledge it
+      await tester.tap(find.text(l10n.scoreboardBrokenLinkDismiss));
+      await tester.pump();
+
+      // Assert — now their own board comes back
+      expect(ref.read(brokenShareLinkProvider), isFalse);
+      expect(find.text(l10n.scoreboardBrokenLinkTitle), findsNothing);
+      expect(find.text('Buchecha'), findsOneWidget);
     });
   });
 }

--- a/test/features/scoreboard/scoreboard_screens_test.dart
+++ b/test/features/scoreboard/scoreboard_screens_test.dart
@@ -394,6 +394,15 @@ void main() {
       // Assert — the message, and none of the board behind it
       expect(find.text(l10n.scoreboardBrokenLinkTitle), findsOneWidget);
       expect(find.text('Buchecha'), findsNothing);
+
+      // …including the header, which would otherwise name the organizer the
+      // user was already watching one line above "that link is broken", and
+      // invite them to read that hex as the link's board
+      expect(
+        find.textContaining(_watched.substring(0, 8)),
+        findsNothing,
+        reason: 'the previous organizer must not be named here',
+      );
       expect(find.byType(TextField), findsNothing,
           reason: 'nothing to type into until they have read this');
       expect(find.byType(StatusFilterBar), findsNothing);

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -81,6 +81,24 @@ void main() {
       );
     });
 
+    test('a URI with no host is never ours, pubkey or not', () {
+      // `/?npub=x` and a scheme-less `bjjscore.live/?npub=x` both parse with an
+      // empty host. Treating them as ours put a full-screen "that link is
+      // broken" in front of somebody over a route they never followed.
+      for (final raw in [
+        '/?npub=nonsense',
+        'bjjscore.live/?npub=nonsense',
+        '/?npub=npub1fake',
+        '/',
+      ]) {
+        expect(
+          readShareLink(Uri.parse(raw), crypto),
+          isA<NotAShareLink>(),
+          reason: raw,
+        );
+      }
+    });
+
     test('tells a broken key apart from no key at all', () {
       // The whole point of the three cases: one of these named a board and
       // failed, the others never named one.

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -15,14 +15,20 @@ const _watched =
 void main() {
   final crypto = FakeNostrCrypto();
 
-  group('pubkeyFromShareLink', () {
+  /// The hex a link names, or null for anything that is not a board link.
+  String? boardOf(Uri uri) {
+    final link = readShareLink(uri, crypto);
+    return link is SharedBoard ? link.pubkeyHex : null;
+  }
+
+  group('readShareLink', () {
     test('reads the link Account actually shares', () {
       // Arrange — the exact URL liveBoardShareUrl builds, so the sharer and the
       // reader cannot drift apart without this failing
       final uri = Uri.parse(liveBoardShareUrl('npub1fake'));
 
       // Act + Assert
-      expect(pubkeyFromShareLink(uri, crypto), _watched);
+      expect(boardOf(uri), _watched);
     });
 
     test('reads a bare hex pubkey too', () {
@@ -30,7 +36,7 @@ void main() {
       final uri = Uri.parse('https://bjjscore.live/?npub=${'a' * 64}');
 
       // Act + Assert
-      expect(pubkeyFromShareLink(uri, crypto), 'a' * 64);
+      expect(boardOf(uri), 'a' * 64);
     });
 
     test('accepts the pubkey parameter the web board also accepts', () {
@@ -39,7 +45,7 @@ void main() {
       final uri = Uri.parse('https://bjjscore.live/?pubkey=npub1fake');
 
       // Act + Assert
-      expect(pubkeyFromShareLink(uri, crypto), _watched);
+      expect(boardOf(uri), _watched);
     });
 
     test('ignores whitespace around a pasted key', () {
@@ -47,7 +53,7 @@ void main() {
       final uri = Uri.parse('https://bjjscore.live/?npub=%20npub1fake%20');
 
       // Act + Assert
-      expect(pubkeyFromShareLink(uri, crypto), _watched);
+      expect(boardOf(uri), _watched);
     });
 
     test('refuses a link belonging to somebody else', () {
@@ -56,23 +62,50 @@ void main() {
       final uri = Uri.parse('https://evil.example/?npub=npub1fake');
 
       // Act + Assert
-      expect(pubkeyFromShareLink(uri, crypto), isNull);
+      expect(boardOf(uri), isNull);
     });
 
     test('refuses a link that names no usable key', () {
       // Act + Assert
       expect(
-        pubkeyFromShareLink(Uri.parse('https://bjjscore.live/'), crypto),
+        boardOf(Uri.parse('https://bjjscore.live/')),
         isNull,
       );
       expect(
-        pubkeyFromShareLink(Uri.parse('https://bjjscore.live/?npub='), crypto),
+        boardOf(Uri.parse('https://bjjscore.live/?npub=')),
         isNull,
       );
       expect(
-        pubkeyFromShareLink(
+        boardOf(Uri.parse('https://bjjscore.live/?npub=nonsense')),
+        isNull,
+      );
+    });
+
+    test('tells a broken key apart from no key at all', () {
+      // The whole point of the three cases: one of these named a board and
+      // failed, the others never named one.
+      expect(
+        readShareLink(
             Uri.parse('https://bjjscore.live/?npub=nonsense'), crypto),
-        isNull,
+        isA<BrokenShareLink>(),
+      );
+      expect(
+        readShareLink(Uri.parse('https://bjjscore.live/'), crypto),
+        isA<NotAShareLink>(),
+      );
+      expect(
+        readShareLink(Uri.parse('https://bjjscore.live/?npub='), crypto),
+        isA<NotAShareLink>(),
+      );
+      expect(
+        readShareLink(Uri.parse('https://evil.example/?npub=nonsense'), crypto),
+        isA<NotAShareLink>(),
+        reason: 'another host is not ours to judge',
+      );
+      expect(
+        readShareLink(Uri.parse('/'), crypto),
+        isA<NotAShareLink>(),
+        reason: 'the ordinary launch route',
       );
     });
   });
@@ -113,8 +146,7 @@ void main() {
       expect(ref.read(selectedTabProvider), AppTab.scoreboard);
     });
 
-    testWidgets('leaves everything alone for a link it does not understand',
-        (tester) async {
+    testWidgets('reports a link whose pubkey cannot be read', (tester) async {
       // Arrange — someone is already watching a board
       final ref = await pumpRef(tester);
       await ref.read(watchedPubkeyProvider.notifier).watch('c' * 64);
@@ -127,11 +159,72 @@ void main() {
       );
       await tester.pump();
 
-      // Assert — forgetting the board they were watching, to show them an empty
-      // one, would be worse than ignoring a link that made no sense
-      expect(handled, isFalse);
+      // Assert — the user followed a link for one board; leaving another one on
+      // screen would be a substitution they cannot see
+      expect(handled, isTrue);
+      expect(ref.read(brokenShareLinkProvider), isTrue);
+      expect(ref.read(selectedTabProvider), AppTab.scoreboard);
+
+      // …and their own board is kept, not thrown away over somebody else's
+      // broken link
       expect(ref.read(watchedPubkeyProvider), 'c' * 64);
+    });
+
+    testWidgets('a good link afterwards clears the broken state',
+        (tester) async {
+      // Arrange
+      final ref = await pumpRef(tester);
+      openShareLink(
+        Uri.parse('https://bjjscore.live/?npub=nonsense'),
+        crypto,
+        ref,
+      );
+      await tester.pump();
+      expect(ref.read(brokenShareLinkProvider), isTrue);
+
+      // Act
+      openShareLink(Uri.parse(liveBoardShareUrl('npub1fake')), crypto, ref);
+      await tester.pump();
+
+      // Assert
+      expect(ref.read(brokenShareLinkProvider), isFalse);
+      expect(ref.read(watchedPubkeyProvider), _watched);
+    });
+
+    testWidgets('an empty parameter is no link, not a broken one',
+        (tester) async {
+      // Arrange — `?npub=` on its own should not accuse anybody of anything
+      final ref = await pumpRef(tester);
+
+      // Act
+      final handled = openShareLink(
+        Uri.parse('https://bjjscore.live/?npub='),
+        crypto,
+        ref,
+      );
+      await tester.pump();
+
+      // Assert
+      expect(handled, isFalse);
+      expect(ref.read(brokenShareLinkProvider), isFalse);
       expect(ref.read(selectedTabProvider), AppTab.home);
+    });
+
+    testWidgets('another host is not ours to complain about', (tester) async {
+      // Arrange
+      final ref = await pumpRef(tester);
+
+      // Act
+      final handled = openShareLink(
+        Uri.parse('https://evil.example/?npub=nonsense'),
+        crypto,
+        ref,
+      );
+      await tester.pump();
+
+      // Assert
+      expect(handled, isFalse);
+      expect(ref.read(brokenShareLinkProvider), isFalse);
     });
 
     testWidgets('ignores the plain launch route', (tester) async {
@@ -144,6 +237,8 @@ void main() {
 
       // Assert
       expect(handled, isFalse);
+      expect(ref.read(brokenShareLinkProvider), isFalse,
+          reason: 'opening the app normally must not report a broken link');
       expect(ref.read(selectedTabProvider), AppTab.home);
     });
   });
@@ -183,8 +278,10 @@ void main() {
         debugPrint = previous;
       }
 
-      // Assert
-      expect(handled, isFalse);
+      // Assert — a pubkey that cannot be read is now reported rather than
+      // swallowed, but what it contained still must not reach the log
+      expect(handled, isTrue);
+      expect(ref.read(brokenShareLinkProvider), isTrue);
       expect(logged, isNotEmpty, reason: 'it should say something');
       expect(logged.join('\n'), isNot(contains(nsec)));
       expect(logged.join('\n'), isNot(contains('nsec1')));


### PR DESCRIPTION
Closes #135.

## The problem

`pubkeyFromShareLink` returned `null` for two different situations:

- the link names no board at all, and
- the link names one, and its pubkey is broken.

`openShareLink` treated both as "not for us" and changed nothing. For the first that is right. For the second the user tapped a link meant for one particular board and was left looking at **whatever board they were already watching** — full of real matches, under the wrong identity, with nothing suggesting the link had failed. On a cold start the asynchronous restore supplied that board a moment later, which made it look like the link had worked.

## What changed

The reader now says which of three things it found:

| Case | Meaning | What happens |
|---|---|---|
| `NotAShareLink` | another host, or no pubkey parameter | nothing, silently |
| `SharedBoard` | a readable pubkey | watch it, show the scoreboard |
| `BrokenShareLink` | named a board, pubkey unreadable | say so |

`NotAShareLink` has to stay silent because it is also the ordinary launch route — an app that complained about that would complain every time it opened.

## Why a state and not a snackbar

A message that fades on its own, over somebody else's board, is the same silent substitution this is meant to stop. So the scoreboard renders the broken-link state **instead of** the board, with the pubkey field and the filter chips hidden as well — neither should invite action on a board the user never reached — and clears it only when they press *Show my board*.

The previously watched pubkey is **kept** throughout. It is theirs, and discarding it because a stranger sent a bad link would punish the wrong person. It just waits behind the message.

## Judgement calls worth checking

- **Empty parameter is not broken.** A bare `?npub=` is treated as no parameter, matching the web board's `readSharedPubkey`, because it should not accuse anybody of anything.
- **`openShareLink` now returns true for a broken link.** It reports "this was one of ours", which is what the caller needs; it no longer means "a board was opened".
- **Another host is still ignored entirely**, broken pubkey or not. Not ours to judge.

## Test plan

- [x] `flutter test` — **610 passing**
- [x] `flutter analyze` — 53 issues, unchanged from `main`
- [x] Three-case parsing: broken vs absent vs empty vs foreign host vs launch route
- [x] Broken link keeps the stored pubkey and does not open a board
- [x] A good link afterwards clears the state
- [x] The screen hides the board, the input and the chips, and restores them on dismiss
- [x] The rejected value still never reaches the log (an nsec pasted into `?npub=`)
- [ ] Not verified on a device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated broken-link state for shared scoreboards.
  * Displays a localized explanation when a shared scoreboard link cannot be read.
  * Added a dismiss action that returns to the user’s scoreboard.

* **Bug Fixes**
  * Valid share links continue opening the correct scoreboard.
  * Invalid links are now distinguished from unrelated links and handled appropriately.

* **Documentation**
  * Added broken-link messaging in English, Spanish, Japanese, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->