### PR TITLE
feat: read a link that names one match, not just a board

### DIFF
--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -1,9 +1,12 @@
 # Shared board links
 
 > **A link to one particular match** — `?npub=…&match=…` — is specified in
-> [`specs/shared-match-links.md`](specs/shared-match-links.md) and is not built
-> yet. Everything below describes the board link, which that one extends rather
-> than replaces.
+> [`specs/shared-match-links.md`](specs/shared-match-links.md). It is **read**
+> but not yet **shown**: `readShareLink` returns `SharedMatch` and
+> `openShareLink` records the request in `requestedMatchProvider`, and the
+> scoreboard does not act on it yet. Nothing produces such a link either.
+> Everything below describes the board link, which that one extends rather than
+> replaces.
 
 Sharing a pubkey from Account produces an ordinary web link:
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -882,9 +882,9 @@
   "@scoreboardBrokenLinkTitle": {
     "description": "Title shown when a shared link named a board but its pubkey could not be read"
   },
-  "scoreboardBrokenLinkBody": "It was meant for a specific board, but the pubkey in it could not be read. Ask whoever shared it to send it again.",
+  "scoreboardBrokenLinkBody": "It was meant for something in particular, but part of it could not be read. Ask whoever shared it to send it again.",
   "@scoreboardBrokenLinkBody": {
-    "description": "Explanation shown with scoreboardBrokenLinkTitle"
+    "description": "Explanation shown with scoreboardBrokenLinkTitle. Deliberately does not name which part failed: a link can now break on its organizer or on the match it names, the recipient does the same thing either way, and claiming the wrong one sends them to fix something that was never wrong"
   },
   "scoreboardBrokenLinkDismiss": "Show my board",
   "@scoreboardBrokenLinkDismiss": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -226,7 +226,7 @@
   },
   "boardLiveCredit": "Marcador en vivo",
   "scoreboardBrokenLinkTitle": "Ese link está roto",
-  "scoreboardBrokenLinkBody": "Apuntaba a un tablero en particular, pero no se pudo leer la clave pública que traía. Pedile a quien te lo compartió que te lo mande de nuevo.",
+  "scoreboardBrokenLinkBody": "Apuntaba a algo en particular, pero no se pudo leer una parte. Pedile a quien te lo compartió que te lo mande de nuevo.",
   "scoreboardBrokenLinkDismiss": "Ver mi tablero",
   "scoreboardShareBoard": "Compartir este tablero",
   "scoreboardShareBoardMessage": "Seguí estas luchas de BJJ en vivo en bjjscore.live:",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -226,7 +226,7 @@
   },
   "boardLiveCredit": "ライブスコアボード",
   "scoreboardBrokenLinkTitle": "このリンクは壊れています",
-  "scoreboardBrokenLinkBody": "特定のスコアボードを指していましたが、公開鍵を読み取れませんでした。共有した人にもう一度送ってもらってください。",
+  "scoreboardBrokenLinkBody": "特定の対象を指していましたが、一部を読み取れませんでした。共有した人にもう一度送ってもらってください。",
   "scoreboardBrokenLinkDismiss": "自分のスコアボードを見る",
   "scoreboardShareBoard": "このスコアボードを共有",
   "scoreboardShareBoardMessage": "bjjscore.live でこれらの BJJ の試合をライブで観戦:",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -226,7 +226,7 @@
   },
   "boardLiveCredit": "Placar ao vivo",
   "scoreboardBrokenLinkTitle": "Esse link está quebrado",
