### PR TITLE
feat: let a match link wait before it gives up

### DIFF
--- a/lib/features/scoreboard/providers/scoreboard_providers.dart
+++ b/lib/features/scoreboard/providers/scoreboard_providers.dart
@@ -157,6 +157,15 @@ class ScoreboardFeedNotifier extends StateNotifier<List<Match>> {
     // author, and carries no hint of which filter matched. Without this the
     // user's own matches would appear as though the watched pubkey had refereed
     // them.
+    //
+    // Load-bearing beyond that, and not obviously so. A shared match link names
+    // an (organizer, matchId) pair, because a match id is four hex characters
+    // and unique only inside one author's events. Nothing downstream re-checks
+    // the author: `ScoreboardMatchScreen` looks its match up by id alone, and
+    // it is *this* line, plus the feed being rebuilt whenever the watched
+    // pubkey changes, that makes that a lookup within one organizer rather than
+    // across all of them. Remove it and a link would silently resolve to
+    // somebody else's match with the same id.
     if (event.pubkey != _pubkey) return;
 
     try {

--- a/lib/features/scoreboard/scoreboard_match_screen.dart
+++ b/lib/features/scoreboard/scoreboard_match_screen.dart
@@ -25,12 +25,35 @@ import 'providers/scoreboard_providers.dart';
 /// Strictly read-only. It renders what the relays say and has no way to change
 /// it; the match belongs to whoever is refereeing it somewhere else.
 class ScoreboardMatchScreen extends ConsumerStatefulWidget {
-  const ScoreboardMatchScreen({super.key, required this.matchId});
+  const ScoreboardMatchScreen({
+    super.key,
+    required this.matchId,
+    this.fromLink = false,
+  });
 
   /// Looked up by id on every build rather than passed in whole, so the screen
   /// re-renders as revisions arrive. Handing it a [Match] would freeze the match
   /// at the moment it was tapped.
+  ///
+  /// The lookup is by id alone, and that is enough: `ScoreboardFeedNotifier`
+  /// drops every event whose author is not the watched pubkey, and the feed is
+  /// rebuilt when that pubkey changes, so everything in
+  /// [scoreboardMatchesProvider] belongs to the watched author by construction.
+  /// That filter is what makes this an (organizer, matchId) lookup — the pair
+  /// the link contract names — rather than a global id lookup. A second check
+  /// here would restate it; removing the filter there would silently break it.
   final String matchId;
+
+  /// Whether a shared link put this screen here, rather than a tap on a card.
+  ///
+  /// The two arrive knowing different things, so they wait differently. A tap
+  /// comes from a list that is already holding the match, so an absent match
+  /// means it went away — the dead end is the truth. A link names a match
+  /// before any data exists, so an absent match means nothing yet, and saying
+  /// "not available" there would break the link's promise on the happy path.
+  /// Hence Pending, and hence only here: making every navigation wait would
+  /// put a spinner in front of a match the user is already looking at.
+  final bool fromLink;
 
   @override
   ConsumerState<ScoreboardMatchScreen> createState() =>
@@ -43,6 +66,22 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
   late final ScreenWakelockLease _wakelock;
 
   Timer? _ticker;
+
+  /// Ends Pending when nothing has answered. Only ever set for a link.
+  Timer? _backstop;
+
+  /// Whether the wait is over: the feed has had its chance and said nothing.
+  ///
+  /// Not terminal. It is what is known so far, and an event arriving after it
+  /// still resolves — [_resolved] outranks this everywhere it is read.
+  bool _settled = false;
+
+  /// Whether the match has ever been in the feed while this screen was open.
+  ///
+  /// Once it has, this screen is the ordinary read-only board and stays that
+  /// way: a match that later ages out under a viewer gets the dead end that has
+  /// always described exactly that, not the copy about a link's window.
+  bool _resolved = false;
 
   /// Now, in unix seconds, advanced once a second so the clock counts down.
   ///
@@ -76,6 +115,14 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
     _syncWakelock();
 
     _scheduleTick();
+
+    // Only a link waits. A tap already has the match, so there is nothing for
+    // a backstop to be the backstop of.
+    if (widget.fromLink) {
+      _backstop = Timer(kMatchLinkBackstop, () {
+        if (mounted) setState(() => _settled = true);
+      });
+    }
   }
 
   /// One tick per wall-clock second, scheduled against the *next* boundary
@@ -113,6 +160,7 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
   @override
   void dispose() {
     _ticker?.cancel();
+    _backstop?.cancel();
     SystemChrome.setPreferredOrientations(DeviceOrientation.values);
     unawaited(_wakelock.release());
     super.dispose();
@@ -140,7 +188,13 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
 
     final palette = BoardPalette.of(context);
 
-    if (match == null) return _buildGone(l10n, palette);
+    if (match == null) return _buildAbsent(l10n, palette);
+
+    // Latched here rather than through setState: this frame is already the
+    // board, so nothing about it changes, and the flag only decides what a
+    // *later* frame says if the match goes away again.
+    _resolved = true;
+    _backstop?.cancel();
 
     return Scaffold(
       backgroundColor: palette.background,
@@ -842,11 +896,82 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
     );
   }
 
+  // ─── No match on screen ─────────────────────────────────────────────────
+
+  /// Which of the three "there is no board here" states this is.
+  ///
+  /// The order is the whole rule. A match that has been here once is never
+  /// described as a link that failed, and a link that has not run out of time
+  /// is never described as a match that is missing — before the feed answers,
+  /// nothing is known either way, and saying otherwise is the failure the
+  /// waiting state exists to prevent.
+  Widget _buildAbsent(AppLocalizations l10n, BoardPalette palette) {
+    if (_resolved || !widget.fromLink) return _buildGone(l10n, palette);
+    return _settled
+        ? _buildUnresolved(l10n, palette)
+        : _buildPending(l10n, palette);
+  }
+
+  /// The link named this match and the feed has not answered yet.
+  ///
+  /// A cold link arrives before any data does: the app sets the watched pubkey,
+  /// subscribes, and events reach it from the relays some unknown time later.
+  /// This is that gap, said out loud, instead of a dead end the recipient would
+  /// read as the link being a lie.
+  Widget _buildPending(AppLocalizations l10n, BoardPalette palette) {
+    return _buildMessage(
+      l10n,
+      palette,
+      // An hourglass, not a spinner. This is the same "waiting on the relays"
+      // the board list already draws that way, and a spinner on a screen that
+      // can be projected onto a wall animates forever in front of a room.
+      icon: Icons.hourglass_empty,
+      title: l10n.scoreboardMatchPendingTitle,
+      body: l10n.scoreboardMatchPendingBody,
+    );
+  }
+
+  /// The feed had its chance and this id is not in it.
+  ///
+  /// The body has to carry the *window*, not just the absence: a match link
+  /// lasts about a day, and a recipient who is not told that reads yesterday's
+  /// link as the app being broken, or blames the sender for something that
+  /// worked when they sent it.
+  ///
+  /// Never becomes the board on its own — the list is one deliberate tap away,
+  /// behind Back, for the same reason a broken link does not quietly hand over
+  /// somebody else's board.
+  Widget _buildUnresolved(AppLocalizations l10n, BoardPalette palette) {
+    return _buildMessage(
+      l10n,
+      palette,
+      icon: Icons.link_off,
+      title: l10n.scoreboardMatchUnresolvedTitle,
+      body: l10n.scoreboardMatchUnresolvedBody,
+    );
+  }
+
   /// The match aged out of the feed, or the relays never had it.
   ///
   /// It can happen while this screen is open: the feed keeps a day, and a board
   /// left running overnight will watch a match disappear out from under it.
   Widget _buildGone(AppLocalizations l10n, BoardPalette palette) {
+    return _buildMessage(
+      l10n,
+      palette,
+      icon: Icons.search_off,
+      title: l10n.scoreboardEmptyTitle,
+    );
+  }
+
+  /// The shape every "no board here" state takes: a glyph, a line, a way out.
+  Widget _buildMessage(
+    AppLocalizations l10n,
+    BoardPalette palette, {
+    required IconData icon,
+    required String title,
+    String? body,
+  }) {
     return Scaffold(
       backgroundColor: palette.background,
       body: Center(
@@ -855,10 +980,10 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(Icons.search_off, size: 44, color: palette.label),
+              Icon(icon, size: 44, color: palette.label),
               const SizedBox(height: 14),
               Text(
-                l10n.scoreboardEmptyTitle,
+                title,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: palette.label,
@@ -866,6 +991,14 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
                   fontWeight: FontWeight.w600,
                 ),
               ),
+              if (body != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  body,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: palette.label, fontSize: 13),
+                ),
+              ],
               const SizedBox(height: 16),
               TextButton(
                 onPressed: () => Navigator.of(context).maybePop(),

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -34,10 +34,73 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   /// edit again, so the error always describes what is in the field now.
   bool _invalid = false;
 
+  /// The request this screen has already pushed a board for.
+  ///
+  /// The consuming half of [requestedMatchProvider]: the provider says what a
+  /// link asked for and keeps saying it for as long as that board is up, and
+  /// this says whether the asking has been acted on. Without it every rebuild —
+  /// a tab change, a new event, a keystroke — would push the same match again.
+  String? _openedRequest;
+
+  @override
+  void initState() {
+    super.initState();
+    // A link the app was *launched* by is read after the first frame, which can
+    // land either side of this listener being registered. Reading the current
+    // value once covers the side that would otherwise be missed; the guard in
+    // [_openRequestedMatch] makes doing it twice harmless.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final requested = ref.read(requestedMatchProvider);
+      if (requested != null) _openRequestedMatch(requested);
+    });
+  }
+
   @override
   void dispose() {
     _controller.dispose();
     super.dispose();
+  }
+
+  /// Put the match a link named on screen.
+  ///
+  /// This lives here, and not in `MainNavigation` or the link handler, because
+  /// this screen is the one that is always alive: it sits in an [IndexedStack]
+  /// that builds every tab and keeps them, so a link arriving while the user is
+  /// on Home still finds a listener — and `openShareLink` has already selected
+  /// this tab by the time the push happens.
+  ///
+  /// The board is pushed rather than swapped in, so Back returns to the list
+  /// the recipient was never shown. It is marked as coming from a link, which
+  /// is the whole difference between waiting for the feed and declaring the
+  /// match gone.
+  void _openRequestedMatch(String matchId) {
+    // Re-opening the link already on screen must do nothing: no flicker, no
+    // reload. That is the group-chat re-share, and pushing a second identical
+    // board would read as the app losing the viewer's place.
+    if (_openedRequest == matchId) return;
+    _openedRequest = matchId;
+
+    Navigator.of(context)
+        .push(MaterialPageRoute(
+      builder: (_) => ScoreboardMatchScreen(matchId: matchId, fromLink: true),
+    ))
+        .then((_) {
+      if (!mounted) return;
+      // Only if this is still the board that came down. A link naming a
+      // *different* match pops this one and pushes the next in the same turn,
+      // and the pop's answer arrives after the push — clearing unconditionally
+      // would forget the board that is now on screen and let a re-share of it
+      // push a duplicate.
+      if (_openedRequest == matchId) _openedRequest = null;
+      // The request outlived the screen that answered it. Dropping it here —
+      // and only if it is still the one this screen opened — lets the same
+      // link, tapped again later, open the match a second time, while a link
+      // that arrived in the meantime keeps its claim.
+      if (ref.read(requestedMatchProvider) == matchId) {
+        ref.read(requestedMatchProvider.notifier).state = null;
+      }
+    });
   }
 
   void _watch() {
@@ -141,6 +204,12 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final tk = ChokeTokens.of(context);
+    // Nothing reads this as state — the board it names is a route, not a
+    // branch of this build — so it is listened to rather than watched.
+    ref.listen<String?>(requestedMatchProvider, (_, requested) {
+      if (requested != null) _openRequestedMatch(requested);
+    });
+
     final brokenLink = ref.watch(brokenShareLinkProvider);
     final watched = ref.watch(watchedPubkeyProvider);
     // Two lists: everything in scope, which the chips count from, and what

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -905,5 +905,21 @@
   "scoreboardQrHint": "Point a phone camera at this code to open the live board",
   "@scoreboardQrHint": {
     "description": "Caption under the QR code of the watched board's link"
+  },
+  "scoreboardMatchPendingTitle": "Looking for that match…",
+  "@scoreboardMatchPendingTitle": {
+    "description": "Title shown after a shared link named one match and before the relays have answered. Never says the match is missing: at this point nothing is known either way, and saying so is the failure the pending state exists to prevent"
+  },
+  "scoreboardMatchPendingBody": "The link named one match on this board. Waiting for it to come through.",
+  "@scoreboardMatchPendingBody": {
+    "description": "Explanation shown with scoreboardMatchPendingTitle while a shared match link is still waiting on the feed"
+  },
+  "scoreboardMatchUnresolvedTitle": "That match isn’t on this board",
+  "@scoreboardMatchUnresolvedTitle": {
+    "description": "Title shown when a shared link named a match and the feed had its chance without producing it"
+  },
+  "scoreboardMatchUnresolvedBody": "It may have ended some time ago — a match link lasts about a day. Ask whoever shared it for a fresh one.",
+  "@scoreboardMatchUnresolvedBody": {
+    "description": "Explanation shown with scoreboardMatchUnresolvedTitle. Must say the match may have ended some time ago and that a link lasts about a day: without that the recipient reads the app as broken, or blames the sender for a link that was fine when it was sent"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -231,5 +231,9 @@
   "scoreboardShareBoard": "Compartir este tablero",
   "scoreboardShareBoardMessage": "Seguí estas luchas de BJJ en vivo en bjjscore.live:",
   "scoreboardQrTitle": "Escaneá para ver en vivo",
-  "scoreboardQrHint": "Apuntá la cámara del teléfono a este código para abrir el tablero en vivo"
+  "scoreboardQrHint": "Apuntá la cámara del teléfono a este código para abrir el tablero en vivo",
+  "scoreboardMatchPendingTitle": "Buscando esa lucha…",
+  "scoreboardMatchPendingBody": "El link nombraba una lucha de este tablero. Esperando a que llegue.",
+  "scoreboardMatchUnresolvedTitle": "Esa lucha no está en este tablero",
+  "scoreboardMatchUnresolvedBody": "Puede que haya terminado hace rato: un link de lucha dura alrededor de un día. Pedile uno nuevo a quien te lo compartió."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -231,5 +231,9 @@
   "scoreboardShareBoard": "このスコアボードを共有",
   "scoreboardShareBoardMessage": "bjjscore.live でこれらの BJJ の試合をライブで観戦:",
   "scoreboardQrTitle": "スキャンしてライブ観戦",
-  "scoreboardQrHint": "スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます"
+  "scoreboardQrHint": "スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます",
+  "scoreboardMatchPendingTitle": "その試合を探しています…",
+  "scoreboardMatchPendingBody": "リンクはこのスコアボードの試合を指しています。届くのを待っています。",
+  "scoreboardMatchUnresolvedTitle": "その試合はこのスコアボードにありません",
+  "scoreboardMatchUnresolvedBody": "しばらく前に終了した可能性があります。試合のリンクは約1日で切れます。共有した人に新しいリンクをもらってください。"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -231,5 +231,9 @@
   "scoreboardShareBoard": "Compartilhar este placar",
   "scoreboardShareBoardMessage": "Acompanhe estas lutas de BJJ ao vivo em bjjscore.live:",
   "scoreboardQrTitle": "Escaneie para ver ao vivo",
-  "scoreboardQrHint": "Aponte a câmera do celular para este código para abrir o placar ao vivo"
+  "scoreboardQrHint": "Aponte a câmera do celular para este código para abrir o placar ao vivo",
+  "scoreboardMatchPendingTitle": "Procurando essa luta…",
+  "scoreboardMatchPendingBody": "O link apontava para uma luta deste placar. Aguardando ela chegar.",
+  "scoreboardMatchUnresolvedTitle": "Essa luta não está neste placar",
+  "scoreboardMatchUnresolvedBody": "Ela pode ter terminado faz um tempo — um link de luta dura cerca de um dia. Peça um novo para quem compartilhou."
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1451,6 +1451,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Point a phone camera at this code to open the live board'**
   String get scoreboardQrHint;
+
+  /// Title shown after a shared link named one match and before the relays have answered. Never says the match is missing: at this point nothing is known either way, and saying so is the failure the pending state exists to prevent
+  ///
+  /// In en, this message translates to:
+  /// **'Looking for that match…'**
+  String get scoreboardMatchPendingTitle;
+
+  /// Explanation shown with scoreboardMatchPendingTitle while a shared match link is still waiting on the feed
+  ///
+  /// In en, this message translates to:
+  /// **'The link named one match on this board. Waiting for it to come through.'**
+  String get scoreboardMatchPendingBody;
+
+  /// Title shown when a shared link named a match and the feed had its chance without producing it
+  ///
+  /// In en, this message translates to:
+  /// **'That match isn’t on this board'**
+  String get scoreboardMatchUnresolvedTitle;
+
+  /// Explanation shown with scoreboardMatchUnresolvedTitle. Must say the match may have ended some time ago and that a link lasts about a day: without that the recipient reads the app as broken, or blames the sender for a link that was fine when it was sent
+  ///
+  /// In en, this message translates to:
+  /// **'It may have ended some time ago — a match link lasts about a day. Ask whoever shared it for a fresh one.'**
+  String get scoreboardMatchUnresolvedBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -726,4 +726,18 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get scoreboardQrHint =>
       'Point a phone camera at this code to open the live board';
+
+  @override
+  String get scoreboardMatchPendingTitle => 'Looking for that match…';
+
+  @override
+  String get scoreboardMatchPendingBody =>
+      'The link named one match on this board. Waiting for it to come through.';
+
+  @override
+  String get scoreboardMatchUnresolvedTitle => 'That match isn’t on this board';
+
+  @override
+  String get scoreboardMatchUnresolvedBody =>
+      'It may have ended some time ago — a match link lasts about a day. Ask whoever shared it for a fresh one.';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -731,4 +731,19 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get scoreboardQrHint =>
       'Apuntá la cámara del teléfono a este código para abrir el tablero en vivo';
+
+  @override
+  String get scoreboardMatchPendingTitle => 'Buscando esa lucha…';
+
+  @override
+  String get scoreboardMatchPendingBody =>
+      'El link nombraba una lucha de este tablero. Esperando a que llegue.';
+
+  @override
+  String get scoreboardMatchUnresolvedTitle =>
+      'Esa lucha no está en este tablero';
+
+  @override
+  String get scoreboardMatchUnresolvedBody =>
+      'Puede que haya terminado hace rato: un link de lucha dura alrededor de un día. Pedile uno nuevo a quien te lo compartió.';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -700,4 +700,17 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get scoreboardQrHint => 'スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます';
+
+  @override
+  String get scoreboardMatchPendingTitle => 'その試合を探しています…';
+
+  @override
+  String get scoreboardMatchPendingBody => 'リンクはこのスコアボードの試合を指しています。届くのを待っています。';
+
+  @override
+  String get scoreboardMatchUnresolvedTitle => 'その試合はこのスコアボードにありません';
+
+  @override
+  String get scoreboardMatchUnresolvedBody =>
+      'しばらく前に終了した可能性があります。試合のリンクは約1日で切れます。共有した人に新しいリンクをもらってください。';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -731,4 +731,19 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get scoreboardQrHint =>
       'Aponte a câmera do celular para este código para abrir o placar ao vivo';
+
+  @override
+  String get scoreboardMatchPendingTitle => 'Procurando essa luta…';
+
+  @override
+  String get scoreboardMatchPendingBody =>
+      'O link apontava para uma luta deste placar. Aguardando ela chegar.';
+
+  @override
+  String get scoreboardMatchUnresolvedTitle =>
+      'Essa luta não está neste placar';
+
+  @override
+  String get scoreboardMatchUnresolvedBody =>
+      'Ela pode ter terminado faz um tempo — um link de luta dura cerca de um dia. Peça um novo para quem compartilhou.';
 }

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -177,6 +177,28 @@ final brokenShareLinkProvider = StateProvider<bool>((ref) => false);
 /// request left by the one before it.
 final requestedMatchProvider = StateProvider<String?>((ref) => null);
 
+/// How long a match link waits before it admits the match is not there.
+///
+/// **There is no settled signal, and this is the whole of the answer.** NIP-01
+/// ends a stored-events replay with `EOSE`, which is what "the feed has
+/// answered" should mean — but `NostrRelayBackend` exposes only
+/// `Stream<NostrEvent> get events`, with nothing to say a subscription has sent
+/// everything it holds. Plumbing one through the backend, and probably through
+/// the Rust layer under it, is deliberate follow-up rather than an oversight:
+/// the spec (`docs/specs/shared-match-links.md` §3.1) permits leaning on this
+/// backstop alone provided the code says so out loud. This is it saying so.
+///
+/// Long enough for a slow relay on venue wifi, short enough that nobody
+/// concludes the app has hung. Waiting is not terminal either way — an event
+/// that arrives after this still wins, because the link was right and the
+/// network was slow.
+///
+/// > **Cross-repo note.** The spec's §3.1 rule 2 currently writes this number
+/// > as 8 seconds and requires both readers to use the same one. This ships as
+/// > 10 on explicit instruction; choke-scoreboard and the spec text need the
+/// > same value before a link can be trusted to resolve identically in both.
+const Duration kMatchLinkBackstop = Duration(seconds: 10);
+
 /// Open a shared board link.
 ///
 /// Returns whether the link was one this app answers for — true both for a

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -193,10 +193,13 @@ final requestedMatchProvider = StateProvider<String?>((ref) => null);
 /// that arrives after this still wins, because the link was right and the
 /// network was slow.
 ///
-/// > **Cross-repo note.** The spec's §3.1 rule 2 currently writes this number
-/// > as 8 seconds and requires both readers to use the same one. This ships as
-/// > 10 on explicit instruction; choke-scoreboard and the spec text need the
-/// > same value before a link can be trusted to resolve identically in both.
+/// > **Cross-repo note.** Ten is the number both readers use, and the spec's
+/// > §3.1 rule 2 says so: choke-scoreboard already waits exactly this long
+/// > before giving up on EOSE, and a second timeout a couple of seconds away
+/// > from it would leave two magic numbers where there was one. Changing it
+/// > here means changing it there and in the spec in the same breath — a link
+/// > that resolves in one reader and not the other is what §4 exists to
+/// > prevent.
 const Duration kMatchLinkBackstop = Duration(seconds: 10);
 
 /// Open a shared board link.

--- a/test/features/scoreboard/scoreboard_match_link_test.dart
+++ b/test/features/scoreboard/scoreboard_match_link_test.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/features/scoreboard/scoreboard_match_screen.dart';
+import 'package:choke/features/scoreboard/scoreboard_screen.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/deep_links/share_link.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+import 'package:choke/services/wakelock/screen_wakelock.dart';
+import 'package:choke/shared/providers/navigation_provider.dart';
+import 'package:choke/shared/theme/app_theme.dart';
+
+import '../../support/nostr_fakes.dart';
+
+/// The relays are not part of what these tests are about; the feed just needs
+/// something that answers.
+class _OfflineNostrService extends NostrService {
+  _OfflineNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  final controller = StreamController<NostrEvent>.broadcast();
+
+  @override
+  Stream<NostrEvent> get eventStream => controller.stream;
+
+  @override
+  void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {}
+
+  @override
+  void unsubscribe(String subscriptionId) {}
+
+  @override
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) => const [];
+}
+
+/// What `FakeNostrCrypto` decodes `npub1fake` to.
+const _watched =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+const _matchId = 'abcd';
+
+/// The link a recipient taps, naming one match on the watched board.
+final _link = Uri.parse(
+  'https://$kShareLinkHost/?npub=npub1fake&$kShareMatchParam=$_matchId',
+);
+
+/// What the feed is holding right now.
+///
+/// A [StateProvider] rather than a fixed override, because half of these tests
+/// are about the moment an event *arrives* — the whole point of Pending is that
+/// the answer comes later than the question.
+final _feed = StateProvider<List<Match>>((ref) => const []);
+
+Match _match() {
+  return Match(
+    id: _matchId,
+    status: MatchStatus.inProgress,
+    startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    duration: 300,
+    f1Name: 'Buchecha',
+    f2Name: 'Roger Gracie',
+    f1Color: '#1BA34E',
+    f2Color: '#F5B800',
+  );
+}
+
+/// The scoreboard, wired the way the app wires it: one navigator, reachable
+/// through [navigatorKeyProvider], so `openShareLink` can clear the stack.
+Widget _wrap(void Function(WidgetRef) captureRef) {
+  return ProviderScope(
+    overrides: [
+      nostrCryptoProvider.overrideWithValue(FakeNostrCrypto()),
+      nostrServiceProvider.overrideWithValue(_OfflineNostrService()),
+      // The real one talks to a method channel nothing answers in a test, and
+      // its timeout would outlive the test as a pending timer.
+      screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+      scoreboardMatchesProvider.overrideWith((ref) => ref.watch(_feed)),
+    ],
+    child: Consumer(
+      builder: (context, ref, _) {
+        captureRef(ref);
+        return MaterialApp(
+          navigatorKey: ref.watch(navigatorKeyProvider),
+          theme: AppTheme.darkTheme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ScoreboardScreen(),
+        );
+      },
+    ),
+  );
+}
+
+void main() {
+  late WidgetRef ref;
+  late AppLocalizations l10n;
+
+  setUp(() async {
+    // Already watching the organizer the link names, which is the ordinary
+    // case: the interesting waiting is on the match, not on the board.
+    SharedPreferences.setMockInitialValues(
+      {'choke:scoreboard-pubkey': _watched},
+    );
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  /// The board on screen, landscape, with the saved pubkey restored.
+  Future<void> pumpApp(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1600, 740);
+    tester.view.devicePixelRatio = 2.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_wrap((r) => ref = r));
+    await tester.pump(); // the saved pubkey is restored asynchronously
+    await tester.pump();
+  }
+
+  /// Long enough for a pushed route's transition to finish, and no longer.
+  ///
+  /// Not `pumpAndSettle`: the board's status dot blinks for as long as a match
+  /// is running, so a settled frame never comes.
+  Future<void> settleRoute(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  Future<void> openLink(WidgetTester tester) async {
+    openShareLink(_link, ref.read(nostrCryptoProvider), ref);
+    await settleRoute(tester);
+  }
+
+  group('a link that names one match', () {
+    testWidgets('waits, rather than saying the match is not there',
+        (tester) async {
+      // Arrange — a cold link: the feed has answered nothing yet
+      await pumpApp(tester);
+
+      // Act
+      await openLink(tester);
+
+      // Assert — the promise of the link is still open, and says so
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchPendingBody), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchUnresolvedTitle), findsNothing);
+    });
+
+    testWidgets('shows the board the moment the match arrives', (tester) async {
+      // Arrange
+      await pumpApp(tester);
+      await openLink(tester);
+
+      // Act — the relay answers
+      ref.read(_feed.notifier).state = [_match()];
+      await tester.pump();
+
+      // Assert
+      expect(find.text('BUCHECHA'), findsOneWidget);
+      expect(find.text('ROGER GRACIE'), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsNothing);
+    });
+
+    testWidgets('says the match may have ended once the backstop expires',
+        (tester) async {
+      // Arrange
+      await pumpApp(tester);
+      await openLink(tester);
+
+      // Act — the feed never answers
+      await tester.pump(kMatchLinkBackstop + const Duration(seconds: 1));
+
+      // Assert — and the copy carries why, not merely that
+      expect(find.text(l10n.scoreboardMatchUnresolvedTitle), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchUnresolvedBody), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsNothing);
+    });
+
+    testWidgets('is still pending one tick before the backstop',
+        (tester) async {
+      // Arrange
+      await pumpApp(tester);
+      await openLink(tester);
+
+      // Act — a slow relay on venue wifi has not run out of time yet
+      await tester.pump(kMatchLinkBackstop - const Duration(seconds: 1));
+
+      // Assert
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchUnresolvedTitle), findsNothing);
+    });
+
+    testWidgets('lets a late arrival win, after Unresolved', (tester) async {
+      // Arrange — the backstop has already run out
+      await pumpApp(tester);
+      await openLink(tester);
+      await tester.pump(kMatchLinkBackstop + const Duration(seconds: 1));
+      expect(find.text(l10n.scoreboardMatchUnresolvedTitle), findsOneWidget);
+
+      // Act — the link was right and the network was slow
+      ref.read(_feed.notifier).state = [_match()];
+      await tester.pump();
+
+      // Assert
+      expect(find.text('BUCHECHA'), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchUnresolvedTitle), findsNothing);
+    });
+
+    testWidgets('does nothing at all when the same link arrives again',
+        (tester) async {
+      // Arrange — the match is open, from the link, and resolved
+      await pumpApp(tester);
+      ref.read(_feed.notifier).state = [_match()];
+      await openLink(tester);
+      expect(find.text('BUCHECHA'), findsOneWidget);
+
+      // Act — a re-share in the group chat
+      await openLink(tester);
+
+      // Assert — one board, not a second pushed on top of the first. A
+      // MaterialPageRoute keeps the route under it in the tree, so a double
+      // push would show up as two of everything.
+      expect(find.byType(ScoreboardMatchScreen), findsOneWidget);
+      expect(find.text('BUCHECHA'), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsNothing);
+    });
+
+    testWidgets('opens a different match on the board already watched',
+        (tester) async {
+      // Arrange — one match from the link, resolved
+      await pumpApp(tester);
+      ref.read(_feed.notifier).state = [_match()];
+      await openLink(tester);
+
+      // Act — a second link, same organizer, different fight
+      openShareLink(
+        Uri.parse(
+          'https://$kShareLinkHost/?npub=npub1fake&$kShareMatchParam=beef',
+        ),
+        ref.read(nostrCryptoProvider),
+        ref,
+      );
+      // Two: one for the board coming down, one for the next going up.
+      await settleRoute(tester);
+      await settleRoute(tester);
+
+      // Assert — the board came down and the new request is waiting on the
+      // feed, where a board link would have had nothing to do at all
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsOneWidget);
+      expect(find.text('BUCHECHA'), findsNothing);
+    });
+  });
+
+  group('a match opened from the list', () {
+    testWidgets('never waits', (tester) async {
+      // Arrange — the card is on screen, so the match is already in hand
+      await pumpApp(tester);
+      ref.read(_feed.notifier).state = [_match()];
+      await tester.pump();
+
+      // Act
+      await tester.tap(find.text('Buchecha'));
+      await settleRoute(tester);
+
+      // Assert — straight to the board, with no waiting state anywhere
+      expect(find.text('ROGER GRACIE'), findsOneWidget);
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsNothing);
+      expect(find.text(l10n.scoreboardMatchUnresolvedTitle), findsNothing);
+    });
+
+    testWidgets('keeps the old dead end when the match ages out under it',
+        (tester) async {
+      // Arrange — a board left running until the match drops out of the feed
+      await pumpApp(tester);
+      ref.read(_feed.notifier).state = [_match()];
+      await tester.pump();
+      await tester.tap(find.text('Buchecha'));
+      await settleRoute(tester);
+
+      // Act
+      ref.read(_feed.notifier).state = const [];
+      await tester.pump();
+
+      // Assert — this path never learned to wait, and must not start now
+      expect(find.text(l10n.scoreboardEmptyTitle), findsWidgets);
+      expect(find.text(l10n.scoreboardMatchPendingTitle), findsNothing);
+    });
+  });
+
+  group('the shared 24-hour window', () {
+    test('is 86400 seconds, the same number choke-scoreboard asserts', () {
+      // The conformance obligation of the spec's §4: two languages and two
+      // build systems make one shared constant impractical, so each repository
+      // pins its own and a silent drift fails a build instead of splitting the
+      // contract in half — a link that resolves in one reader and not the
+      // other.
+      expect(scoreboardMaxAgeSeconds, 86400);
+    });
+  });
+}

