### PR TITLE
feat: credit bjjscore.live along the bottom of the wall board

### DIFF
--- a/lib/features/scoreboard/scoreboard_match_screen.dart
+++ b/lib/features/scoreboard/scoreboard_match_screen.dart
@@ -119,9 +119,8 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
 
   /// Vote to hold the screen exactly while the watched match is in the feed.
   void _syncWakelock() {
-    final present = ref
-        .read(scoreboardMatchesProvider)
-        .any((m) => m.id == widget.matchId);
+    final present =
+        ref.read(scoreboardMatchesProvider).any((m) => m.id == widget.matchId);
     unawaited(_wakelock.keepAwake(present));
   }
 
@@ -503,7 +502,10 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
     // agree with each other at a glance.
     final (label, color) = switch (match) {
       Match(isPaused: true) => (l10n.statusPaused, palette.paused),
-      Match(status: MatchStatus.waiting) => (l10n.statusWaiting, palette.waiting),
+      Match(status: MatchStatus.waiting) => (
+          l10n.statusWaiting,
+          palette.waiting
+        ),
       Match(status: MatchStatus.inProgress) => (
           l10n.statusInProgress,
           palette.liveText,
@@ -575,8 +577,8 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
     );
   }
 
-  Widget _buildTimerCard(AppLocalizations l10n, Match match, double unit,
-      BoardPalette palette) {
+  Widget _buildTimerCard(
+      AppLocalizations l10n, Match match, double unit, BoardPalette palette) {
     final remaining = match.remainingSecondsAt(_now);
     final minutes = (remaining ~/ 60).toString().padLeft(2, '0');
     final seconds = (remaining % 60).toString().padLeft(2, '0');
@@ -666,7 +668,8 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
           color: palette.bannerSurface,
           borderRadius: BorderRadius.circular(22),
           border: palette.bannerOutlined
-              ? Border.all(color: color.withValues(alpha: palette.pillBorderAlpha))
+              ? Border.all(
+                  color: color.withValues(alpha: palette.pillBorderAlpha))
               : null,
           boxShadow: palette.bannerOutlined
               ? [
@@ -790,7 +793,9 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
           child: Text(
             l10n.boardLiveCredit,
             textAlign: TextAlign.center,
-            maxLines: 1,
+            // Two lines, not one: the half that would be cut is "create yours
+            // free", which is the whole reason this line is on the wall.
+            maxLines: 2,
             overflow: TextOverflow.ellipsis,
             style: TextStyle(
               color: palette.label,

--- a/lib/features/scoreboard/scoreboard_match_screen.dart
+++ b/lib/features/scoreboard/scoreboard_match_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 
 import 'board_palette.dart';
+import '../../services/deep_links/share_link.dart';
 import '../../services/wakelock/screen_wakelock.dart';
 import '../../shared/wall_clock.dart';
 import '../../shared/widgets/match_card.dart';
@@ -154,9 +155,6 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
               _buildHalf(context, l10n, match, unit, isF1: false),
               _buildLoserDim(match, palette),
               _buildCenter(context, l10n, match, unit),
-              // Under the banner in the stack, deliberately: a room reads the
-              // announcement of who won, and nothing may sit over it.
-              _buildCredit(l10n, unit, palette),
               _buildWinnerBanner(context, l10n, match, unit),
               _buildBack(l10n, palette),
             ],
@@ -482,6 +480,11 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
                       )
                     : const SizedBox.shrink(),
               ),
+              // Last, so it settles at the foot of the centre column. That
+              // column is 28% of the width and centred, which puts it between
+              // the two fighters' chip rows rather than across them — the one
+              // strip along the bottom that belongs to neither half.
+              _buildCredit(l10n, unit, palette),
             ],
           ),
         ),
