### PR TITLE
feat: let a watched board be handed on, by link or by QR

### DIFF
--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -1,22 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
-import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../services/deep_links/share_link.dart';
 import '../../services/nostr/nostr_service.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import '../../shared/theme/app_theme.dart';
+import '../../shared/widgets/qr_dialog.dart';
 import '../../services/key_management/key_manager.dart';
-
-/// Base of the public live board. A shared link carries the organizer's npub in
-/// the query string (`?npub=…`), so opening it drops the spectator straight onto
-/// this user's matches with nothing to paste. Must match the reader in
-/// choke-scoreboard (`buildShareLink` / `readSharedPubkey`).
-const String kLiveBoardBaseUrl = 'https://bjjscore.live';
-
-/// Build the share link for an organizer's npub.
-String liveBoardShareUrl(String npub) => '$kLiveBoardBaseUrl/?npub=$npub';
 
 /// Point the relays and the home feed at the identity that is now stored.
 ///
@@ -806,73 +798,12 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
   }
 
   void _showQRCode(BuildContext context, String data) {
-    showDialog(
-      context: context,
-      builder: (context) {
-        final l10n = AppLocalizations.of(context);
-        final theme = Theme.of(context);
-        final colors = theme.colorScheme;
-        return AlertDialog(
-          backgroundColor: colors.surface,
-          title: Text(
-            l10n.yourPublicKey,
-            style: TextStyle(color: colors.onSurface),
-            textAlign: TextAlign.center,
-          ),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: BJJColors.white,
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: SizedBox(
-                  width: 200,
-                  height: 200,
-                  child: QrImageView(
-                    data: data,
-                    backgroundColor: BJJColors.white,
-                    eyeStyle: const QrEyeStyle(
-                      eyeShape: QrEyeShape.square,
-                      color: BJJColors.navy,
-                    ),
-                    dataModuleStyle: const QrDataModuleStyle(
-                      dataModuleShape: QrDataModuleShape.square,
-                      color: BJJColors.navy,
-                    ),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                data,
-                style: TextStyle(
-                  color: theme.textTheme.bodyMedium?.color,
-                  fontSize: 11,
-                  fontFamily: 'monospace',
-                ),
-                textAlign: TextAlign.center,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                l10n.scanQrToShare,
-                style: theme.textTheme.bodyMedium?.copyWith(fontSize: 12),
-                textAlign: TextAlign.center,
-              ),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(l10n.close),
-            ),
-          ],
-        );
-      },
+    final l10n = AppLocalizations.of(context);
+    showQrDialog(
+      context,
+      title: l10n.yourPublicKey,
+      data: data,
+      caption: l10n.scanQrToShare,
     );
   }
 }

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 
 import '../../services/deep_links/share_link.dart';
 import '../../services/nostr/crypto/nostr_crypto.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
+import '../../shared/widgets/qr_dialog.dart';
 import '../../shared/widgets/status_filter_bar.dart';
 import '../match/models/match.dart';
 import 'providers/scoreboard_providers.dart';
@@ -63,6 +65,67 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
         Set<MatchStatus>.from(ref.read(scoreboardStatusFilterProvider));
     if (!current.remove(status)) current.add(status);
     ref.read(scoreboardStatusFilterProvider.notifier).state = current;