--- a/test/features/scoreboard/scoreboard_match_link_test.dart
+++ b/test/features/scoreboard/scoreboard_match_link_test.dart
@@ -26,10 +26,11 @@ class _OfflineNostrService extends NostrService {
       : super(KeyManager(crypto: FakeNostrCrypto()),
             crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
 
-  final controller = StreamController<NostrEvent>.broadcast();
-
+  /// Empty, not a controller nobody writes to: events reach these tests
+  /// through the [_feed] override, and a live controller here would only be
+  /// one more thing left open at the end of every test.
   @override
-  Stream<NostrEvent> get eventStream => controller.stream;
+  Stream<NostrEvent> get eventStream => const Stream.empty();
 
   @override
   void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {}


### PR DESCRIPTION
Step 3 of `docs/specs/shared-match-links.md` §9.3. Stacked on #154 (`feat/match-share-links`) — review that first.

## The problem

`ScoreboardMatchScreen` looks its match up by id in `scoreboardMatchesProvider` on every build and renders the &#34;no longer available&#34; dead end when it is absent. A cold deep link arrives *before* any data does — the app sets the watched pubkey, subscribes, and events reach it from the relays some unknown time later — so pushing that screen the instant a link opened showed the recipient **&#34;this match is not available&#34; as the first thing they saw, on the happy path**. That is the exact failure §3.1 exists to prevent.

## The three states (§3.1)

| State | When | Shown |
|---|---|---|
| **Pending** | named, feed has not answered | hourglass, &#34;Looking for that match…&#34; |
| **Resolved** | the event arrived | the existing read-only board, unchanged |
| **Unresolved** | backstop expired, id absent | says the match may have ended some time ago, and that a match link lasts about a day |

Ordering rule, in `_buildAbsent`: a match that has ever been on screen is never described as a link that failed (it gets the old dead end, which for an aged-out board is the truth), and a link that has not run out of time is never described as a match that is missing.

### When Pending ends

1. **Settled signal: there isn&#39;t one.** `NostrRelayBackend` exposes only `Stream get events` — no EOSE. The spec permits leaning on the backstop alone *provided the code says so*; `kMatchLinkBackstop`&#39;s doc comment says so at length, and records that plumbing EOSE through the backend (and the Rust layer under it) is deliberate follow-up. No Rust change here.
2. **Backstop:** a named `Duration` constant, not a literal — **10 seconds**, the value both readers share. See below.
3. **A late arrival still wins.** An event that turns up after Unresolved resolves to the board. Unresolved is what is known so far, not a verdict. Covered by a test.
4. **Unresolved never becomes the board on its own** — Back is the only way out, same as the broken-link state.

## Backstop: 10 seconds, settled and verified

When this PR was opened, the spec&#39;s §3.1 rule 2 said **8 seconds** while this shipped **10**, and the divergence was flagged here as needing a decision before merge. That decision has since landed on `main`: 06cab4b (via #156) corrected the spec to **10**, because choke-scoreboard already waits exactly that long before giving up on EOSE — a second timeout two seconds away from an existing one buys nothing and leaves two magic numbers where there was one.

7eece2e rewrites the `&gt; Cross-repo note` on the constant, which was the last thing still describing the disagreement as open; it now records the agreed value and what changing it would cost.

**All three readers verified to hold the same number**: `kMatchLinkBackstop = Duration(seconds: 10)` here, §3.1 rule 2 in the spec, and `MATCH_LINK_BACKSTOP_MS = 10_000` in choke-scoreboard&#39;s `src/lib/constants.ts`, used for its EOSE fallback timer (confirmed by CodeRabbit fetching that repo, since this one cannot check across the boundary itself). Nothing about the backstop blocks the merge.

## Where the navigation lives, and why

In `_ScoreboardScreenState`, not `MainNavigation` and not the link handler. `ScoreboardScreen` is the one screen that is always alive: `MainNavigation`&#39;s `IndexedStack` builds every tab and keeps it, so a link arriving while the user is on Home still finds a listener, and `openShareLink` has already selected the scoreboard tab by the time the push happens. A `ref.listen` on `requestedMatchProvider`, plus a post-frame read in `initState` (the launch link is read after the first frame, which can land either side of the listener registering).

**Consuming the request** is done by the screen (`_openedRequest`), not by nulling the provider. Nulling it would break §6.1&#39;s stack-clearing condition, which compares against `requestedMatchProvider`, and a re-share would then re-push. Instead the provider keeps naming the match for as long as its board is up, and the pushed route&#39;s completion drops both — so a re-share of the link already on screen does nothing (§7: no flicker, no reload), while the same link tapped again after backing out opens it a second time. The pop&#39;s completion only clears if it is still *its own* request, because a link naming a different match pops and pushes in the same turn and the pop answers last.

## Link path vs tap path

`ScoreboardMatchScreen.fromLink` (default `false`). Only the link path arms a backstop or renders Pending; a tap comes from a list already holding the match, so an absent match there means it went away and the dead end is correct. Home and the list are untouched.

## Author scoping — documented, not duplicated

`ScoreboardFeedNotifier._onEvent` drops any event whose `pubkey` differs from the watched one, and the feed provider is rebuilt when that pubkey changes, so `scoreboardMatchesProvider` holds the watched author&#39;s matches by construction — which is what makes an id-only lookup the `(organizer, matchId)` pair §2.1 requires. A comment at that filter now records that it is load-bearing for the link contract, and a matching note sits on `ScoreboardMatchScreen.matchId`. No second check added.

## Also here

`scoreboardMaxAgeSeconds == 86400`, asserted — the §4 conformance obligation choke-scoreboard already holds up its half of.

## Strings

Four new keys × four locales (`en` with `@` descriptions, `es`/`pt`/`ja` values). Spanish uses voseo to match its neighbours (&#34;Pedile uno nuevo a quien te lo compartió&#34;). The Unresolved body carries the 24-hour window in every locale — a recipient not told that blames the sender or thinks the app is broken. `goBack` and `scoreboardEmptyTitle` are reused rather than duplicated.

## Test plan

New focused file `test/features/scoreboard/scoreboard_match_link_test.dart` (10 tests), harness shaped after `scoreboard_board_credit_test.dart`, driving the feed through a `StateProvider` so events can arrive mid-test.

- [x] Pending while the feed is silent, and no Unresolved copy anywhere
- [x] The match arriving resolves it
- [x] Still Pending one second before the backstop
- [x] The backstop expiring yields Unresolved, body included
- [x] A late arrival after Unresolved still resolves
- [x] The same link again does nothing (asserts a single `ScoreboardMatchScreen`)
- [x] A different match on the same board does navigate (§6.1)
- [x] A tap from the list never shows Pending
- [x] A tap-opened match that ages out keeps the old dead end
- [x] `scoreboardMaxAgeSeconds == 86400`

No pending timers at test end (`_backstop` cancelled in `dispose`). `pumpAndSettle` is avoided on the board — the status dot blinks for as long as a match is running, so a settled frame never comes. The fixture&#39;s `eventStream` is an empty stream: events reach these tests through the `_feed` override, and 7eece2e drops the `StreamController` nothing wrote to and nothing closed.

`flutter pub get &amp;&amp; dart format . &amp;&amp; flutter analyze &amp;&amp; flutter test`: **690/690 pass** (including the `rust`-tagged suites, with the crate built), analyze clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUo75zQ6ozahYQEf1emtzq



## Summary by CodeRabbit

* **New Features**
  * Added support for opening scoreboard matches directly from shared links.
  * Shared links now show a pending state while the match loads, followed by clear guidance if the match cannot be found or has expired.
  * Duplicate link requests are handled without opening multiple screens.
* **Localization**
  * Added translated match-link status and guidance messages in English, Spanish, Japanese, and Portuguese.
* **Bug Fixes**
  * Improved match-link behavior when matches arrive late or disappear after being opened.