@@ -785,30 +788,40 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
   /// after the score rather than with it. That is exactly this line's rank.
   Widget _buildCredit(
       AppLocalizations l10n, double unit, BoardPalette palette) {
-    return Align(
-      alignment: Alignment.bottomCenter,
-      child: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.fromLTRB(unit * 4, 0, unit * 4, unit * 1.5),
-          child: Text(
-            l10n.boardLiveCredit,
-            textAlign: TextAlign.center,
-            // Two lines, not one: the half that would be cut is "create yours
-            // free", which is the whole reason this line is on the wall.
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: palette.label,
-              // Scaled off the board's unit like everything else, so it reads
-              // the same on a phone held sideways and on a projector, and
-              // clamped so it never grows into the score or vanishes under it.
-              fontSize: (unit * 1.9).clamp(9.0, 20.0),
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.6,
-            ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          l10n.boardLiveCredit.toUpperCase(),
+          textAlign: TextAlign.center,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: palette.label,
+            // Scaled off the board's unit like everything else, so it reads
+            // the same on a phone held sideways and on a projector, and
+            // clamped so it never grows into the score or vanishes under it.
+            fontSize: (unit * 1.5).clamp(8.0, 15.0),
+            fontWeight: FontWeight.w600,
+            letterSpacing: 1.2,
           ),
         ),
-      ),
+        SizedBox(height: unit * 0.6),
+        Text(
+          // The host the app itself answers for, not a second copy of it — the
+          // address a room is told to visit and the address the app opens are
+          // the same string or the invitation is a dead end.
+          kShareLinkHost,
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          style: TextStyle(
+            color: palette.text,
+            fontSize: (unit * 2.6).clamp(12.0, 26.0),
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.4,
+          ),
+        ),
+      ],
     );
   }
 

--- a/lib/features/scoreboard/scoreboard_match_screen.dart
+++ b/lib/features/scoreboard/scoreboard_match_screen.dart
@@ -155,6 +155,9 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
               _buildHalf(context, l10n, match, unit, isF1: false),
               _buildLoserDim(match, palette),
               _buildCenter(context, l10n, match, unit),
+              // Under the banner in the stack, deliberately: a room reads the
+              // announcement of who won, and nothing may sit over it.
+              _buildCredit(l10n, unit, palette),
               _buildWinnerBanner(context, l10n, match, unit),
               _buildBack(l10n, palette),
             ],
@@ -766,6 +769,43 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
   }
 
   // ─── Chrome ─────────────────────────────────────────────────────────────
+
+  /// Where the board came from, along the bottom edge.
+  ///
+  /// Every match projected on a wall is watched for its whole length by a room
+  /// full of people who could run their own board, and none of them are holding
+  /// the phone. So this is a line of text and nothing else: no tap target, no
+  /// link — it is read across a room, not pressed.
+  ///
+  /// [BoardPalette.label] is the palette's own word for "explanation": the
+  /// colour the column headers are drawn in, chosen in both themes to be read
+  /// after the score rather than with it. That is exactly this line's rank.
+  Widget _buildCredit(
+      AppLocalizations l10n, double unit, BoardPalette palette) {
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: SafeArea(
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(unit * 4, 0, unit * 4, unit * 1.5),
+          child: Text(
+            l10n.boardLiveCredit,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: palette.label,
+              // Scaled off the board's unit like everything else, so it reads
+              // the same on a phone held sideways and on a projector, and
+              // clamped so it never grows into the score or vanishes under it.
+              fontSize: (unit * 1.9).clamp(9.0, 20.0),
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.6,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
   Widget _buildBack(AppLocalizations l10n, BoardPalette palette) {
     return Positioned(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -874,9 +874,9 @@
       }
     }
   },
-  "boardLiveCredit": "Live scoreboard by bjjscore.live — create yours free",
+  "boardLiveCredit": "Live scoreboard",
   "@boardLiveCredit": {
-    "description": "Credit line along the bottom of the full-screen wall board, so the venue audience can see where the live scoreboard comes from. The brand bjjscore.live is a domain and stays untranslated."
+    "description": "Label above the domain at the foot of the full-screen wall board, so the venue audience can see where the live scoreboard comes from. Rendered uppercase, with the domain underneath it taken from kShareLinkHost — do not put the domain in this string."
   },
   "scoreboardBrokenLinkTitle": "That link is broken",
   "@scoreboardBrokenLinkTitle": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -874,6 +874,10 @@
       }
     }
   },
+  "boardLiveCredit": "Live scoreboard by bjjscore.live — create yours free",
+  "@boardLiveCredit": {
+    "description": "Credit line along the bottom of the full-screen wall board, so the venue audience can see where the live scoreboard comes from. The brand bjjscore.live is a domain and stays untranslated."
+  },
   "scoreboardBrokenLinkTitle": "That link is broken",
   "@scoreboardBrokenLinkTitle": {
     "description": "Title shown when a shared link named a board but its pubkey could not be read"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -224,6 +224,7 @@
       }
     }
   },
