### PR TITLE
fix: bootstrap flutter before piping its version into jq

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,19 @@ jobs:
       # Recorded so the release job can install the same version. Two
       # independent "stable" resolutions can disagree when a Flutter release
       # lands between them, and one app release must not ship two frameworks.
+      #
+      # The bare `flutter --version` first is load-bearing. The first flutter
+      # invocation on a fresh runner bootstraps the tool (Dart SDK download,
+      # pub upgrade), spraying non-JSON progress output. Piped into jq, that
+      # noise makes jq bail and close the pipe — and on Windows the tool then
+      # dies writing to the closed pipe (errno 232), and its retry loop hangs
+      # the job forever. Bootstrap with nobody reading the pipe, so the
+      # --machine call below emits clean JSON.
       - name: Report Flutter version
         id: flutter
         shell: bash
         run: |
+          flutter --version
           echo "version=$(flutter --version --machine | jq -r .frameworkVersion)" \
             >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## What

The v2.0.0 release run hung for ~29 minutes on the Windows job's **Report Flutter version** step, then died. Run: https://github.com/protolayer-io/choke/actions/runs/30266024159

Log tail, repeating forever:

```
Error (255): Unable to 'pub upgrade' flutter tool. Retrying in five seconds... (3 tries left)
Running pub upgrade...
Unhandled exception:
FileSystemException: writeFrom failed, path = '' (OS Error: The pipe is being closed, errno = 232)
```

## Why

```bash
echo "version=$(flutter --version --machine | jq -r .frameworkVersion)" >> $GITHUB_OUTPUT
```

was the **first** flutter invocation on the runner, so the tool bootstrapped itself (Dart SDK download, pub upgrade) spraying non-JSON progress output into the pipe. jq choked on it and exited, closing the pipe; the flutter tool then crashed writing to the closed pipe (errno 232), and its retry logic re-ran the bootstrap into the same dead pipe, forever. Linux never hit it because its bootstrap keeps the pipe usable long enough for jq to survive.

## Fix

Run a bare `flutter --version` first — bootstrap completes with nobody reading the pipe — so the `--machine` call below it emits clean JSON. One line, plus a comment explaining why it's load-bearing.

## Test plan

- [x] Only occurrence of the pattern in the workflows (grep).
- [x] The step's output name/format (`steps.flutter.outputs.version`) is unchanged, so the `build-and-release` job's consumption is untouched.
- [ ] Real verification is the re-tagged v2.0.0 release run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWuDmvaV3sK1Z8QQF5hrAK