-  "scoreboardBrokenLinkBody": "Ele apontava para um placar específico, mas não foi possível ler a chave pública que trazia. Peça para quem compartilhou enviar de novo.",
+  "scoreboardBrokenLinkBody": "Ele apontava para algo específico, mas não foi possível ler uma parte. Peça para quem compartilhou enviar de novo.",
   "scoreboardBrokenLinkDismiss": "Ver meu placar",
   "scoreboardShareBoard": "Compartilhar este placar",
   "scoreboardShareBoardMessage": "Acompanhe estas lutas de BJJ ao vivo em bjjscore.live:",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1416,10 +1416,10 @@ abstract class AppLocalizations {
   /// **'That link is broken'**
   String get scoreboardBrokenLinkTitle;
 
-  /// Explanation shown with scoreboardBrokenLinkTitle
+  /// Explanation shown with scoreboardBrokenLinkTitle. Deliberately does not name which part failed: a link can now break on its organizer or on the match it names, the recipient does the same thing either way, and claiming the wrong one sends them to fix something that was never wrong
   ///
   /// In en, this message translates to:
-  /// **'It was meant for a specific board, but the pubkey in it could not be read. Ask whoever shared it to send it again.'**
+  /// **'It was meant for something in particular, but part of it could not be read. Ask whoever shared it to send it again.'**
   String get scoreboardBrokenLinkBody;
 
   /// Button that dismisses the broken-link state and returns to the board the user was already watching

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -708,7 +708,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkBody =>
-      'It was meant for a specific board, but the pubkey in it could not be read. Ask whoever shared it to send it again.';
+      'It was meant for something in particular, but part of it could not be read. Ask whoever shared it to send it again.';
 
   @override
   String get scoreboardBrokenLinkDismiss => 'Show my board';

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -713,7 +713,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkBody =>
-      'Apuntaba a un tablero en particular, pero no se pudo leer la clave pública que traía. Pedile a quien te lo compartió que te lo mande de nuevo.';
+      'Apuntaba a algo en particular, pero no se pudo leer una parte. Pedile a quien te lo compartió que te lo mande de nuevo.';
 
   @override
   String get scoreboardBrokenLinkDismiss => 'Ver mi tablero';

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -683,7 +683,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkBody =>
-      '特定のスコアボードを指していましたが、公開鍵を読み取れませんでした。共有した人にもう一度送ってもらってください。';
+      '特定の対象を指していましたが、一部を読み取れませんでした。共有した人にもう一度送ってもらってください。';
 
   @override
   String get scoreboardBrokenLinkDismiss => '自分のスコアボードを見る';

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -713,7 +713,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get scoreboardBrokenLinkBody =>
-      'Ele apontava para um placar específico, mas não foi possível ler a chave pública que trazia. Peça para quem compartilhou enviar de novo.';
+      'Ele apontava para algo específico, mas não foi possível ler uma parte. Peça para quem compartilhou enviar de novo.';
 
   @override
   String get scoreboardBrokenLinkDismiss => 'Ver meu placar';

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -42,7 +42,7 @@ const String kShareMatchParam = 'match';
 ///
 /// Four lowercase hex characters, which is what `Match.create` generates.
 /// Matched against the *decoded* value after trimming and lowercasing — see
-/// [readMatchId] for why that order, and `docs/specs/shared-match-links.md`
+/// [_rawMatchId] for why that order, and `docs/specs/shared-match-links.md`
 /// for the contract both readers implement.
 final RegExp _matchIdPattern = RegExp(r'^[0-9a-f]{4}$');
 
@@ -224,9 +224,14 @@ bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
         _clearStack(ref);
       }
 
+      // The request goes in before the pubkey, not after. Switching the
+      // watched author rebuilds the feed, and anything that reacts to that
+      // synchronously asks "was a match asked for?" — set second, it would
+      // read the previous answer. The board case above clears it first for
+      // the same reason; these two have to agree.
       ref.read(brokenShareLinkProvider.notifier).state = false;
-      ref.read(watchedPubkeyProvider.notifier).watch(pubkeyHex);
       ref.read(requestedMatchProvider.notifier).state = matchId;
+      ref.read(watchedPubkeyProvider.notifier).watch(pubkeyHex);
       ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
       return true;
 

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -27,6 +27,35 @@ const String kLiveBoardBaseUrl = 'https://$kShareLinkHost';
 /// reader in choke-scoreboard (`buildShareLink` / `readSharedPubkey`).
 String liveBoardShareUrl(String npub) => '$kLiveBoardBaseUrl/?npub=$npub';
 