+  }
+
+  /// The link a spectator opens to reach the board being watched.
+  ///
+  /// The npub, not the hex: it is what the web board publishes and what a
+  /// person can recognise if they ever look at the URL.
+  String _boardUrl(String watchedHex) =>
+      liveBoardShareUrl(ref.read(nostrCryptoProvider).npubEncode(watchedHex));
+
+  /// Hand this board to somebody else.
+  ///
+  /// A board is worth nothing to the person already watching it — its value is
+  /// that it travels: a coach sends it to a parent two rooms away, a spectator
+  /// re-shares it into the academy group. Sharing the *link* rather than the
+  /// key means the recipient has nothing to paste, and the same URL serves both
+  /// of them: the app opens it if they have it, the web board if they do not.
+  Future<void> _shareBoard(String watchedHex) async {
+    final l10n = AppLocalizations.of(context);
+    final url = _boardUrl(watchedHex);
+
+    // iPad requires a non-null origin to anchor the share popover; the screen's
+    // render box is a safe fallback on phones.
+    final box = context.findRenderObject() as RenderBox?;
+    final origin =
+        box != null ? box.localToGlobal(Offset.zero) & box.size : null;
+
+    try {
+      await Share.share(
+        '${l10n.scoreboardShareBoardMessage}\n$url',
+        subject: l10n.scoreboardShareBoard,
+        sharePositionOrigin: origin,
+      );
+    } on PlatformException catch (e) {
+      // The platform share sheet can fail to open (no handler registered, a
+      // transient platform error). Surface it instead of letting the failure
+      // escape this tap callback as an unhandled async error. Only the code is
+      // logged — never the message, which could echo shared content back out.
+      debugPrint('ScoreboardScreen: share sheet failed (${e.code})');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(l10n.shareFailed),
+          backgroundColor: Theme.of(context).colorScheme.error,
+        ),
+      );
+    }
+  }
+
+  /// The same link as a code, for a room rather than a chat.
+  ///
+  /// This is how a board reaches people who are physically present: the
+  /// organizer holds up or projects the code and the crowd points a camera at
+  /// it, with nothing typed and no key exchanged.
+  void _showQr(String watchedHex) {
+    final l10n = AppLocalizations.of(context);
+    showQrDialog(
+      context,
+      title: l10n.scoreboardQrTitle,
+      data: _boardUrl(watchedHex),
+      caption: l10n.scoreboardQrHint,
+    );
   }
 
   void _open(Match match) {
@@ -146,6 +209,25 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
                       ],
                     ),
                   ),
+                  // Only once there is a board to hand over. With nothing
+                  // watched there is no link to give, and behind a broken link
+                  // the board underneath is not the one that was asked for —
+                  // passing it on would spread the substitution the broken-link
+                  // state exists to stop.
+                  if (watched != null && !brokenLink) ...[
+                    IconButton(
+                      onPressed: () => _showQr(watched),
+                      tooltip: l10n.showQr,
+                      color: tk.muted,
+                      icon: const Icon(Icons.qr_code_2),
+                    ),
+                    IconButton(
+                      onPressed: () => _shareBoard(watched),
+                      tooltip: l10n.scoreboardShareBoard,
+                      color: tk.muted,
+                      icon: const Icon(Icons.ios_share),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -885,5 +885,21 @@
   "scoreboardBrokenLinkDismiss": "Show my board",
   "@scoreboardBrokenLinkDismiss": {
     "description": "Button that dismisses the broken-link state and returns to the board the user was already watching"
+  },
+  "scoreboardShareBoard": "Share this board",
+  "@scoreboardShareBoard": {
+    "description": "Tooltip and share-sheet subject for sharing a link to the board being watched"
+  },
+  "scoreboardShareBoardMessage": "Follow these BJJ matches live on bjjscore.live:",
+  "@scoreboardShareBoardMessage": {
+    "description": "Message shown before the shared bjjscore.live link when sharing a watched board"
+  },
+  "scoreboardQrTitle": "Scan to watch live",
+  "@scoreboardQrTitle": {
+    "description": "Title of the dialog holding a QR code of the watched board's link"
+  },
+  "scoreboardQrHint": "Point a phone camera at this code to open the live board",
+  "@scoreboardQrHint": {
+    "description": "Caption under the QR code of the watched board's link"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -226,5 +226,9 @@
   },
   "scoreboardBrokenLinkTitle": "Ese link está roto",
   "scoreboardBrokenLinkBody": "Apuntaba a un tablero en particular, pero no se pudo leer la clave pública que traía. Pedile a quien te lo compartió que te lo mande de nuevo.",
-  "scoreboardBrokenLinkDismiss": "Ver mi tablero"
+  "scoreboardBrokenLinkDismiss": "Ver mi tablero",
+  "scoreboardShareBoard": "Compartir este tablero",
+  "scoreboardShareBoardMessage": "Seguí estas luchas de BJJ en vivo en bjjscore.live:",
+  "scoreboardQrTitle": "Escaneá para ver en vivo",
+  "scoreboardQrHint": "Apuntá la cámara del teléfono a este código para abrir el tablero en vivo"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -226,5 +226,9 @@
   },
   "scoreboardBrokenLinkTitle": "このリンクは壊れています",
   "scoreboardBrokenLinkBody": "特定のスコアボードを指していましたが、公開鍵を読み取れませんでした。共有した人にもう一度送ってもらってください。",
-  "scoreboardBrokenLinkDismiss": "自分のスコアボードを見る"
+  "scoreboardBrokenLinkDismiss": "自分のスコアボードを見る",
+  "scoreboardShareBoard": "このスコアボードを共有",
+  "scoreboardShareBoardMessage": "bjjscore.live でこれらの BJJ の試合をライブで観戦:",
+  "scoreboardQrTitle": "スキャンしてライブ観戦",
+  "scoreboardQrHint": "スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -226,5 +226,9 @@
   },
   "scoreboardBrokenLinkTitle": "Esse link está quebrado",
   "scoreboardBrokenLinkBody": "Ele apontava para um placar específico, mas não foi possível ler a chave pública que trazia. Peça para quem compartilhou enviar de novo.",
