### PR TITLE
refactor: read a shared link's key from npub, and only npub

### DIFF
--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -26,10 +26,14 @@ Both need the platform to hand the link to the framework rather than merely
 launching the activity, which is what `flutter_deeplinking_enabled` does in the
 Android manifest.
 
-The accepted parameters are `npub` and `pubkey`, holding either an `npub1…` or
-64-character hex — the same pair choke-scoreboard accepts (`SHARE_PUBKEY_PARAMS`
-in its `share-link.ts`), because the same URL is opened by whichever of the two
-the recipient has.
+The accepted parameter is `npub`, holding either an `npub1…` or 64-character hex
+— the same name choke-scoreboard accepts (`SHARE_PUBKEY_PARAM` in its
+`share-link.ts`), because the same URL is opened by whichever of the two the
+recipient has.
+
+A `pubkey` alias used to be accepted alongside it. Nothing ever produced one, so
+it was removed rather than carried: two names for one thing doubled the cases to
+cover and left "which is canonical?" to be asked every time a link was built.
 
 A link for any other host is ignored. So is one that names no usable key: the
 app keeps whatever board the user was already watching rather than dropping them

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -27,13 +27,15 @@ const String kLiveBoardBaseUrl = 'https://$kShareLinkHost';
 /// reader in choke-scoreboard (`buildShareLink` / `readSharedPubkey`).
 String liveBoardShareUrl(String npub) => '$kLiveBoardBaseUrl/?npub=$npub';
 
-/// The query parameters a shared board link may carry the pubkey in.
+/// The query parameter a shared board link carries the pubkey in.
 ///
-/// Both, and in this order, because choke-scoreboard has always accepted both
-/// (`SHARE_PUBKEY_PARAMS` in its `share-link.ts`) and one URL is shared to
-/// everyone: whichever of the two the recipient opens it in has to understand
-/// it.
-const List<String> kSharePubkeyParams = ['npub', 'pubkey'];
+/// One name, matching `SHARE_PUBKEY_PARAM` in choke-scoreboard's
+/// `share-link.ts`, because one URL is shared to everyone and whichever of the
+/// two the recipient opens it in has to understand it.
+///
+/// The *value* may still be an `npub1…` or bare 64-character hex — `parsePubkey`
+/// sorts that out, so this stays a question about the URL and not about crypto.
+const String kSharePubkeyParam = 'npub';
 
 /// What a link turned out to be.
 ///
@@ -72,8 +74,8 @@ class BrokenShareLink extends ShareLink {
 
 /// Read a link the OS handed over.
 ///
-/// Accepts exactly what the web board accepts: `https://bjjscore.live/?npub=…`
-/// or `?pubkey=…`, holding either an npub or bare hex.
+/// Accepts exactly what the web board accepts: `https://bjjscore.live/?npub=…`,
+/// holding either an npub or bare hex.
 ///
 /// Never throws. What arrives here is whatever was tapped, which is not a
 /// trusted caller.
@@ -87,21 +89,14 @@ ShareLink readShareLink(Uri uri, NostrCrypto crypto) {
     return const NotAShareLink();
   }
 
-  var sawParameter = false;
+  final value = uri.queryParameters[kSharePubkeyParam]?.trim();
 
-  for (final param in kSharePubkeyParams) {
-    final value = uri.queryParameters[param]?.trim();
+  // An empty value is not a broken key, it is no key — the web board skips it
+  // the same way, and a bare `?npub=` should not accuse anybody of anything.
+  if (value == null || value.isEmpty) return const NotAShareLink();
 
-    // An empty value is not a broken key, it is no key — the web board skips it
-    // the same way, and a bare `?npub=` should not accuse anybody of anything.
-    if (value == null || value.isEmpty) continue;
-
-    sawParameter = true;
-    final hex = parsePubkey(value, crypto);
-    if (hex != null) return SharedBoard(hex);
-  }
-
-  return sawParameter ? const BrokenShareLink() : const NotAShareLink();
+  final hex = parsePubkey(value, crypto);
+  return hex != null ? SharedBoard(hex) : const BrokenShareLink();
 }
 
 /// Set when a link named a board and its pubkey could not be read.