+/// Build the share link for one match on an organizer's board.
+///
+/// The board link plus the match it names. A recipient whose client predates
+/// this parameter reads the npub, ignores the rest, and lands on the board —
+/// one tap from the match instead of on it.
+String matchShareUrl(String npub, String matchId) =>
+    '${liveBoardShareUrl(npub)}&$kShareMatchParam=$matchId';
+
+/// The query parameter naming one match on the board.
+const String kShareMatchParam = 'match';
+
+/// What a match id is allowed to look like.
+///
+/// Four lowercase hex characters, which is what `Match.create` generates.
+/// Matched against the *decoded* value after trimming and lowercasing — see
+/// [readMatchId] for why that order, and `docs/specs/shared-match-links.md`
+/// for the contract both readers implement.
+final RegExp _matchIdPattern = RegExp(r'^[0-9a-f]{4}$');
+
+/// The match id in [uri], or null if it names none.
+///
+/// Returns the id, or null both for "no match parameter" and for one that is
+/// not a match id — the caller separates those, because they are the difference
+/// between a board link and a broken one.
+String? _rawMatchId(Uri uri) {
+  final value = uri.queryParameters[kShareMatchParam]?.trim().toLowerCase();
+  return (value == null || value.isEmpty) ? null : value;
+}
+
 /// The query parameter a shared board link carries the pubkey in.
 ///
 /// One name, matching `SHARE_PUBKEY_PARAM` in choke-scoreboard's
@@ -63,6 +92,20 @@ class SharedBoard extends ShareLink {
   final String pubkeyHex;
 }
 
+/// A shared link naming one match on [pubkeyHex].
+///
+/// Both halves, always. A match id is unique only inside one author's events,
+/// so an id without an organizer names nothing and never reaches here.
+class SharedMatch extends ShareLink {
+  const SharedMatch(this.pubkeyHex, this.matchId);
+
+  /// The watched author, in lowercase hex.
+  final String pubkeyHex;
+
+  /// The requested match, already validated against the contract's grammar.
+  final String matchId;
+}
+
 /// A shared board link whose pubkey could not be read.
 ///
 /// The user followed a link meant for one particular board. Showing them any
@@ -74,8 +117,9 @@ class BrokenShareLink extends ShareLink {
 
 /// Read a link the OS handed over.
 ///
-/// Accepts exactly what the web board accepts: `https://bjjscore.live/?npub=…`,
-/// holding either an npub or bare hex.
+/// Accepts exactly what the web board accepts: `https://bjjscore.live/?npub=…`
+/// holding either an npub or bare hex, optionally followed by `&match=…`
+/// naming one match on that board.
 ///
 /// Never throws. What arrives here is whatever was tapped, which is not a
 /// trusted caller.
@@ -89,14 +133,29 @@ ShareLink readShareLink(Uri uri, NostrCrypto crypto) {
     return const NotAShareLink();
   }
 
+  final match = _rawMatchId(uri);
   final value = uri.queryParameters[kSharePubkeyParam]?.trim();
 
   // An empty value is not a broken key, it is no key — the web board skips it
   // the same way, and a bare `?npub=` should not accuse anybody of anything.
-  if (value == null || value.isEmpty) return const NotAShareLink();
+  //
+  // Unless a match was named. Then the link did promise something, and an id
+  // with no author to look it up under cannot deliver it: ids are unique only
+  // inside one organizer's events.
+  if (value == null || value.isEmpty) {
+    return match == null ? const NotAShareLink() : const BrokenShareLink();
+  }
 
   final hex = parsePubkey(value, crypto);
-  return hex != null ? SharedBoard(hex) : const BrokenShareLink();
+  if (hex == null) return const BrokenShareLink();
+
+  if (match == null) return SharedBoard(hex);
+
+  // A named match that is not a match id is a promise this app cannot keep,
+  // and saying so beats quietly handing over the board it sits on.
+  return _matchIdPattern.hasMatch(match)
+      ? SharedMatch(hex, match)
+      : const BrokenShareLink();
 }
 
 /// Set when a link named a board and its pubkey could not be read.