-  "scoreboardBrokenLinkDismiss": "Ver meu placar"
+  "scoreboardBrokenLinkDismiss": "Ver meu placar",
+  "scoreboardShareBoard": "Compartilhar este placar",
+  "scoreboardShareBoardMessage": "Acompanhe estas lutas de BJJ ao vivo em bjjscore.live:",
+  "scoreboardQrTitle": "Escaneie para ver ao vivo",
+  "scoreboardQrHint": "Aponte a câmera do celular para este código para abrir o placar ao vivo"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1421,6 +1421,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Show my board'**
   String get scoreboardBrokenLinkDismiss;
+
+  /// Tooltip and share-sheet subject for sharing a link to the board being watched
+  ///
+  /// In en, this message translates to:
+  /// **'Share this board'**
+  String get scoreboardShareBoard;
+
+  /// Message shown before the shared bjjscore.live link when sharing a watched board
+  ///
+  /// In en, this message translates to:
+  /// **'Follow these BJJ matches live on bjjscore.live:'**
+  String get scoreboardShareBoardMessage;
+
+  /// Title of the dialog holding a QR code of the watched board's link
+  ///
+  /// In en, this message translates to:
+  /// **'Scan to watch live'**
+  String get scoreboardQrTitle;
+
+  /// Caption under the QR code of the watched board's link
+  ///
+  /// In en, this message translates to:
+  /// **'Point a phone camera at this code to open the live board'**
+  String get scoreboardQrHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -709,4 +709,18 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkDismiss => 'Show my board';
+
+  @override
+  String get scoreboardShareBoard => 'Share this board';
+
+  @override
+  String get scoreboardShareBoardMessage =>
+      'Follow these BJJ matches live on bjjscore.live:';
+
+  @override
+  String get scoreboardQrTitle => 'Scan to watch live';
+
+  @override
+  String get scoreboardQrHint =>
+      'Point a phone camera at this code to open the live board';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -714,4 +714,18 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkDismiss => 'Ver mi tablero';
+
+  @override
+  String get scoreboardShareBoard => 'Compartir este tablero';
+
+  @override
+  String get scoreboardShareBoardMessage =>
+      'Seguí estas luchas de BJJ en vivo en bjjscore.live:';
+
+  @override
+  String get scoreboardQrTitle => 'Escaneá para ver en vivo';
+
+  @override
+  String get scoreboardQrHint =>
+      'Apuntá la cámara del teléfono a este código para abrir el tablero en vivo';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -684,4 +684,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkDismiss => '自分のスコアボードを見る';
+
+  @override
+  String get scoreboardShareBoard => 'このスコアボードを共有';
+
+  @override
+  String get scoreboardShareBoardMessage =>
+      'bjjscore.live でこれらの BJJ の試合をライブで観戦:';
+
+  @override
+  String get scoreboardQrTitle => 'スキャンしてライブ観戦';
+
+  @override
+  String get scoreboardQrHint => 'スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -714,4 +714,18 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkDismiss => 'Ver meu placar';
+
+  @override
+  String get scoreboardShareBoard => 'Compartilhar este placar';
+
+  @override
+  String get scoreboardShareBoardMessage =>
+      'Acompanhe estas lutas de BJJ ao vivo em bjjscore.live:';
+
+  @override
+  String get scoreboardQrTitle => 'Escaneie para ver ao vivo';
+
+  @override
+  String get scoreboardQrHint =>
+      'Aponte a câmera do celular para este código para abrir o placar ao vivo';
 }

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -12,6 +12,21 @@ import '../nostr/crypto/nostr_crypto.dart';
 /// to somebody else, and is ignored rather than guessed at.
 const String kShareLinkHost = 'bjjscore.live';
 