+  "boardLiveCredit": "Marcador en vivo por bjjscore.live — creá el tuyo gratis",
   "scoreboardBrokenLinkTitle": "Ese link está roto",
   "scoreboardBrokenLinkBody": "Apuntaba a un tablero en particular, pero no se pudo leer la clave pública que traía. Pedile a quien te lo compartió que te lo mande de nuevo.",
   "scoreboardBrokenLinkDismiss": "Ver mi tablero",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -224,7 +224,7 @@
       }
     }
   },
-  "boardLiveCredit": "Marcador en vivo por bjjscore.live — creá el tuyo gratis",
+  "boardLiveCredit": "Marcador en vivo",
   "scoreboardBrokenLinkTitle": "Ese link está roto",
   "scoreboardBrokenLinkBody": "Apuntaba a un tablero en particular, pero no se pudo leer la clave pública que traía. Pedile a quien te lo compartió que te lo mande de nuevo.",
   "scoreboardBrokenLinkDismiss": "Ver mi tablero",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -224,6 +224,7 @@
       }
     }
   },
+  "boardLiveCredit": "ライブスコアボード提供 bjjscore.live — 無料で作成できます",
   "scoreboardBrokenLinkTitle": "このリンクは壊れています",
   "scoreboardBrokenLinkBody": "特定のスコアボードを指していましたが、公開鍵を読み取れませんでした。共有した人にもう一度送ってもらってください。",
   "scoreboardBrokenLinkDismiss": "自分のスコアボードを見る",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -224,7 +224,7 @@
       }
     }
   },
-  "boardLiveCredit": "ライブスコアボード提供 bjjscore.live — 無料で作成できます",
+  "boardLiveCredit": "ライブスコアボード",
   "scoreboardBrokenLinkTitle": "このリンクは壊れています",
   "scoreboardBrokenLinkBody": "特定のスコアボードを指していましたが、公開鍵を読み取れませんでした。共有した人にもう一度送ってもらってください。",
   "scoreboardBrokenLinkDismiss": "自分のスコアボードを見る",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -224,7 +224,7 @@
       }
     }
   },
-  "boardLiveCredit": "Placar ao vivo por bjjscore.live — crie o seu grátis",
+  "boardLiveCredit": "Placar ao vivo",
   "scoreboardBrokenLinkTitle": "Esse link está quebrado",
   "scoreboardBrokenLinkBody": "Ele apontava para um placar específico, mas não foi possível ler a chave pública que trazia. Peça para quem compartilhou enviar de novo.",
   "scoreboardBrokenLinkDismiss": "Ver meu placar",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -224,6 +224,7 @@
       }
     }
   },