@@ -105,6 +164,18 @@ ShareLink readShareLink(Uri uri, NostrCrypto crypto) {
 /// its own: only the user can say "fine, show me what I had", because only they
 /// know they did not get what they tapped.
 final brokenShareLinkProvider = StateProvider<bool>((ref) => false);
+
+/// The match a link asked for, until something shows it.
+///
+/// Set by [openShareLink] and read by the scoreboard, which owns the waiting:
+/// the feed answers whenever it answers, and until then there is a request and
+/// no match. Deliberately not "the match to display" — the parser's job ends at
+/// saying what was named, and Pending, Resolved and Unresolved are states of a
+/// screen, not of a URL.
+///
+/// Cleared by any link that names no match, so a board link never inherits the
+/// request left by the one before it.
+final requestedMatchProvider = StateProvider<String?>((ref) => null);
 
 /// Open a shared board link.
 ///
@@ -135,7 +206,27 @@ bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
       }
 
       ref.read(brokenShareLinkProvider.notifier).state = false;
+      ref.read(requestedMatchProvider.notifier).state = null;
       ref.read(watchedPubkeyProvider.notifier).watch(pubkeyHex);
+      ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
+      return true;
+
+    case SharedMatch(:final pubkeyHex, :final matchId):
+      // The same "only when there is something to gain" rule as above, widened
+      // by what this link names. A re-share of the match already on screen must
+      // still change nothing — that is the group-chat case, and it reads as the
+      // app losing the viewer's place. But a link naming a *different* match on
+      // the board already being watched now has something to do, where a board
+      // link would have had nothing: the stack has to come down for the new
+      // match to be seen.
+      if (ref.read(watchedPubkeyProvider) != pubkeyHex ||
+          ref.read(requestedMatchProvider) != matchId) {
+        _clearStack(ref);
+      }
+
+      ref.read(brokenShareLinkProvider.notifier).state = false;
+      ref.read(watchedPubkeyProvider.notifier).watch(pubkeyHex);
+      ref.read(requestedMatchProvider.notifier).state = matchId;
       ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
       return true;
 
@@ -152,6 +243,10 @@ bool openShareLink(Uri uri, NostrCrypto crypto, WidgetRef ref) {
       _log(uri, 'reporting as broken');
       _clearStack(ref);
 
+      // No request survives the message. Leaving one behind would have the
+      // scoreboard still waiting on a match underneath a screen saying the
+      // link could not be read.
+      ref.read(requestedMatchProvider.notifier).state = null;
       ref.read(brokenShareLinkProvider.notifier).state = true;
       ref.read(selectedTabProvider.notifier).state = AppTab.scoreboard;
       return true;

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -556,4 +556,161 @@ void main() {
       expect(find.text('a match in progress'), findsOneWidget);
     });
   });