+/// Base of the public live board.
+///
+/// Built from [kShareLinkHost] rather than written out again: the host this app
+/// answers for and the host it hands out have to be the same one, and two
+/// literals are two things to forget to change together.
+const String kLiveBoardBaseUrl = 'https://$kShareLinkHost';
+
+/// Build the share link for an organizer's npub.
+///
+/// A shared link carries the npub in the query string (`?npub=…`), so opening
+/// it drops the spectator straight onto that board with nothing to paste — in
+/// the app if they have it, on the web board if they do not. Must match the
+/// reader in choke-scoreboard (`buildShareLink` / `readSharedPubkey`).
+String liveBoardShareUrl(String npub) => '$kLiveBoardBaseUrl/?npub=$npub';
+
 /// The query parameters a shared board link may carry the pubkey in.
 ///
 /// Both, and in this order, because choke-scoreboard has always accepted both

--- a/lib/shared/widgets/qr_dialog.dart
+++ b/lib/shared/widgets/qr_dialog.dart
@@ -79,8 +79,6 @@ class QrDialog extends StatelessWidget {
               fontFamily: 'monospace',
             ),
             textAlign: TextAlign.center,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
           ),
           const SizedBox(height: 8),
           Text(

--- a/lib/shared/widgets/qr_dialog.dart
+++ b/lib/shared/widgets/qr_dialog.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+import '../theme/app_theme.dart';
+
+/// A scannable code, and the thing it encodes spelled out underneath it.
+///
+/// Two screens hand out the same kind of thing — the account screen a public
+/// key, the scoreboard a link to a live board — and a camera pointed at a phone
+/// is how both travel across a room. [data] is always shown as text as well:
+/// codes fail to scan in bad light, at an angle, and on cracked glass, and
+/// somebody has to be able to read it out.
+class QrDialog extends StatelessWidget {
+  const QrDialog({
+    super.key,
+    required this.title,
+    required this.data,
+    required this.caption,
+  });
+
+  /// What this code is, in the reader's language.
+  final String title;
+
+  /// What the code encodes. Shown as text as well as scanned.
+  final String data;
+
+  /// What to do with it — "scan this to…".
+  final String caption;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return AlertDialog(
+      backgroundColor: colors.surface,
+      title: Text(
+        title,
+        style: TextStyle(color: colors.onSurface),
+        textAlign: TextAlign.center,
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Always a white plate with navy modules, in either theme. A scanner
+          // needs the contrast, and a code tinted to match the dark theme is a
+          // code that does not read.
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: BJJColors.white,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: SizedBox(
+              width: 200,
+              height: 200,
+              child: QrImageView(
+                data: data,
+                backgroundColor: BJJColors.white,
+                eyeStyle: const QrEyeStyle(
+                  eyeShape: QrEyeShape.square,
+                  color: BJJColors.navy,
+                ),
+                dataModuleStyle: const QrDataModuleStyle(
+                  dataModuleShape: QrDataModuleShape.square,
+                  color: BJJColors.navy,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            data,
+            style: TextStyle(
+              color: theme.textTheme.bodyMedium?.color,
+              fontSize: 11,
+              fontFamily: 'monospace',
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            caption,
+            style: theme.textTheme.bodyMedium?.copyWith(fontSize: 12),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(l10n.close),
+        ),
+      ],
+    );
+  }
+}
+
+/// Show [QrDialog] over [context].
+Future<void> showQrDialog(
+  BuildContext context, {
+  required String title,
+  required String data,
+  required String caption,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (_) => QrDialog(title: title, data: data, caption: caption),
+  );
+}

--- a/test/features/account/account_screen_interactions_test.dart
+++ b/test/features/account/account_screen_interactions_test.dart
@@ -7,9 +7,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:choke/features/account/account_screen.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/deep_links/share_link.dart';
 import 'package:choke/services/key_management/key_manager.dart';
 
 import '../../support/nostr_fakes.dart';
+import '../../support/share_channel.dart';
 
 const _npub = 'npub1testpublickey';
 const _nsec = 'nsec1testprivatekey';
@@ -106,31 +108,6 @@ void main() {
           .setMockMethodCallHandler(SystemChannels.platform, null);
     });
     return copied;
-  }
-
-  /// Mock the share_plus platform channel; records the shared text, or throws
-  /// when [fail] is set.
-  List<Map<Object?, Object?>> mockShareChannel(
-    WidgetTester tester, {
-    bool fail = false,
-  }) {
-    const channel = MethodChannel('dev.fluttercommunity.plus/share');
-    final calls = <Map<Object?, Object?>>[];
-    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-      channel,
-      (call) async {
-        if (fail) {
-          throw PlatformException(code: 'no-share-target');
-        }
-        calls.add((call.arguments as Map).cast<Object?, Object?>());
-        return 'dev.fluttercommunity.plus/share/success';
-      },
-    );
-    addTearDown(() {
-      tester.binding.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, null);
-    });
-    return calls;
   }
 
   test('liveBoardShareUrl carries the npub in the query string', () {

--- a/test/features/scoreboard/scoreboard_share_test.dart
+++ b/test/features/scoreboard/scoreboard_share_test.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/features/scoreboard/scoreboard_screen.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/deep_links/share_link.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+import 'package:choke/services/wakelock/screen_wakelock.dart';
+import 'package:choke/shared/theme/app_theme.dart';
+import 'package:choke/shared/widgets/qr_dialog.dart';
+
+import '../../support/nostr_fakes.dart';
+import '../../support/share_channel.dart';
+
+/// The relays are not part of what these tests are about; the feed just needs
+/// something that answers.
+class _OfflineNostrService extends NostrService {
+  _OfflineNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  @override
+  Stream<NostrEvent> get eventStream => const Stream.empty();
+
+  @override
+  void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {}
+
+  @override
+  void unsubscribe(String subscriptionId) {}
+
+  @override
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) => const [];
+}
+
+const _watched =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+/// The link the fake crypto's npub encodes to. Spelled out rather than built,
+/// so a change to how the URL is assembled fails here too.
+const _sharedUrl = 'https://bjjscore.live/?npub=npub1fake';
+
+Match _match() => Match(
+      id: 'abcd',
+      status: MatchStatus.inProgress,
+      startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      duration: 300,
+      f1Name: 'Buchecha',
+      f2Name: 'Roger Gracie',
+      f1Color: '#1BA34E',
+      f2Color: '#F5B800',
+    );
+
+Widget _wrap(Widget child, {List<Override> overrides = const []}) {
+  return ProviderScope(
+    overrides: [
+      nostrCryptoProvider.overrideWithValue(FakeNostrCrypto()),
+      nostrServiceProvider.overrideWithValue(_OfflineNostrService()),
+      screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+      ...overrides,
+    ],
+    child: MaterialApp(
+      theme: AppTheme.darkTheme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    ),
+  );
+}
+
+/// The screen with a board already being watched, which is the only state the
+/// share actions exist in.
+Future<void> _pumpWatching(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues(
+    {'choke:scoreboard-pubkey': _watched},
+  );
+  await tester.pumpWidget(_wrap(
+    const ScoreboardScreen(),
+    overrides: [
+      scoreboardMatchesProvider.overrideWithValue([_match()]),
+      scoreboardFilteredMatchesProvider.overrideWithValue([_match()]),
+    ],
+  ));
+  await tester.pump();
+  await tester.pump(); // the saved pubkey is restored asynchronously
+}
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('ScoreboardScreen sharing', () {
+    testWidgets('offers nothing to share until a board is being watched',
+        (tester) async {
+      // Arrange + Act — the welcome state, no pubkey watched
+      await tester.pumpWidget(_wrap(const ScoreboardScreen()));
+      await tester.pump();
+
+      // Assert — sharing "the board" with no board named would hand somebody a
+      // link to nothing.
+      expect(find.byTooltip(l10n.scoreboardShareBoard), findsNothing);
+      expect(find.byTooltip(l10n.showQr), findsNothing);
+    });
+
+    testWidgets('opens the share sheet with a link to the watched board',
+        (tester) async {
+      // Arrange
+      final calls = mockShareChannel(tester);
+      await _pumpWatching(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareBoard));
+      await tester.pumpAndSettle();
+
+      // Assert — the spectator gets a link, never the raw hex key
+      expect(calls, hasLength(1));
+      final sharedText = calls.single['text'] as String;
+      expect(sharedText, contains(_sharedUrl));
+      expect(sharedText, contains(l10n.scoreboardShareBoardMessage));
+      expect(sharedText, isNot(contains(_watched)));
+    });
+
+    testWidgets('surfaces a share sheet failure instead of crashing',
+        (tester) async {
+      // Arrange
+      mockShareChannel(tester, fail: true);
+      await _pumpWatching(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareBoard));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text(l10n.shareFailed), findsOneWidget);
+    });
+
+    testWidgets('shows a QR of the same link, for projecting at the venue',
+        (tester) async {
+      // Arrange
+      await _pumpWatching(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.showQr));
+      await tester.pumpAndSettle();
+
+      // Assert — the code carries the share link, and the link is legible
+      // underneath it for anyone whose camera will not scan.
+      expect(find.byType(QrImageView), findsOneWidget);
+      final dialog = tester.widget<QrDialog>(find.byType(QrDialog));
+      expect(dialog.data, _sharedUrl);
+      expect(find.text(_sharedUrl), findsOneWidget);
+      expect(find.text(l10n.scoreboardQrTitle), findsOneWidget);
+
+      // Act — and it closes
+      await tester.tap(find.text(l10n.close));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.byType(QrImageView), findsNothing);
+    });
+
+    testWidgets('offers nothing to share behind a broken link', (tester) async {
+      // Arrange — a link named a board and could not be read. Sharing the board
+      // underneath it would pass on the substitution the state exists to stop.
+      await _pumpWatching(tester);
+      final context = tester.element(find.byType(ScoreboardScreen));
+      final container = ProviderScope.containerOf(context);
+
+      // Act
+      container.read(brokenShareLinkProvider.notifier).state = true;
+      await tester.pump();
+
+      // Assert
+      expect(find.byTooltip(l10n.scoreboardShareBoard), findsNothing);
+      expect(find.byTooltip(l10n.showQr), findsNothing);
+    });
+  });
+}

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:choke/features/account/account_screen.dart';
 import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
 import 'package:choke/services/deep_links/share_link.dart';
 import 'package:choke/shared/providers/navigation_provider.dart';

