### PR TITLE
docs: add Google Play release notes for v2.0.0

### DIFF
--- a/distribution/play/whatsnew-v2.0.0.txt
+++ b/distribution/play/whatsnew-v2.0.0.txt
@@ -1,0 +1,43 @@
+<en-US>
+The screen no longer dims while you follow a live board — it stays awake for as long as the match does.
+
+The board carries its own light theme, so it reads just as clearly in daylight.
+
+Scores published by an organiser now land the moment they change, instead of a couple of seconds later.
+
+Fixed: opening a match whose time had already run out crashed the app.
+Fixed: a board could freeze on a match that was no longer live.
+</en-US>
+
+<es-ES>
+La pantalla ya no se atenúa mientras sigues un marcador en directo: permanece encendida mientras dure la lucha.
+
+El marcador tiene su propio tema claro, así que se lee igual de bien a plena luz.
+
+Los puntos que publica un organizador llegan en el momento en que cambian, y no un par de segundos después.
+
+Corregido: abrir una lucha cuyo tiempo ya había terminado cerraba la app.
+Corregido: el marcador podía congelarse en una lucha que ya no estaba en directo.
+</es-ES>
+
+<es-419>
+La pantalla ya no se atenúa mientras sigues un marcador en vivo: se mantiene encendida mientras dure la lucha.
+
+El marcador tiene su propio tema claro, así que se lee igual de bien a plena luz.
+
+Los puntos que publica un organizador llegan en el momento en que cambian, y no un par de segundos después.
+
+Corregido: abrir una lucha cuyo tiempo ya había terminado cerraba la app.
+Corregido: el marcador podía congelarse en una lucha que ya no estaba en vivo.
+</es-419>
+
+<pt-BR>
+A tela não escurece mais enquanto você acompanha um placar ao vivo: ela fica acesa enquanto durar a luta.
+
+O placar tem o próprio tema claro e continua legível sob luz forte.
+
+Os pontos publicados por um organizador chegam no instante em que mudam, e não alguns segundos depois.
+
+Corrigido: abrir uma luta cujo tempo já havia acabado fechava o app.
+Corrigido: o placar podia travar em uma luta que não estava mais ao vivo.
+</pt-BR>


### PR DESCRIPTION
## What

Release notes for the v2.0.0 Play listing, in Play's tagged multi-locale format, at `distribution/play/whatsnew-v2.0.0.txt`:

| Locale | | Length |
|---|---|---|
| `en-US` | English | 425 / 500 |
| `es-ES` | Spanish (Spain) | 460 / 500 |
| `es-419` | Spanish (Latin America) | 456 / 500 |
| `pt-BR` | Portuguese (Brazil) | 422 / 500 |

## How the copy was chosen

Written for people installing the app, not transcribed from the changelog:

- **Dropped the Windows binary.** It ships in v2.0.0, but it means nothing to someone reading the notes on Android.
- **Dropped the eight "address the review findings" commits.** Real work, no user-visible story.
- **Kept what a user would notice:** the screen staying awake on a live board, the board's light theme, organiser scores arriving without the ~2s delay, and the two crashes that are gone (expired match on open, board freezing on a stale match).

`es-ES` and `es-419` are not copies of each other — the Latin American variant uses *en vivo* where the peninsular one uses *en directo*.

## Not wired up

The Play upload step in `release.yml` uses `r0adkll/upload-google-play` without a `whatsnewDirectory`, so nothing reads this file — it is text to paste into the console for now. Automating it would mean one file per locale under a `whatsnew/` directory and a new input on that step; happy to do it in a follow-up if you want the notes to ship with the bundle.

## Test plan

- [x] Every locale block verified under Play's 500-character limit (script in the PR discussion).
- [x] Tag names match Play's locale codes (`en-US`, `es-ES`, `es-419`, `pt-BR`).
- [ ] Final check is pasting into the Play Console, which validates locales against the listing's configured languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWuDmvaV3sK1Z8QQF5hrAK