+
+  group('readShareLink — match links', () {
+    /// The match a link names, or null when it names none this app can read.
+    String? matchOf(Uri uri) {
+      final link = readShareLink(uri, crypto);
+      return link is SharedMatch ? link.matchId : null;
+    }
+
+    test('reads the link matchShareUrl actually builds', () {
+      // Arrange — the exact URL the sharer produces, so the two cannot drift
+      final uri = Uri.parse(matchShareUrl('npub1fake', 'abcd'));
+
+      // Act
+      final link = readShareLink(uri, crypto);
+
+      // Assert — both halves, because either alone names nothing
+      expect(link, isA<SharedMatch>());
+      expect((link as SharedMatch).pubkeyHex, _watched);
+      expect(link.matchId, 'abcd');
+    });
+
+    test('accepts the spellings a chat client might hand back', () {
+      // Arrange — validation is on the decoded value, trimmed and lowercased,
+      // so all three of these are the same id
+      for (final raw in ['abcd', '%61%62%63%64', 'abcd%20', 'ABCD']) {
+        final uri =
+            Uri.parse('https://bjjscore.live/?npub=npub1fake&match=$raw');
+
+        // Act + Assert
+        expect(matchOf(uri), 'abcd', reason: raw);
+      }
+    });
+
+    test('a value that is not a match id breaks the link', () {
+      // Arrange — the sender named something and it cannot be read. That is
+      // not the same as naming nothing.
+      for (final raw in ['abc', 'abcde', 'zzzz', 'ab-cd']) {
+        final uri =
+            Uri.parse('https://bjjscore.live/?npub=npub1fake&match=$raw');
+
+        // Act + Assert
+        expect(readShareLink(uri, crypto), isA<BrokenShareLink>(), reason: raw);
+      }
+    });
+
+    test('an empty match is no match, and leaves a board link intact', () {
+      // Arrange — `&match=` on its own should not accuse anybody of anything,
+      // exactly as a bare `?npub=` does not
+      final uri = Uri.parse('https://bjjscore.live/?npub=npub1fake&match=');
+
+      // Act
+      final link = readShareLink(uri, crypto);
+
+      // Assert
+      expect(link, isA<SharedBoard>());
+      expect((link as SharedBoard).pubkeyHex, _watched);
+    });
+
+    test('a match with no organizer names nothing at all', () {
+      // Arrange — a match id is unique only inside one author's events, so
+      // there is nobody to subscribe to and nothing to show
+      expect(
+        readShareLink(Uri.parse('https://bjjscore.live/?match=abcd'), crypto),
+        isA<BrokenShareLink>(),
+      );
+      expect(
+        readShareLink(
+            Uri.parse('https://bjjscore.live/?npub=&match=abcd'), crypto),
+        isA<BrokenShareLink>(),
+      );
+    });
+
+    test('an unreadable organizer breaks the link, match or no match', () {
+      expect(
+        readShareLink(
+            Uri.parse('https://bjjscore.live/?npub=nonsense&match=abcd'),
+            crypto),
+        isA<BrokenShareLink>(),
+      );
+    });
+
+    test('another host is still not ours, match or no match', () {
+      expect(
+        readShareLink(
+            Uri.parse('https://evil.example/?npub=npub1fake&match=abcd'),
+            crypto),
+        isA<NotAShareLink>(),
+      );
+    });
+  });
+
+  group('openShareLink — match links', () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    Future<WidgetRef> pumpRef(WidgetTester tester) async {
+      late WidgetRef captured;
+      await tester.pumpWidget(ProviderScope(
+        child: Consumer(builder: (context, ref, _) {
+          captured = ref;
+          return const SizedBox();
+        }),
+      ));
+      return captured;
+    }
+
+    testWidgets('asks for the match the link named', (tester) async {
+      // Arrange
+      final ref = await pumpRef(tester);
+
+      // Act
+      final handled = openShareLink(
+          Uri.parse(matchShareUrl('npub1fake', 'abcd')), crypto, ref);
+      await tester.pump();
+
+      // Assert — the board is watched and the match is requested; resolving it
+      // is the screen's job, not this one's
+      expect(handled, isTrue);
+      expect(ref.read(watchedPubkeyProvider), _watched);
+      expect(ref.read(requestedMatchProvider), 'abcd');
+      expect(ref.read(selectedTabProvider), AppTab.scoreboard);
+    });
+
+    testWidgets('a board link afterwards asks for no match', (tester) async {
+      // Arrange — a link naming only a board is not a request for whatever
+      // match happened to be open before it
+      final ref = await pumpRef(tester);
+      openShareLink(Uri.parse(matchShareUrl('npub1fake', 'abcd')), crypto, ref);
+      await tester.pump();
+      expect(ref.read(requestedMatchProvider), 'abcd');
+
+      // Act
+      openShareLink(Uri.parse(liveBoardShareUrl('npub1fake')), crypto, ref);
+      await tester.pump();
+
+      // Assert
+      expect(ref.read(requestedMatchProvider), isNull);
+    });
+
+    testWidgets('a broken link asks for no match either', (tester) async {
+      // Arrange
+      final ref = await pumpRef(tester);
+      openShareLink(Uri.parse(matchShareUrl('npub1fake', 'abcd')), crypto, ref);
+      await tester.pump();
+
+      // Act
+      openShareLink(
+        Uri.parse('https://bjjscore.live/?npub=npub1fake&match=zzzz'),
+        crypto,
+        ref,
+      );
+      await tester.pump();
+
+      // Assert — the message must not sit over a match still being requested
+      expect(ref.read(brokenShareLinkProvider), isTrue);
+      expect(ref.read(requestedMatchProvider), isNull);
+    });
+  });
 }

--- a/test/services/deep_links/share_link_test.dart
+++ b/test/services/deep_links/share_link_test.dart
@@ -678,6 +678,36 @@ void main() {
       expect(ref.read(selectedTabProvider), AppTab.scoreboard);
     });
 