--- a/test/support/share_channel.dart
+++ b/test/support/share_channel.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Mock the share_plus platform channel; records the shared text, or throws
+/// when [fail] is set.
+///
+/// Shared by every screen that opens the share sheet, so how the plugin is
+/// driven is asserted in one place rather than drifting between the account
+/// screen's tests and the scoreboard's.
+List<Map<Object?, Object?>> mockShareChannel(
+  WidgetTester tester, {
+  bool fail = false,
+}) {
+  const channel = MethodChannel('dev.fluttercommunity.plus/share');
+  final calls = <Map<Object?, Object?>>[];
+  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    channel,
+    (call) async {
+      if (fail) {
+        throw PlatformException(code: 'no-share-target');
+      }
+      calls.add((call.arguments as Map).cast<Object?, Object?>());
+      return 'dev.fluttercommunity.plus/share/success';
+    },
+  );
+  addTearDown(() {
+    tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+  return calls;
+}


### PR DESCRIPTION
Implements the share half of the viral loop from the business plan (§2.1): every board a spectator watches should be one tap away from reaching the next person.

## What changes

The Scoreboard header gains two actions, shown only while a board is actually being watched:

- **Share** — opens the platform share sheet with `https://bjjscore.live/?npub=…` and a short message. For chats.
- **QR** — the same link as a scannable code, for a room: the organizer holds it up or projects it at the mat and the crowd points a camera at it, with nothing typed and no key exchanged.

Both hand out the **link**, never the raw hex pubkey, so the recipient needs nothing — the app opens it via App Links if they have it installed, the web board if they do not.

Neither action appears with no board watched (there would be no link to give), nor behind a broken share link (passing on the board underneath would spread the very substitution that state exists to prevent).

## Refactors carried along

- `kLiveBoardBaseUrl` / `liveBoardShareUrl` move from `account_screen.dart` into `services/deep_links/share_link.dart`, next to the reader that parses them, and the base URL is now derived from `kShareLinkHost` so the host the app answers for and the host it hands out cannot drift apart.
- The QR dialog is extracted to `shared/widgets/qr_dialog.dart` — the account screen was already showing one, and this is now the second caller.
- The share_plus channel mock moves to `test/support/share_channel.dart`, shared by both screens' tests.

## Localization

Four new keys in all four locales (en/es/pt/ja): `scoreboardShareBoard`, `scoreboardShareBoardMessage`, `scoreboardQrTitle`, `scoreboardQrHint`.

## Test plan

- [x] `flutter test` — 663 passing, including 5 new cases: nothing to share before a board is watched, the share sheet carries the link and not the key, a failed share sheet surfaces instead of crashing, the QR encodes the same link, and nothing is offered behind a broken link
- [x] `flutter analyze` — no new warnings (the analyzer's remaining items are pre-existing on main)
- [x] `dart format` clean
- [ ] On device: watch a board, share it into a chat, tap the link from another phone → opens the app on that board
- [ ] On device: show the QR, scan it with a second phone's camera → opens the same board

Pairs with protolayer-io/choke-scoreboard#32, which adds the matching "get the app" CTA to the web board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sharing for watched scoreboards through shareable links.
  * Added QR-code viewing for watched scoreboard links.
  * Share and QR actions appear only when a valid scoreboard is available.
  * Added reusable, high-contrast QR dialogs for easier scanning.
  * Added localized sharing and QR instructions in English, Spanish, Japanese, and Portuguese.

* **Bug Fixes**
  * Added user feedback when sharing fails.
  * Prevented sharing actions from appearing for unavailable or broken scoreboards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->