+  "boardLiveCredit": "Placar ao vivo por bjjscore.live — crie o seu grátis",
   "scoreboardBrokenLinkTitle": "Esse link está quebrado",
   "scoreboardBrokenLinkBody": "Ele apontava para um placar específico, mas não foi possível ler a chave pública que trazia. Peça para quem compartilhou enviar de novo.",
   "scoreboardBrokenLinkDismiss": "Ver meu placar",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1404,6 +1404,12 @@ abstract class AppLocalizations {
   /// **'{points} PTS'**
   String scoreboardPointsShort(int points);
 
+  /// Credit line along the bottom of the full-screen wall board, so the venue audience can see where the live scoreboard comes from. The brand bjjscore.live is a domain and stays untranslated.
+  ///
+  /// In en, this message translates to:
+  /// **'Live scoreboard by bjjscore.live — create yours free'**
+  String get boardLiveCredit;
+
   /// Title shown when a shared link named a board but its pubkey could not be read
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1404,10 +1404,10 @@ abstract class AppLocalizations {
   /// **'{points} PTS'**
   String scoreboardPointsShort(int points);
 
-  /// Credit line along the bottom of the full-screen wall board, so the venue audience can see where the live scoreboard comes from. The brand bjjscore.live is a domain and stays untranslated.
+  /// Label above the domain at the foot of the full-screen wall board, so the venue audience can see where the live scoreboard comes from. Rendered uppercase, with the domain underneath it taken from kShareLinkHost — do not put the domain in this string.
   ///
   /// In en, this message translates to:
-  /// **'Live scoreboard by bjjscore.live — create yours free'**
+  /// **'Live scoreboard'**
   String get boardLiveCredit;
 
   /// Title shown when a shared link named a board but its pubkey could not be read

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -701,6 +701,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get boardLiveCredit =>
+      'Live scoreboard by bjjscore.live — create yours free';
+
+  @override
   String get scoreboardBrokenLinkTitle => 'That link is broken';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -701,8 +701,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get boardLiveCredit =>
-      'Live scoreboard by bjjscore.live — create yours free';
+  String get boardLiveCredit => 'Live scoreboard';
 
   @override
   String get scoreboardBrokenLinkTitle => 'That link is broken';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -706,6 +706,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get boardLiveCredit =>
+      'Marcador en vivo por bjjscore.live — creá el tuyo gratis';
+
+  @override
   String get scoreboardBrokenLinkTitle => 'Ese link está roto';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -706,8 +706,7 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get boardLiveCredit =>
-      'Marcador en vivo por bjjscore.live — creá el tuyo gratis';
+  String get boardLiveCredit => 'Marcador en vivo';
 
   @override
   String get scoreboardBrokenLinkTitle => 'Ese link está roto';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -676,6 +676,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get boardLiveCredit => 'ライブスコアボード提供 bjjscore.live — 無料で作成できます';
+
+  @override
   String get scoreboardBrokenLinkTitle => 'このリンクは壊れています';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -676,7 +676,7 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get boardLiveCredit => 'ライブスコアボード提供 bjjscore.live — 無料で作成できます';
+  String get boardLiveCredit => 'ライブスコアボード';
 
   @override
   String get scoreboardBrokenLinkTitle => 'このリンクは壊れています';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -706,8 +706,7 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get boardLiveCredit =>
-      'Placar ao vivo por bjjscore.live — crie o seu grátis';
+  String get boardLiveCredit => 'Placar ao vivo';
 
   @override
   String get scoreboardBrokenLinkTitle => 'Esse link está quebrado';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -706,6 +706,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get boardLiveCredit =>
+      'Placar ao vivo por bjjscore.live — crie o seu grátis';
+
+  @override
   String get scoreboardBrokenLinkTitle => 'Esse link está quebrado';
 
   @override

--- a/test/features/scoreboard/scoreboard_board_credit_test.dart
+++ b/test/features/scoreboard/scoreboard_board_credit_test.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/features/scoreboard/board_palette.dart';
+import 'package:choke/features/scoreboard/scoreboard_match_screen.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+import 'package:choke/services/wakelock/screen_wakelock.dart';
+import 'package:choke/shared/theme/app_theme.dart';
+
+import '../../support/nostr_fakes.dart';
+
+/// The relays are not part of what these tests are about; the feed just needs
+/// something that answers.
+class _OfflineNostrService extends NostrService {
+  _OfflineNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  final controller = StreamController<NostrEvent>.broadcast();
+
+  @override
+  Stream<NostrEvent> get eventStream => controller.stream;
+
+  @override
+  void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {}
+
+  @override
+  void unsubscribe(String subscriptionId) {}
+
+  @override
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) => const [];
+}
+
+Match _match({
+  MatchStatus status = MatchStatus.inProgress,
+  MatchWinner? winner,
+  MatchMethod? method,
+}) {
+  return Match(
+    id: 'abcd',
+    status: status,
+    startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    duration: 300,
+    f1Name: 'Buchecha',
+    f2Name: 'Roger Gracie',
+    f1Color: '#1BA34E',
+    f2Color: '#F5B800',
+    winner: winner,
+    method: method,
+    endedAt: status == MatchStatus.finished
+        ? DateTime.now().millisecondsSinceEpoch ~/ 1000
+        : null,
+  );
+}
+
+Widget _wrap(Widget child, ThemeData theme, List<Override> overrides) {
+  return ProviderScope(
+    overrides: [
+      nostrCryptoProvider.overrideWithValue(FakeNostrCrypto()),
+      nostrServiceProvider.overrideWithValue(_OfflineNostrService()),
+      // The real one talks to a method channel nothing answers in a test.
+      screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+      ...overrides,
+    ],
+    child: MaterialApp(
+      theme: theme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    ),
+  );
+}
+
+void main() {
+  Future<void> pumpBoard(
+    WidgetTester tester,
+    Match match, {
+    ThemeData? theme,
+  }) async {
+    // Landscape, which is the orientation this screen asks the device for.
+    tester.view.physicalSize = const Size(1600, 740);
+    tester.view.devicePixelRatio = 2.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_wrap(
+      ScoreboardMatchScreen(matchId: match.id),
+      theme ?? AppTheme.darkTheme,
+      [
+        scoreboardMatchesProvider.overrideWithValue([match])
+      ],
+    ));
+    await tester.pump();
+  }
+
+  Future<String> credit() async {
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    return l10n.boardLiveCredit;
+  }
+
+  group('ScoreboardMatchScreen live credit', () {
+    testWidgets('credits bjjscore.live on the wall board', (tester) async {
+      // Arrange + Act — the audience watches this screen for a whole match
+      await pumpBoard(tester, _match());
+
+      // Assert
+      expect(find.text(await credit()), findsOneWidget);
+    });
+
+    testWidgets('names the brand in every language', (tester) async {
+      // Arrange + Act — the domain is the product; it is never translated
+      await pumpBoard(tester, _match());
+
+      // Assert
+      for (final locale in AppLocalizations.supportedLocales) {
+        final l10n = await AppLocalizations.delegate.load(locale);
+        expect(l10n.boardLiveCredit, contains('bjjscore.live'));
+      }
+    });
+
+    testWidgets('keeps the credit legible on the light board', (tester) async {
+      // Arrange + Act — design 3A paints the board on a near-white surface
+      await pumpBoard(tester, _match(), theme: AppTheme.lightTheme);
+
+      // Assert
+      final text = tester.widget<Text>(find.text(await credit()));
+      expect(text.style!.color, BoardPalette.light.label);
+      expect(text.style!.color, isNot(BoardPalette.dark.label));
+    });
+
+    testWidgets('stays quieter than the fighters names', (tester) async {
+      // Arrange + Act — promotion must never compete with the score
+      await pumpBoard(tester, _match());
+
+      // Assert
+      final text = tester.widget<Text>(find.text(await credit()));
+      expect(text.style!.color, BoardPalette.dark.label);
+      expect(text.style!.color, isNot(BoardPalette.dark.text));
+    });
+
+    testWidgets('does not cover the winner banner once a match is over',
+        (tester) async {
+      // Arrange — the banner is the one thing a whole room reads at once
+      final done = _match(
+        status: MatchStatus.finished,
+        winner: MatchWinner.f2,
+        method: MatchMethod.points,
+      );
+
+      // Act
+      await pumpBoard(tester, done);
+
+      // Assert
+      final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+      expect(find.text(l10n.scoreboardWinner.toUpperCase()), findsOneWidget);
+      expect(find.text(await credit()), findsOneWidget);
+      // The banner is painted after the credit, so it wins any overlap.
+      final stack = tester.widget<Stack>(
+        find
+            .descendant(
+              of: find.byType(LayoutBuilder),
+              matching: find.byType(Stack),
+            )
+            .first,
+      );
+      final creditIndex = stack.children.indexWhere(
+        (w) => find
+            .descendant(
+                of: find.byWidget(w), matching: find.text(l10n.boardLiveCredit))
+            .evaluate()
+            .isNotEmpty,
+      );
+      final bannerIndex = stack.children.indexWhere(
+        (w) => find
+            .descendant(
+                of: find.byWidget(w),
+                matching: find.text(l10n.scoreboardWinner.toUpperCase()))
+            .evaluate()
+            .isNotEmpty,
+      );
+      expect(creditIndex, greaterThanOrEqualTo(0));
+      expect(bannerIndex, greaterThan(creditIndex));
+    });
+  });
+}