+    testWidgets('has the request in place before the pubkey changes',
+        (tester) async {
+      // Arrange — switching the watched author rebuilds the feed, and anything
+      // reacting to that asks whether a match was requested. Set second, it
+      // would read the previous answer.
+      late ProviderContainer container;
+      late WidgetRef ref;
+      await tester.pumpWidget(ProviderScope(
+        child: Consumer(builder: (context, r, _) {
+          ref = r;
+          container = ProviderScope.containerOf(context);
+          return const SizedBox();
+        }),
+      ));
+
+      String? seenWhenPubkeyChanged;
+      container.listen<String?>(
+        watchedPubkeyProvider,
+        (_, __) =>
+            seenWhenPubkeyChanged = container.read(requestedMatchProvider),
+      );
+
+      // Act
+      openShareLink(Uri.parse(matchShareUrl('npub1fake', 'abcd')), crypto, ref);
+      await tester.pump();
+
+      // Assert
+      expect(seenWhenPubkeyChanged, 'abcd');
+    });
+
     testWidgets('a board link afterwards asks for no match', (tester) async {
       // Arrange — a link naming only a board is not a request for whatever
       // match happened to be open before it


### PR DESCRIPTION
Step 1–2 of the build order in `docs/specs/shared-match-links.md` (§9.3): the parser and the link handler. **Nothing shows a match yet, and nothing produces such a link.** That is the point — §9.2 requires readers to land before writers, so the links that eventually go out are readable the day they go out.

## What this adds

- `kShareMatchParam` (`match`) and `matchShareUrl(npub, matchId)`.
- A fourth `ShareLink` case, `SharedMatch(pubkeyHex, matchId)` — both halves always, because an id alone names nothing.
- `requestedMatchProvider`: what a link asked for, until something shows it. `openShareLink` records the request; it does not resolve it. Pending / Resolved / Unresolved are states of a screen, not of a URL, and the screen is the next change.

## The parsing rules, as specified

A match id is four lowercase hex characters — what `Match.create` generates. Validation runs on the **decoded** value, trimmed and lowercased, because both platforms percent-decode before this code sees anything and reading the raw query to get underneath that would be fighting the platform for nothing.

| Link | Result |
|---|---|
| `?npub=X&match=abcd` | `SharedMatch` |
| `?npub=X&match=%61%62%63%64` / `ABCD` / `abcd%20` | `SharedMatch` — same id |
| `?npub=X&match=abc` / `abcde` / `zzzz` / `ab-cd` | **Broken** |
| `?npub=X&match=` | `SharedBoard` — empty is absent |
| `?match=abcd` (no npub) | **Broken** |

Accepting more than we emit is deliberate: chat clients and auto-capitalising keyboards mangle what people paste, and the `npub` reader already trims for the same reason.

Two cases are worth their own sentence. A **malformed id is broken, not absent** — the sender named something, and quietly handing over the board it sits on is exactly the substitution this file exists to refuse. And an **id with no organizer is broken** because it cannot work: ids are unique only inside one author's events, so there is nobody to look it up under.

## Behaviour change, per §6.1

The "only clear the stack when there is something to gain" rule widens. A re-share of the match already on screen still changes nothing — that is the group-chat case and it reads as the app losing the viewer's place. But a link naming a *different* match on the board already being watched now has something to do, where a board link had nothing.

The referee protection of §6.2 is untouched: `_clearStack` still stops at the first route that refuses to go.

## Test plan

- [x] `flutter test` — 679 passing, 11 new cases covering the table above, the stack rule, and that a board or broken link clears any outstanding request
- [x] `flutter analyze` — 0 errors
- [x] Existing deep-link tests extended rather than rewritten around, per §9.3

Pairs with the web reader in choke-scoreboard, which lands alongside this per §9.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shareable links that open a specific match directly.
  - Match links now validate match identifiers and handle navigation to the requested match.
  - Link handling distinguishes board, match, broken, and unrelated links.

- **Bug Fixes**
  - Improved broken-link messages across supported languages to describe unreadable link content more accurately.

- **Documentation**
  - Clarified that match links can be read and recorded but are not yet displayed or generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->