@@ -171,11 +166,10 @@ bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
 /// [what] names the decision, because "ignoring" and "showing the user an
 /// error" read identically in a support report otherwise.
 void _log(Uri uri, String what) {
-  final named =
-      kSharePubkeyParams.where(uri.queryParameters.containsKey).join(',');
+  final named = uri.queryParameters.containsKey(kSharePubkeyParam);
   debugPrint(
     'DeepLink: $what a link for ${uri.host.isEmpty ? '(no host)' : uri.host}'
-    '${named.isEmpty ? ' with no pubkey parameter' : ' whose $named did not parse'}',
+    '${named ? ' whose $kSharePubkeyParam did not parse' : ' with no pubkey parameter'}',
   );
 }
 

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -38,13 +38,17 @@ void main() {
       expect(boardOf(uri), 'a' * 64);
     });
 
-    test('accepts the pubkey parameter the web board also accepts', () {
-      // Arrange — choke-scoreboard takes either name, and one link is shared to
-      // everyone
+    test('ignores the pubkey parameter that used to be an alias', () {
+      // Arrange — `pubkey` was a second spelling of `npub` that nothing ever
+      // produced. This asserts the removal rather than merely dropping the
+      // case that covered it: silently starting to accept it again is the
+      // regression worth catching.
       final uri = Uri.parse('https://bjjscore.live/?pubkey=npub1fake');
 
-      // Act + Assert
-      expect(boardOf(uri), _watched);
+      // Act + Assert — not a *broken* link either. It names nothing this app
+      // answers for, which is the silent case, not the accusing one.
+      expect(boardOf(uri), isNull);
+      expect(readShareLink(uri, crypto), isA<NotAShareLink>());
     });
 
     test('ignores whitespace around a pasted key', () {


### PR DESCRIPTION
Removes the `pubkey` query-parameter alias. A shared board link is read from `?npub=` and nothing else.

## Why now, and why it is safe

This is a **breaking change to a public URL contract**, and the only reason it can be made is that the contract was never exercised:

- `liveBoardShareUrl` produces `?npub=`.
- choke-scoreboard's `buildShareLink` sets `npub`.
- The web commit that introduced the alias, `1a294dd`, is titled *"auto-load an organizer from a shared link **(?npub=)**"*.

Nothing in either repo has ever generated a `?pubkey=` link, so there are none in the wild to break. The residual risk is a third party who hand-built one against an alias documented nowhere but in a code comment.

The window for this is now. A shared link lives in a chat forever — once real `?pubkey=` links exist, removing support stops being reversible.

## Why remove it at all

Two names for one thing doubles the cases to cover and the sentences needed to explain the URL, and it leaves "which one is canonical?" to be asked every time somebody builds a link. It also came up as the counter-example while specifying match links (protolayer-io/choke#152 §2.3): the reason *not* to add a second name for `match` is this pair, which exists as historical drift rather than because two names were ever wanted.

## Changes

- `kSharePubkeyParams` (list) → `kSharePubkeyParam` (single const). `readShareLink` no longer loops; its three outcomes are unchanged.
- `_log` reports the one parameter name it now knows about.
- Doc comments corrected, including the claim that the app "accepts exactly what the web board accepts".
- `docs/deep-links.md` records the removal and why, so the next reader does not re-add it.

## Test plan

- [x] `flutter test` — 669 passing
- [x] `flutter analyze` — 0 errors
- [x] The test that asserted the alias was **inverted, not deleted**: `?pubkey=…` now asserts `NotAShareLink`. Silently accepting it again is the regression worth catching.
- [x] Confirmed no remaining references — the surviving `'pubkey'` hits are the Nostr event field in `nostr_service.dart`, unrelated

Pairs with protolayer-io/choke-scoreboard#35, which does the same on the web side.