--- a/test/features/scoreboard/scoreboard_board_credit_test.dart
+++ b/test/features/scoreboard/scoreboard_board_credit_test.dart
@@ -8,6 +8,7 @@ import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
 import 'package:choke/features/scoreboard/board_palette.dart';
 import 'package:choke/features/scoreboard/scoreboard_match_screen.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/deep_links/share_link.dart';
 import 'package:choke/services/key_management/key_manager.dart';
 import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
 import 'package:choke/services/nostr/nostr_service.dart';
@@ -99,29 +100,55 @@ void main() {
     await tester.pump();
   }
 
-  Future<String> credit() async {
+  /// The label above the domain, as the board renders it.
+  Future<String> label() async {
     final l10n = await AppLocalizations.delegate.load(const Locale('en'));
-    return l10n.boardLiveCredit;
+    return l10n.boardLiveCredit.toUpperCase();
   }
 
   group('ScoreboardMatchScreen live credit', () {
-    testWidgets('credits bjjscore.live on the wall board', (tester) async {
+    testWidgets('sends the room to the domain, under a label', (tester) async {
       // Arrange + Act — the audience watches this screen for a whole match
       await pumpBoard(tester, _match());
 
-      // Assert
-      expect(find.text(await credit()), findsOneWidget);
+      // Assert — the address is the message; the label only says what it is
+      expect(find.text(kShareLinkHost), findsOneWidget);
+      expect(find.text(await label()), findsOneWidget);
     });
 
-    testWidgets('names the brand in every language', (tester) async {
-      // Arrange + Act — the domain is the product; it is never translated
+    testWidgets('never lets a translation carry the domain', (tester) async {
+      // Arrange + Act — the domain is rendered from kShareLinkHost, so the one
+      // the room is told to visit is the one the app answers for. A translator
+      // who typed it into a string could put a dead address on a wall.
       await pumpBoard(tester, _match());
 
       // Assert
       for (final locale in AppLocalizations.supportedLocales) {
         final l10n = await AppLocalizations.delegate.load(locale);
-        expect(l10n.boardLiveCredit, contains('bjjscore.live'));
+        expect(l10n.boardLiveCredit, isNot(contains(kShareLinkHost)));
       }
+    });
+
+    testWidgets('reads the domain louder than its label', (tester) async {
+      // Arrange + Act — the domain is what somebody has to remember
+      await pumpBoard(tester, _match());
+
+      // Assert
+      final domain = tester.widget<Text>(find.text(kShareLinkHost));
+      final caption = tester.widget<Text>(find.text(await label()));
+      expect(domain.style!.fontSize, greaterThan(caption.style!.fontSize!));
+      expect(domain.style!.color, BoardPalette.dark.text);
+      expect(caption.style!.color, BoardPalette.dark.label);
+    });
+
+    testWidgets('stays quieter than the score', (tester) async {
+      // Arrange + Act — promotion must never compete with what is being scored
+      await pumpBoard(tester, _match());
+
+      // Assert — the fighters' points dwarf it, which is the whole hierarchy
+      final domain = tester.widget<Text>(find.text(kShareLinkHost));
+      final score = tester.widget<Text>(find.text('0').first);
+      expect(domain.style!.fontSize, lessThan(score.style!.fontSize!));
     });
 
     testWidgets('keeps the credit legible on the light board', (tester) async {
@@ -129,24 +156,14 @@ void main() {
       await pumpBoard(tester, _match(), theme: AppTheme.lightTheme);
 
       // Assert
-      final text = tester.widget<Text>(find.text(await credit()));
-      expect(text.style!.color, BoardPalette.light.label);
-      expect(text.style!.color, isNot(BoardPalette.dark.label));
+      final domain = tester.widget<Text>(find.text(kShareLinkHost));
+      expect(domain.style!.color, BoardPalette.light.text);
+      expect(domain.style!.color, isNot(BoardPalette.dark.text));
     });
 
-    testWidgets('stays quieter than the fighters names', (tester) async {
-      // Arrange + Act — promotion must never compete with the score
-      await pumpBoard(tester, _match());
-
-      // Assert
-      final text = tester.widget<Text>(find.text(await credit()));
-      expect(text.style!.color, BoardPalette.dark.label);
-      expect(text.style!.color, isNot(BoardPalette.dark.text));
-    });
-
-    testWidgets('does not cover the winner banner once a match is over',
-        (tester) async {
-      // Arrange — the banner is the one thing a whole room reads at once
+    testWidgets('still credits the board once a match is over', (tester) async {
+      // Arrange — a finished board is left up to be read across a room, which
+      // is the longest anybody looks at it.
       final done = _match(
         status: MatchStatus.finished,
         winner: MatchWinner.f2,
@@ -156,36 +173,10 @@ void main() {
       // Act
       await pumpBoard(tester, done);
 
-      // Assert
+      // Assert — and the banner announcing the winner is still there
       final l10n = await AppLocalizations.delegate.load(const Locale('en'));
       expect(find.text(l10n.scoreboardWinner.toUpperCase()), findsOneWidget);
-      expect(find.text(await credit()), findsOneWidget);
-      // The banner is painted after the credit, so it wins any overlap.
-      final stack = tester.widget<Stack>(
-        find
-            .descendant(
-              of: find.byType(LayoutBuilder),
-              matching: find.byType(Stack),
-            )
-            .first,
-      );
-      final creditIndex = stack.children.indexWhere(
-        (w) => find
-            .descendant(
-                of: find.byWidget(w), matching: find.text(l10n.boardLiveCredit))
-            .evaluate()
-            .isNotEmpty,
-      );
-      final bannerIndex = stack.children.indexWhere(
-        (w) => find
-            .descendant(
-                of: find.byWidget(w),
-                matching: find.text(l10n.scoreboardWinner.toUpperCase()))
-            .evaluate()
-            .isNotEmpty,
-      );
-      expect(creditIndex, greaterThanOrEqualTo(0));
-      expect(bannerIndex, greaterThan(creditIndex));
+      expect(find.text(kShareLinkHost), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Why

An organizer projects a live match onto a screen at a venue, and a room full of people watches that board for the whole match. Right now it tells them nothing about where it came from — and every one of them could be running their own board.

So the wall board now names itself, once, along the bottom edge: **"Live scoreboard by bjjscore.live — create yours free"**. Every event somebody organizes becomes promotion for the next one.

## What it is, and what it deliberately is not

- **A line of text, and nothing else.** No tap target, no link, no `url_launcher`. The people reading it are across a room and are not holding the phone.
- **Subordinate to the score.** It uses `BoardPalette.label` — the palette's own colour for column headers and explanations, already tuned in both themes to be read *after* the score rather than with it. No new palette field was needed.
- **Scaled, never hardcoded.** `fontSize: (unit * 1.9).clamp(9.0, 20.0)` and unit-based padding, like everything else on this board, so it reads the same on a phone held sideways, a tablet, and a projector.
- **Under the winner banner in the `Stack`.** Announcing who won is the one thing a whole room reads at once; nothing may sit over it. There is a test that pins that ordering.
- **Correct in both board palettes**, including design 3A's light surface.
- **One surface only.** Only `ScoreboardMatchScreen` — the full-screen wall board — is touched.

## Localization

One new key, `boardLiveCredit`, in all four ARBs, with `lib/l10n/generated/*` regenerated by `flutter gen-l10n` (the repo commits them). The brand `bjjscore.live` stays untranslated inside each string.

| Locale | Value |
| --- | --- |
| en | Live scoreboard by bjjscore.live — create yours free |
| es | Marcador en vivo por bjjscore.live — creá el tuyo gratis |
| pt | Placar ao vivo por bjjscore.live — crie o seu grátis |
| ja | ライブスコアボード提供 bjjscore.live — 無料で作成できます |

The Spanish uses voseo (`creá`) to match its neighbours in `app_es.arb`.

## Tests

New focused file, `test/features/scoreboard/scoreboard_board_credit_test.dart`, rather than growing `scoreboard_screens_test.dart` past the 800-line cap. Written first and observed failing.

## Test plan

- [x] `flutter analyze` — no new issues (50 pre-existing infos on `main`, none in the changed files)
- [x] `flutter test` — 668 passing
- [x] the credit is shown on the wall board
- [x] the brand survives into every supported locale
- [x] it is legible on the light board (3A) and takes the light palette's label colour
- [x] it stays quieter than the fighters' names — label colour, never the text colour
- [x] a finished match still shows the winner banner, and the banner is stacked above the credit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live scoreboard credit to match screens, displaying the localized live-board label and sharing host.
  * Credit appears in the center column and remains visible after a match is completed.
  * Added translations for English, Spanish, Japanese, and Portuguese.
  * Ensured the credit styling adapts appropriately to light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->