### PR TITLE
fix: stop an expired match from crashing the app when it is reopened

### DIFF
--- a/lib/features/match/providers/match_control_provider.dart
+++ b/lib/features/match/providers/match_control_provider.dart
@@ -99,6 +99,11 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   int _retryAttempt = 0;
   StreamSubscription<String>? _relayConnectedSub;
 
+  /// True only while the constructor body runs. See [_publishState]: settling
+  /// an already-expired clock publishes from in there, and a provider may not
+  /// write to another provider while it is still being created.
+  bool _initializing = true;
+
   MatchControlNotifier(
     Match match,
     this._nostrService, [
@@ -124,11 +129,8 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
       _drainOutbox();
     });
 
-    if (match.status == MatchStatus.inProgress) {
-      if (match.pausedAt != null) {
-        // A paused clock stays paused, however long the app was away.
-        return;
-      }
+    // A paused clock stays paused, however long the app was away.
+    if (match.status == MatchStatus.inProgress && match.pausedAt == null) {
       // The clock may have run out while the app was closed — a match is
       // never left in progress past its own duration. It ran out unwatched,
       // though, so it is settled in silence: sounding the horn here would
@@ -140,6 +142,8 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
         _startTimer();
       }
     }
+
+    _initializing = false;
   }
 
   /// The clock lives on [Match], so that this screen and the read-only
@@ -476,8 +480,21 @@ class MatchControlNotifier extends StateNotifier<MatchControlState> {
   void _publishState() {
     _outbox = state.match;
 
-    // Update home feed immediately (don't wait for relay round-trip)
-    _feedNotifier?.addLocal(state.match);
+    // Update home feed immediately (don't wait for relay round-trip) — except
+    // while this notifier is still being constructed. It is created from the
+    // control screen's initState, so writing to the feed provider there would
+    // be a provider mutating another provider mid-build, which Riverpod
+    // rejects outright. A microtask lands the write just after the frame, and
+    // reading the state there rather than capturing it now keeps the feed
+    // converging on the newest match either way.
+    if (_initializing) {
+      scheduleMicrotask(() {
+        if (!mounted) return;
+        _feedNotifier?.addLocal(state.match);
+      });
+    } else {
+      _feedNotifier?.addLocal(state.match);
+    }
 
     // A fresh action beats waiting out a backoff — try again right away.
     _retryTimer?.cancel();

--- a/test/features/match/providers/match_control_provider_edge_cases_test.dart
+++ b/test/features/match/providers/match_control_provider_edge_cases_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/home/providers/home_providers.dart';
 import 'package:choke/features/match/models/match.dart';
 import 'package:choke/features/match/providers/match_control_provider.dart';
 import 'package:choke/services/key_management/key_manager.dart';
@@ -173,6 +174,35 @@ void main() {
       expect(
         () => container.read(matchControlProvider),
         throwsA(isA<StateError>()),
+      );
+    });
+
+    test('reopening an expired match through the provider does not throw',
+        () async {
+      // Arrange — the control screen reads this provider from initState, so
+      // the notifier is created mid-build. An in-progress match whose clock
+      // already ran out settles itself in the constructor, and settling
+      // publishes: Riverpod forbids touching the feed provider while this one
+      // is still being created.
+      final container = ProviderContainer(
+        overrides: [
+          nostrServiceProvider.overrideWithValue(nostr),
+        ],
+      );
+      addTearDown(container.dispose);
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      container.read(activeMatchProvider.notifier).state =
+          _match(startAt: now - 600, duration: 300, f1Pt2: 1);
+
+      // Act
+      final state = container.read(matchControlProvider);
+
+      // Assert — the clock is settled, and the feed still learns about it
+      expect(state.match.status, MatchStatus.finished);
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        container.read(matchFeedProvider).map((m) => m.id),
+        contains('abcd'),
       );
     });
 


### PR DESCRIPTION
## What

An old match left `in-progress` keeps showing on the home feed. Tapping it crashed the app into a red screen:

```
Providers are not allowed to modify other providers during their initialization.
The provider StateNotifierProvider<MatchControlNotifier, MatchControlState> modified
StateNotifierProvider<MatchFeedNotifier, List<Match>> while building.

MatchFeedNotifier._upsert -> addLocal -> MatchControlNotifier._publishState
  -> _onTimeUp -> new MatchControlNotifier
```

## Why it happened

`MatchControlScreen.initState` reads `matchControlProvider`, so the notifier is created mid-build. If the match it carries has a clock that already expired, the constructor settles it there and then — and settling publishes, which also pushes the new state into the home feed. One provider writing to another during its own creation is exactly what Riverpod asserts against.

## The fix

Defer only the feed write, and only while the constructor body runs (`_initializing`).

- The settlement stays synchronous — `remainingSeconds`, `awaitsOutcome`, the silent (no-horn) finish and the expiry timestamp are unchanged, so the screen's first frame reads exactly as before.
- Relay publishing is untouched and still starts immediately.
- The deferred closure reads `state.match` when it fires instead of capturing it now, so if the referee got ahead of it the feed still converges on the newest match.

The paused-clock early `return` in the constructor was folded into its condition so the flag is always cleared on every path.

## Test plan

- [x] New regression test builds `matchControlProvider` through a real `ProviderContainer` with an expired match — it fails on `main` with the exact production stack, and passes here.
- [x] `flutter test` — 656 passing, 0 failing.
- [x] `flutter analyze` — no new issues (the 2 in the touched file are pre-existing `_UndoEntry` warnings).
- [x] Verified on a Pixel 6: the stale match that crashed now opens and asks how it ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWuDmvaV3sK1Z8QQF5hrAK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause errors when reopening expired matches.
  * Ensured match feed updates complete safely during match initialization.
  * Improved handling of matches that transition to a finished state.

* **Tests**
  * Added coverage for reopening expired matches and confirming their feed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->