### PR TITLE
feat: the share affordances that produce a match link

### DIFF
--- a/lib/features/account/account_screen.dart
+++ b/lib/features/account/account_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
-import 'package:share_plus/share_plus.dart';
 
 import '../../services/deep_links/share_link.dart';
 import '../../services/nostr/nostr_service.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
+import '../../shared/share_sheet.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/qr_dialog.dart';
 import '../../services/key_management/key_manager.dart';
@@ -60,34 +60,13 @@ class _AccountScreenState extends ConsumerState<AccountScreen> {
   /// a spectator only has to tap it — no key to copy or paste on the web.
   Future<void> _shareLiveBoard(String npub) async {
     final l10n = AppLocalizations.of(context);
-    final url = liveBoardShareUrl(npub);
-
-    // iPad requires a non-null origin to anchor the share popover; the screen's
-    // render box is a safe fallback on phones.
-    final box = context.findRenderObject() as RenderBox?;
-    final origin =
-        box != null ? box.localToGlobal(Offset.zero) & box.size : null;
-
-    try {
-      await Share.share(
-        '${l10n.shareLiveBoardMessage}\n$url',
-        subject: l10n.shareLiveBoard,
-        sharePositionOrigin: origin,
-      );
-    } on PlatformException catch (e) {
-      // The platform share sheet can fail to open (no handler registered, a
-      // transient platform error). Surface it instead of letting the failure
-      // escape this tap callback as an unhandled async error. Only the code is
-      // logged — never the message, which could echo shared content back out.
-      debugPrint('AccountScreen: share sheet failed (${e.code})');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(l10n.shareFailed),
-          backgroundColor: Theme.of(context).colorScheme.error,
-        ),
-      );
-    }
+    await shareLink(
+      context,
+      message: l10n.shareLiveBoardMessage,
+      url: liveBoardShareUrl(npub),
+      subject: l10n.shareLiveBoard,
+      logTag: 'AccountScreen',
+    );
   }
 
   Future<void> _showImportDialog() async {

--- a/lib/features/scoreboard/scoreboard_match_screen.dart
+++ b/lib/features/scoreboard/scoreboard_match_screen.dart
@@ -7,9 +7,7 @@ import 'package:choke/l10n/generated/app_localizations.dart';
 
 import 'board_palette.dart';
 import '../../services/deep_links/share_link.dart';
-import '../../services/nostr/crypto/nostr_crypto.dart';
 import '../../services/wakelock/screen_wakelock.dart';
-import '../../shared/share_sheet.dart';
 import '../../shared/wall_clock.dart';
 import '../../shared/widgets/match_card.dart';
 import '../match/models/match.dart';
@@ -927,7 +925,7 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
       right: 8,
       child: SafeArea(
         child: IconButton(
-          onPressed: () => _share(l10n, watched),
+          onPressed: () => _share(watched),
           tooltip: l10n.scoreboardShareMatch,
           color: palette.backLabel,
           icon: const Icon(Icons.ios_share, size: 18),
@@ -936,13 +934,12 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
     );
   }
 
-  Future<void> _share(AppLocalizations l10n, String watchedHex) async {
-    final npub = ref.read(nostrCryptoProvider).npubEncode(watchedHex);
-    await shareLink(
+  Future<void> _share(String watchedHex) async {
+    await shareMatchLink(
       context,
-      message: l10n.scoreboardShareMatchMessage,
-      url: matchShareUrl(npub, widget.matchId),
-      subject: l10n.scoreboardShareMatch,
+      ref,
+      watchedHex: watchedHex,
+      matchId: widget.matchId,
       logTag: 'ScoreboardMatchScreen',
     );
   }

--- a/lib/features/scoreboard/scoreboard_match_screen.dart
+++ b/lib/features/scoreboard/scoreboard_match_screen.dart
@@ -7,7 +7,9 @@ import 'package:choke/l10n/generated/app_localizations.dart';
 
 import 'board_palette.dart';
 import '../../services/deep_links/share_link.dart';
+import '../../services/nostr/crypto/nostr_crypto.dart';
 import '../../services/wakelock/screen_wakelock.dart';
+import '../../shared/share_sheet.dart';
 import '../../shared/wall_clock.dart';
 import '../../shared/widgets/match_card.dart';
 import '../match/models/match.dart';
@@ -211,6 +213,7 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
               _buildCenter(context, l10n, match, unit),
               _buildWinnerBanner(context, l10n, match, unit),
               _buildBack(l10n, palette),
+              _buildShare(l10n, palette),
             ],
           );
         },
@@ -893,6 +896,54 @@ class _ScoreboardMatchScreenState extends ConsumerState<ScoreboardMatchScreen> {
           ),
         ),
       ),
+    );
+  }
+
+  /// Send this fight to somebody, from the screen that is watching it.
+  ///
+  /// Mirrors [_buildBack] exactly — same offsets, same [SafeArea], same
+  /// [BoardPalette.backLabel] — at the opposite corner, so the two chrome items
+  /// read as a pair rather than as one control and one decoration.
+  ///
+  /// Icon only, where Back carries a word. Leaving is a decision and wants
+  /// naming; sharing is one glyph everybody already knows, and a board that
+  /// gets projected onto a wall has no room to spend on saying so twice.
+  ///
+  /// One tap straight to the platform share sheet, with no chooser in front of
+  /// it: this is the "look at this" reflex, and a menu costs more than it
+  /// offers. No QR either — when this screen *is* the projection, the audience
+  /// is already reading the bjjscore.live credit along the bottom of it, and a
+  /// code here would do that job again on the surface least able to afford the
+  /// clutter.
+  ///
+  /// Absent with nobody watched, because there is then no npub to name the
+  /// organizer, and a match id on its own names nothing.
+  Widget _buildShare(AppLocalizations l10n, BoardPalette palette) {
+    final watched = ref.watch(watchedPubkeyProvider);
+    if (watched == null) return const SizedBox.shrink();
+
+    return Positioned(
+      top: 8,
+      right: 8,
+      child: SafeArea(
+        child: IconButton(
+          onPressed: () => _share(l10n, watched),
+          tooltip: l10n.scoreboardShareMatch,
+          color: palette.backLabel,
+          icon: const Icon(Icons.ios_share, size: 18),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _share(AppLocalizations l10n, String watchedHex) async {
+    final npub = ref.read(nostrCryptoProvider).npubEncode(watchedHex);
+    await shareLink(
+      context,
+      message: l10n.scoreboardShareMatchMessage,
+      url: matchShareUrl(npub, widget.matchId),
+      subject: l10n.scoreboardShareMatch,
+      logTag: 'ScoreboardMatchScreen',
     );
   }
 

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:share_plus/share_plus.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 
 import '../../services/deep_links/share_link.dart';
 import '../../services/nostr/crypto/nostr_crypto.dart';
+import '../../shared/share_sheet.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
 import '../../shared/widgets/qr_dialog.dart';
@@ -146,34 +146,33 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   /// of them: the app opens it if they have it, the web board if they do not.
   Future<void> _shareBoard(String watchedHex) async {
     final l10n = AppLocalizations.of(context);
-    final url = _boardUrl(watchedHex);
+    await shareLink(
+      context,
+      message: l10n.scoreboardShareBoardMessage,
+      url: _boardUrl(watchedHex),
+      subject: l10n.scoreboardShareBoard,
+      logTag: 'ScoreboardScreen',
+    );
+  }
 
-    // iPad requires a non-null origin to anchor the share popover; the screen's
-    // render box is a safe fallback on phones.
-    final box = context.findRenderObject() as RenderBox?;
-    final origin =
-        box != null ? box.localToGlobal(Offset.zero) & box.size : null;
-
-    try {
-      await Share.share(
-        '${l10n.scoreboardShareBoardMessage}\n$url',
-        subject: l10n.scoreboardShareBoard,
-        sharePositionOrigin: origin,
-      );
-    } on PlatformException catch (e) {
-      // The platform share sheet can fail to open (no handler registered, a
-      // transient platform error). Surface it instead of letting the failure
-      // escape this tap callback as an unhandled async error. Only the code is
-      // logged — never the message, which could echo shared content back out.
-      debugPrint('ScoreboardScreen: share sheet failed (${e.code})');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(l10n.shareFailed),
-          backgroundColor: Theme.of(context).colorScheme.error,
-        ),
-      );
-    }
+  /// Hand one fight to somebody else, without opening it first.
+  ///
+  /// The unit people actually share. A board link says "follow this academy"
+  /// and leaves the recipient hunting a list that reorders itself as matches
+  /// start and finish; this one says "watch this fight" and lands on it.
+  ///
+  /// The npub travels with the id because an id names nothing on its own — four
+  /// hex characters are unique only inside one organizer's events.
+  Future<void> _shareMatch(Match match, String watchedHex) async {
+    final l10n = AppLocalizations.of(context);
+    final npub = ref.read(nostrCryptoProvider).npubEncode(watchedHex);
+    await shareLink(
+      context,
+      message: l10n.scoreboardShareMatchMessage,
+      url: matchShareUrl(npub, match.id),
+      subject: l10n.scoreboardShareMatch,
+      logTag: 'ScoreboardScreen',
+    );
   }
 
   /// The same link as a code, for a room rather than a chat.
@@ -321,7 +320,7 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
                 (true, _, _) => _buildBrokenLink(l10n, tk),
                 (_, null, _) => _buildWelcome(l10n, tk),
                 (_, _, true) => _buildEmpty(l10n, tk),
-                _ => _buildList(matches),
+                _ => _buildList(matches, watched),
               },
             ),
           ],
@@ -396,7 +395,15 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
     );
   }
 
-  Widget _buildList(List<Match> matches) {
+  /// The board, one card per match.
+  ///
+  /// [watchedHex] is what makes a card shareable: the link a card hands out
+  /// names the organizer as well as the match, so with nobody watched there is
+  /// no link to give and the icon does not appear. In practice this list is
+  /// only reached with a board watched — the argument is threaded rather than
+  /// asserted because the alternative is a `!` on something the type system
+  /// cannot see is settled.
+  Widget _buildList(List<Match> matches, String? watchedHex) {
     return ListView.builder(
       padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
       itemCount: matches.length,
@@ -404,7 +411,13 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
         final match = matches[index];
         return Padding(
           padding: const EdgeInsets.only(bottom: 11),
-          child: MatchCard(match: match, onTap: () => _open(match)),
+          child: MatchCard(
+            match: match,
+            onTap: () => _open(match),
+            onShare: watchedHex == null
+                ? null
+                : () => _shareMatch(match, watchedHex),
+          ),
         );
       },
     );

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -164,13 +164,11 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   /// The npub travels with the id because an id names nothing on its own — four
   /// hex characters are unique only inside one organizer's events.
   Future<void> _shareMatch(Match match, String watchedHex) async {
-    final l10n = AppLocalizations.of(context);
-    final npub = ref.read(nostrCryptoProvider).npubEncode(watchedHex);
-    await shareLink(
+    await shareMatchLink(
       context,
-      message: l10n.scoreboardShareMatchMessage,
-      url: matchShareUrl(npub, match.id),
-      subject: l10n.scoreboardShareMatch,
+      ref,
+      watchedHex: watchedHex,
+      matchId: match.id,
       logTag: 'ScoreboardScreen',
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -898,6 +898,14 @@
   "@scoreboardShareBoardMessage": {
     "description": "Message shown before the shared bjjscore.live link when sharing a watched board"
   },
+  "scoreboardShareMatch": "Share this match",
+  "@scoreboardShareMatch": {
+    "description": "Tooltip and share-sheet subject for sharing a link to one particular match. Never a bare 'Share': it sits beside scoreboardShareBoard, and a user who cannot tell the two apart sends a whole board when they meant to send one fight"
+  },
+  "scoreboardShareMatchMessage": "Watch this BJJ match live on bjjscore.live:",
+  "@scoreboardShareMatchMessage": {
+    "description": "Message shown before the shared bjjscore.live link when sharing one match. Singular and about watching, where the board's message is plural and about following, so the two read differently in a chat even without the link"
+  },
   "scoreboardQrTitle": "Scan to watch live",
   "@scoreboardQrTitle": {
     "description": "Title of the dialog holding a QR code of the watched board's link"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -230,6 +230,8 @@
   "scoreboardBrokenLinkDismiss": "Ver mi tablero",
   "scoreboardShareBoard": "Compartir este tablero",
   "scoreboardShareBoardMessage": "Seguí estas luchas de BJJ en vivo en bjjscore.live:",
+  "scoreboardShareMatch": "Compartir esta lucha",
+  "scoreboardShareMatchMessage": "Mirá esta lucha de BJJ en vivo en bjjscore.live:",
   "scoreboardQrTitle": "Escaneá para ver en vivo",
   "scoreboardQrHint": "Apuntá la cámara del teléfono a este código para abrir el tablero en vivo",
   "scoreboardMatchPendingTitle": "Buscando esa lucha…",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -230,6 +230,8 @@
   "scoreboardBrokenLinkDismiss": "自分のスコアボードを見る",
   "scoreboardShareBoard": "このスコアボードを共有",
   "scoreboardShareBoardMessage": "bjjscore.live でこれらの BJJ の試合をライブで観戦:",
+  "scoreboardShareMatch": "この試合を共有",
+  "scoreboardShareMatchMessage": "bjjscore.live でこの BJJ の試合をライブで観戦:",
   "scoreboardQrTitle": "スキャンしてライブ観戦",
   "scoreboardQrHint": "スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます",
   "scoreboardMatchPendingTitle": "その試合を探しています…",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -230,6 +230,8 @@
   "scoreboardBrokenLinkDismiss": "Ver meu placar",
   "scoreboardShareBoard": "Compartilhar este placar",
   "scoreboardShareBoardMessage": "Acompanhe estas lutas de BJJ ao vivo em bjjscore.live:",
+  "scoreboardShareMatch": "Compartilhar esta luta",
+  "scoreboardShareMatchMessage": "Assista a esta luta de BJJ ao vivo em bjjscore.live:",
   "scoreboardQrTitle": "Escaneie para ver ao vivo",
   "scoreboardQrHint": "Aponte a câmera do celular para este código para abrir o placar ao vivo",
   "scoreboardMatchPendingTitle": "Procurando essa luta…",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1440,6 +1440,18 @@ abstract class AppLocalizations {
   /// **'Follow these BJJ matches live on bjjscore.live:'**
   String get scoreboardShareBoardMessage;
 
+  /// Tooltip and share-sheet subject for sharing a link to one particular match. Never a bare 'Share': it sits beside scoreboardShareBoard, and a user who cannot tell the two apart sends a whole board when they meant to send one fight
+  ///
+  /// In en, this message translates to:
+  /// **'Share this match'**
+  String get scoreboardShareMatch;
+
+  /// Message shown before the shared bjjscore.live link when sharing one match. Singular and about watching, where the board's message is plural and about following, so the two read differently in a chat even without the link
+  ///
+  /// In en, this message translates to:
+  /// **'Watch this BJJ match live on bjjscore.live:'**
+  String get scoreboardShareMatchMessage;
+
   /// Title of the dialog holding a QR code of the watched board's link
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -721,6 +721,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Follow these BJJ matches live on bjjscore.live:';
 
   @override
+  String get scoreboardShareMatch => 'Share this match';
+
+  @override
+  String get scoreboardShareMatchMessage =>
+      'Watch this BJJ match live on bjjscore.live:';
+
+  @override
   String get scoreboardQrTitle => 'Scan to watch live';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -726,6 +726,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Seguí estas luchas de BJJ en vivo en bjjscore.live:';
 
   @override
+  String get scoreboardShareMatch => 'Compartir esta lucha';
+
+  @override
+  String get scoreboardShareMatchMessage =>
+      'Mirá esta lucha de BJJ en vivo en bjjscore.live:';
+
+  @override
   String get scoreboardQrTitle => 'Escaneá para ver en vivo';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -696,6 +696,12 @@ class AppLocalizationsJa extends AppLocalizations {
       'bjjscore.live でこれらの BJJ の試合をライブで観戦:';
 
   @override
+  String get scoreboardShareMatch => 'この試合を共有';
+
+  @override
+  String get scoreboardShareMatchMessage => 'bjjscore.live でこの BJJ の試合をライブで観戦:';
+
+  @override
   String get scoreboardQrTitle => 'スキャンしてライブ観戦';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -726,6 +726,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Acompanhe estas lutas de BJJ ao vivo em bjjscore.live:';
 
   @override
+  String get scoreboardShareMatch => 'Compartilhar esta luta';
+
+  @override
+  String get scoreboardShareMatchMessage =>
+      'Assista a esta luta de BJJ ao vivo em bjjscore.live:';
+
+  @override
   String get scoreboardQrTitle => 'Escaneie para ver ao vivo';
 
   @override

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -2,7 +2,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/scoreboard/providers/scoreboard_providers.dart';
+import '../../l10n/generated/app_localizations.dart';
 import '../../shared/providers/navigation_provider.dart';
+import '../../shared/share_sheet.dart';
 import '../nostr/crypto/nostr_crypto.dart';
 
 /// The host whose links this app answers for.
@@ -34,6 +36,38 @@ String liveBoardShareUrl(String npub) => '$kLiveBoardBaseUrl/?npub=$npub';
 /// one tap from the match instead of on it.
 String matchShareUrl(String npub, String matchId) =>
     '${liveBoardShareUrl(npub)}&$kShareMatchParam=$matchId';
+
+/// Hand one match to the platform share sheet.
+///
+/// Two surfaces send a match — a card in the scoreboard list, and the wall
+/// board while it is on screen — and what they send has to be the same thing:
+/// the same npub encoding, the same `&match=` link, and the same pair of
+/// strings, because "watch this fight" is one promise however it was reached.
+/// Written once here, next to [matchShareUrl], so that promise cannot drift
+/// into two slightly different ones.
+///
+/// [watchedHex] is the organizer's key, not the recipient's: an id names
+/// nothing on its own, and it is encoded to an npub here rather than by each
+/// caller. [logTag] is the only thing the two surfaces differ by, and it names
+/// which one in the debug line [shareLink] writes.
+Future<void> shareMatchLink(
+  BuildContext context,
+  WidgetRef ref, {
+  required String watchedHex,
+  required String matchId,
+  required String logTag,
+}) {
+  final l10n = AppLocalizations.of(context);
+  final npub = ref.read(nostrCryptoProvider).npubEncode(watchedHex);
+
+  return shareLink(
+    context,
+    message: l10n.scoreboardShareMatchMessage,
+    url: matchShareUrl(npub, matchId),
+    subject: l10n.scoreboardShareMatch,
+    logTag: logTag,
+  );
+}
 
 /// The query parameter naming one match on the board.
 const String kShareMatchParam = 'match';

--- a/lib/shared/share_sheet.dart
+++ b/lib/shared/share_sheet.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+
+/// Hand a link to the platform share sheet, and say so when it will not open.
+///
+/// Three screens send links now — the account screen's board link, the
+/// scoreboard header's, and a match's — and every one of them needs the same
+/// three things: an origin rect so an iPad has somewhere to anchor the popover,
+/// a `PlatformException` caught so a failure does not escape a tap callback as
+/// an unhandled async error, and the [AppLocalizations.shareFailed] snackbar
+/// that tells the user why nothing happened. Written once here rather than
+/// three times, because three copies of a `try`/`catch` is where a difference
+/// between them stops being deliberate.
+///
+/// [message] precedes the link and [url] follows it on its own line: what
+/// arrives in a chat is a sentence and then something tappable, never a bare
+/// URL nobody asked for. [subject] is what the sheet calls the thing being
+/// shared, and must name it — "share this board" and "share this match" produce
+/// different links, and a bare "Share" on either is how somebody sends the
+/// wrong one.
+///
+/// [logTag] names the caller in the one debug line this writes. Never the URL,
+/// which carries a pubkey, and never the platform's message, which could echo
+/// shared content back out to the device log.
+Future<void> shareLink(
+  BuildContext context, {
+  required String message,
+  required String url,
+  required String subject,
+  required String logTag,
+}) async {
+  final l10n = AppLocalizations.of(context);
+  final messenger = ScaffoldMessenger.of(context);
+  final errorColor = Theme.of(context).colorScheme.error;
+
+  // iPad requires a non-null origin to anchor the share popover; the caller's
+  // render box is a safe fallback on phones.
+  final box = context.findRenderObject() as RenderBox?;
+  final origin = box != null ? box.localToGlobal(Offset.zero) & box.size : null;
+
+  try {
+    await Share.share(
+      '$message\n$url',
+      subject: subject,
+      sharePositionOrigin: origin,
+    );
+  } on PlatformException catch (e) {
+    debugPrint('$logTag: share sheet failed (${e.code})');
+    if (!context.mounted) return;
+    messenger.showSnackBar(
+      SnackBar(content: Text(l10n.shareFailed), backgroundColor: errorColor),
+    );
+  }
+}

--- a/lib/shared/widgets/match_card.dart
+++ b/lib/shared/widgets/match_card.dart
@@ -354,6 +354,10 @@ class MatchCard extends StatelessWidget {
   /// line with the status rather than claiming one of its own. A list of ten
   /// cards each shouting "share" is a list nobody reads, and the card's own tap
   /// target is still "open this match".
+  ///
+  /// Secondary is not the same as small to hit: the icon costs the header line
+  /// the height of a full 48×48 tap target, and that is the price of the
+  /// affordance rather than an accident to shave down.
   Widget _buildTrailing(AppLocalizations l10n, ChokeTokens tk) {
     if (onShare == null) return MatchStatusChip(status: match.status);
 
@@ -365,11 +369,18 @@ class MatchCard extends StatelessWidget {
         IconButton(
           onPressed: onShare,
           tooltip: l10n.scoreboardShareMatch,
-          // Sized down to the chip beside it so the header line does not grow
-          // a taller row for one glyph.
+          // The glyph is 14px; the thing you tap is 48×48, which is Material's
+          // minimum and clears Apple's 44pt. Quiet is a matter of size, weight
+          // and colour — not of being hard to hit, and this one sits beside a
+          // much larger competing target (the card itself opens the match), so
+          // a near miss does the wrong thing rather than nothing.
+          //
+          // Left to the tap target rather than set here: an IconButton's hit
+          // area comes from `MaterialTapTargetSize`, and tightening
+          // `constraints` under it only shrinks the ink, never the gesture. A
+          // `constraints: tightFor(30, 26)` here read as 30×26 and measured
+          // 40×40.
           padding: EdgeInsets.zero,
-          constraints: const BoxConstraints.tightFor(width: 30, height: 26),
-          visualDensity: VisualDensity.compact,
           icon: Icon(Icons.ios_share, size: 14, color: tk.faint),
         ),
       ],

--- a/lib/shared/widgets/match_card.dart
+++ b/lib/shared/widgets/match_card.dart
@@ -136,13 +136,22 @@ class _SmallBadge extends StatelessWidget {
 /// matches and differ only in what opening one means — hence [onTap], rather
 /// than a card that knows where it is.
 class MatchCard extends StatelessWidget {
-  const MatchCard({super.key, required this.match, this.onTap});
+  const MatchCard({super.key, required this.match, this.onTap, this.onShare});
 
   final Match match;
 
   /// What opening this match means here. A card with no [onTap] does not react
   /// to being pressed.
   final VoidCallback? onTap;
+
+  /// How to hand this match to somebody else, where that is possible.
+  ///
+  /// Optional, and absent by default, because only the read-only scoreboard has
+  /// a link to give: it knows whose board it is watching, and a match id names
+  /// nothing without an organizer. A card with no callback renders exactly what
+  /// it rendered before this existed, which is what keeps the home feed
+  /// untouched.
+  final VoidCallback? onShare;
 
   @override
   Widget build(BuildContext context) {
@@ -187,7 +196,7 @@ class MatchCard extends StatelessWidget {
                   fontWeight: FontWeight.w600,
                 ),
               ),
-              MatchStatusChip(status: match.status),
+              _buildTrailing(l10n, tk),
             ],
           ),
           const SizedBox(height: 11),
@@ -331,6 +340,39 @@ class MatchCard extends StatelessWidget {
       onTap: onTap,
       borderRadius: BorderRadius.circular(18),
       child: isCanceled ? Opacity(opacity: .72, child: card) : card,
+    );
+  }
+
+  /// The right-hand end of the card's first line: the status, and a way to pass
+  /// the match on where there is one.
+  ///
+  /// Returns the chip alone when there is nothing to share, rather than a Row
+  /// holding only the chip, so a card without [onShare] lays out exactly as it
+  /// did before this existed.
+  ///
+  /// The affordance is deliberately secondary — small, faint, and sharing the
+  /// line with the status rather than claiming one of its own. A list of ten
+  /// cards each shouting "share" is a list nobody reads, and the card's own tap
+  /// target is still "open this match".
+  Widget _buildTrailing(AppLocalizations l10n, ChokeTokens tk) {
+    if (onShare == null) return MatchStatusChip(status: match.status);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        MatchStatusChip(status: match.status),
+        const SizedBox(width: 2),
+        IconButton(
+          onPressed: onShare,
+          tooltip: l10n.scoreboardShareMatch,
+          // Sized down to the chip beside it so the header line does not grow
+          // a taller row for one glyph.
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints.tightFor(width: 30, height: 26),
+          visualDensity: VisualDensity.compact,
+          icon: Icon(Icons.ios_share, size: 14, color: tk.faint),
+        ),
+      ],
     );
   }
 }

--- a/test/features/scoreboard/scoreboard_match_share_test.dart
+++ b/test/features/scoreboard/scoreboard_match_share_test.dart
@@ -1,0 +1,329 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/features/scoreboard/scoreboard_match_screen.dart';
+import 'package:choke/features/scoreboard/scoreboard_screen.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+import 'package:choke/services/wakelock/screen_wakelock.dart';
+import 'package:choke/shared/theme/app_theme.dart';
+import 'package:choke/shared/widgets/match_card.dart';
+
+import '../../support/nostr_fakes.dart';
+import '../../support/share_channel.dart';
+
+/// The relays are not part of what these tests are about; the feed just needs
+/// something that answers.
+class _OfflineNostrService extends NostrService {
+  _OfflineNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  @override
+  Stream<NostrEvent> get eventStream => const Stream.empty();
+
+  @override
+  void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {}
+
+  @override
+  void unsubscribe(String subscriptionId) {}
+
+  @override
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) => const [];
+}
+
+const _watched =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+/// The two links, spelled out rather than built from the same helpers the code
+/// uses. Asserting against `matchShareUrl(...)` would pass however the URL is
+/// assembled; these fail if the shape of either one moves.
+const _boardUrl = 'https://bjjscore.live/?npub=npub1fake';
+const _matchUrl = 'https://bjjscore.live/?npub=npub1fake&match=abcd';
+
+Match _match() => Match(
+      id: 'abcd',
+      status: MatchStatus.inProgress,
+      startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      duration: 300,
+      f1Name: 'Buchecha',
+      f2Name: 'Roger Gracie',
+      f1Color: '#1BA34E',
+      f2Color: '#F5B800',
+    );
+
+Widget _wrap(Widget child, {List<Override> overrides = const []}) {
+  return ProviderScope(
+    overrides: [
+      nostrCryptoProvider.overrideWithValue(FakeNostrCrypto()),
+      nostrServiceProvider.overrideWithValue(_OfflineNostrService()),
+      // The real one talks to a method channel nothing answers in a test.
+      screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+      ...overrides,
+    ],
+    child: MaterialApp(
+      theme: AppTheme.darkTheme,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    ),
+  );
+}
+
+/// The list, with a board being watched and one match on it.
+Future<void> _pumpList(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues({'choke:scoreboard-pubkey': _watched});
+  await tester.pumpWidget(_wrap(
+    const ScoreboardScreen(),
+    overrides: [
+      scoreboardMatchesProvider.overrideWithValue([_match()]),
+      scoreboardFilteredMatchesProvider.overrideWithValue([_match()]),
+    ],
+  ));
+  await tester.pump();
+  await tester.pump(); // the saved pubkey is restored asynchronously
+}
+
+/// The wall board for one match, with the same board being watched.
+///
+/// `pumpAndSettle` is unusable here: the live status dot animates for as long
+/// as the match is running, so a settled frame never arrives. Every wait in
+/// this file is a fixed pump for that reason.
+Future<void> _pumpBoard(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(1600, 740);
+  tester.view.devicePixelRatio = 2.0;
+  addTearDown(tester.view.reset);
+
+  SharedPreferences.setMockInitialValues({'choke:scoreboard-pubkey': _watched});
+  await tester.pumpWidget(_wrap(
+    const ScoreboardMatchScreen(matchId: 'abcd'),
+    overrides: [
+      scoreboardMatchesProvider.overrideWithValue([_match()]),
+    ],
+  ));
+  await tester.pump();
+  await tester.pump(); // the saved pubkey is restored asynchronously
+}
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() async {
+    l10n = await AppLocalizations.delegate.load(const Locale('en'));
+  });
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('MatchCard share affordance', () {
+    testWidgets('renders nothing extra without a callback', (tester) async {
+      // Arrange + Act — the home feed's card, which this change must not touch
+      await tester.pumpWidget(_wrap(
+        Scaffold(body: MatchCard(match: _match())),
+      ));
+      await tester.pump();
+
+      // Assert
+      expect(find.byTooltip(l10n.scoreboardShareMatch), findsNothing);
+      expect(find.byIcon(Icons.ios_share), findsNothing);
+    });
+
+    testWidgets('offers a share icon when given a callback', (tester) async {
+      // Arrange
+      var shared = 0;
+
+      // Act
+      await tester.pumpWidget(_wrap(
+        Scaffold(body: MatchCard(match: _match(), onShare: () => shared++)),
+      ));
+      await tester.pump();
+      await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
+      await tester.pump();
+
+      // Assert — and the card's own tap target is untouched by the icon's
+      expect(shared, 1);
+    });
+
+    testWidgets('stays quieter than the card it sits on', (tester) async {
+      // Arrange + Act — a list of ten cards each shouting "share" is a list
+      // nobody reads, so the affordance recedes until it is looked for.
+      await tester.pumpWidget(_wrap(
+        Scaffold(body: MatchCard(match: _match(), onShare: () {})),
+      ));
+      await tester.pump();
+
+      // Assert — muted, and smaller than the fighters' names
+      final icon = tester.widget<Icon>(find.byIcon(Icons.ios_share));
+      final name = tester.widget<Text>(find.text('Buchecha'));
+      expect(icon.size, isNotNull);
+      expect(icon.size!, lessThan(name.style!.fontSize!));
+      expect(icon.color, ChokeTokens.dark.faint);
+    });
+  });
+
+  group('ScoreboardScreen match sharing', () {
+    testWidgets('shares a link naming the match, not the board',
+        (tester) async {
+      // Arrange
+      final calls = mockShareChannel(tester);
+      await _pumpList(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
+      await tester.pump();
+
+      // Assert — the id travels with the organizer, because an id alone names
+      // nothing, and the raw hex key never leaves the device.
+      expect(calls, hasLength(1));
+      final text = calls.single['text'] as String;
+      expect(text, contains(_matchUrl));
+      expect(text, contains('&match=abcd'));
+      expect(text, contains(l10n.scoreboardShareMatchMessage));
+      expect(text, isNot(contains(_watched)));
+    });
+
+    testWidgets('sends a different link than sharing the board does',
+        (tester) async {
+      // Arrange — the two actions sit inches apart, and a user who cannot tell
+      // them apart sends the wrong one.
+      final calls = mockShareChannel(tester);
+      await _pumpList(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareBoard));
+      await tester.pump();
+      await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
+      await tester.pump();
+
+      // Assert
+      expect(calls, hasLength(2));
+      final board = calls.first['text'] as String;
+      final match = calls.last['text'] as String;
+      expect(board, contains(_boardUrl));
+      expect(board, isNot(contains('match=')));
+      expect(match, contains(_matchUrl));
+      expect(board, isNot(match));
+      // And neither is labelled a bare "Share"
+      expect(calls.first['subject'], l10n.scoreboardShareBoard);
+      expect(calls.last['subject'], l10n.scoreboardShareMatch);
+    });
+
+    testWidgets('surfaces a share sheet failure instead of crashing',
+        (tester) async {
+      // Arrange
+      mockShareChannel(tester, fail: true);
+      await _pumpList(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Assert
+      expect(find.text(l10n.shareFailed), findsOneWidget);
+    });
+  });
+
+  group('ScoreboardMatchScreen sharing', () {
+    testWidgets('shares the match being watched', (tester) async {
+      // Arrange
+      final calls = mockShareChannel(tester);
+      await _pumpBoard(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
+      await tester.pump();
+
+      // Assert
+      expect(calls, hasLength(1));
+      final text = calls.single['text'] as String;
+      expect(text, contains(_matchUrl));
+      expect(text, contains('&match=abcd'));
+      expect(text, isNot(contains(_watched)));
+    });
+
+    testWidgets('goes straight to the share sheet, with no menu in the way',
+        (tester) async {
+      // Arrange — this is the "look at this" reflex; a chooser in front of it
+      // costs more than it offers.
+      final calls = mockShareChannel(tester);
+      await _pumpBoard(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
+      await tester.pump();
+
+      // Assert
+      expect(calls, hasLength(1));
+      expect(find.byType(Dialog), findsNothing);
+    });
+
+    testWidgets('carries no QR — the credit line already does that job',
+        (tester) async {
+      // Arrange + Act — when this screen is the projection the audience is
+      // already reading bjjscore.live along the bottom of it.
+      await _pumpBoard(tester);
+
+      // Assert
+      expect(find.byIcon(Icons.qr_code_2), findsNothing);
+    });
+
+    testWidgets('sits opposite Back, as its pair', (tester) async {
+      // Arrange + Act
+      await _pumpBoard(tester);
+
+      // Assert — same offsets, mirrored, so the two chrome items read together
+      final back = tester.widget<Positioned>(find.ancestor(
+        of: find.text(l10n.goBack),
+        matching: find.byType(Positioned),
+      ));
+      final share = tester.widget<Positioned>(find.ancestor(
+        of: find.byTooltip(l10n.scoreboardShareMatch),
+        matching: find.byType(Positioned),
+      ));
+      expect(back.top, 8);
+      expect(back.left, 8);
+      expect(share.top, back.top);
+      expect(share.right, 8);
+    });
+
+    testWidgets('offers no share with no board to name', (tester) async {
+      // Arrange — nothing watched means no npub, and a match id on its own
+      // names nothing.
+      tester.view.physicalSize = const Size(1600, 740);
+      tester.view.devicePixelRatio = 2.0;
+      addTearDown(tester.view.reset);
+      await tester.pumpWidget(_wrap(
+        const ScoreboardMatchScreen(matchId: 'abcd'),
+        overrides: [
+          scoreboardMatchesProvider.overrideWithValue([_match()]),
+        ],
+      ));
+      await tester.pump();
+
+      // Assert
+      expect(find.byTooltip(l10n.scoreboardShareMatch), findsNothing);
+    });
+
+    testWidgets('surfaces a share sheet failure instead of crashing',
+        (tester) async {
+      // Arrange
+      mockShareChannel(tester, fail: true);
+      await _pumpBoard(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Assert
+      expect(find.text(l10n.shareFailed), findsOneWidget);
+    });
+  });
+}

--- a/test/features/scoreboard/scoreboard_match_share_test.dart
+++ b/test/features/scoreboard/scoreboard_match_share_test.dart
@@ -165,6 +165,33 @@ void main() {
       expect(icon.size!, lessThan(name.style!.fontSize!));
       expect(icon.color, ChokeTokens.dark.faint);
     });
+
+    testWidgets('is quiet to look at without being small to hit',
+        (tester) async {
+      // Arrange — quiet is a matter of size, weight and colour; the thing you
+      // tap has to clear Material's 48x48 either way, and it sits next to a
+      // much larger competing target, so a near miss opens the match instead
+      // of sharing it.
+      var shared = 0;
+      await tester.pumpWidget(_wrap(
+        Scaffold(body: MatchCard(match: _match(), onShare: () => shared++)),
+      ));
+      await tester.pump();
+
+      // Act + Assert — the tap target, not the glyph
+      final target = tester.getRect(find.byType(IconButton));
+      final glyph = tester.getRect(find.byIcon(Icons.ios_share));
+      expect(target.width, greaterThanOrEqualTo(48));
+      expect(target.height, greaterThanOrEqualTo(48));
+      expect(glyph.height, lessThan(target.height));
+
+      // A tap a pixel inside the corner is nowhere near the glyph, and still
+      // shares. `constraints` on an IconButton cannot shrink this — only
+      // `MaterialTapTargetSize` can — which is why none is set.
+      await tester.tapAt(target.topLeft + const Offset(1, 1));
+      await tester.pump();
+      expect(shared, 1);
+    });
   });
 
   group('ScoreboardScreen match sharing', () {


### PR DESCRIPTION
Step 4 — the last — of `docs/specs/shared-match-links.md` §9.3. Third in the stack: `main` ← #154 ← #155 ← this.

`matchShareUrl` has had no callers outside its tests since it was built. Giving it callers is this whole PR.

## The share helper (§5.5)

A third call site was about to copy the same origin-rect / `PlatformException` / `shareFailed` snackbar block. `lib/shared/share_sheet.dart` now owns it, and the account screen, the scoreboard header and both new actions route through it. It also owns the &#34;message, newline, link&#34; shape, so what arrives in a chat is a sentence and then something tappable on every surface.

One level up, `shareMatchLink` (in `share_link.dart`, beside `matchShareUrl`) owns what a *match* share is: the npub encoding, the `&amp;match=` URL and the pair of strings. The two surfaces that send a match differ only by their log tag, which is the only thing they should ever have differed by.

## From the board list (§5.1)

`MatchCard` gains an optional `onShare`. Additive: with no callback `_buildTrailing` returns the status chip alone — not a `Row` holding only the chip — so a card lays out exactly as it did and the home feed is untouched. Home belongs to §5.3, a later change.

Wired only on the scoreboard list, and only while a board is watched: the link names the organizer as well as the match, because four hex characters are unique only inside one author&#39;s events.

Secondary by construction: a 14px `ios_share` in `tk.faint`, sharing the header line with the status chip. Quiet is a matter of size, weight and colour — the thing you *tap* is a full 48×48, Material&#39;s minimum, because this affordance sits beside a much larger competing target (the card itself opens the match) and a near miss does the wrong thing rather than nothing. That costs the card 16px of header line; see the review thread for the measurements.

## While watching one match (§5.2)

One icon at `Positioned(top: 8, right: 8)` inside a `SafeArea`, in `palette.backLabel` — the same offsets and the same colour as `_buildBack`, mirrored, so the two chrome items read as a pair. Icon only, no label. One tap straight to the platform share sheet, no intermediate menu.

No QR. The QR&#39;s job is a room, the room is the organizer&#39;s moment, and when this screen *is* the projection the audience is already reading the bjjscore.live credit along the bottom.

## Labels (§5.4)

| Action | Link | Means |
|---|---|---|
| `scoreboardShareBoard` (existing) | `?npub=…` | follow this academy |
| `scoreboardShareMatch` (new) | `?npub=…&amp;match=…` | watch this fight |

Neither is a bare &#34;Share&#34;. The existing board strings were re-read against the new neighbours and stay correct: &#34;Share this board&#34; / &#34;Follow these BJJ matches live&#34; is plural and about following, where the match pair is singular and about watching, so the two read differently in a chat even before the link.

New keys in all four locales (`en` with `@` descriptions, `es` in voseo to match its neighbours, `pt`, `ja`), and `lib/l10n/generated/*` regenerated.

## Tests

New focused file `test/features/scoreboard/scoreboard_match_share_test.dart`, 13 tests. `pumpAndSettle` is unusable on the wall board — its live status dot animates forever — so every wait is a fixed pump.

- the card&#39;s icon shares a link carrying `&amp;match=abcd`
- the wall board&#39;s icon does too
- both share the link and never the raw hex pubkey
- board share and match share produce *different* links, with different subjects
- a failed share sheet surfaces `shareFailed` on both surfaces instead of crashing
- a card given no `onShare` renders no icon — the home-untouched guarantee
- the icon is muted and smaller than the fighters&#39; names
- the icon is quiet to look at without being small to hit: the target is ≥48×48, and a tap one pixel inside its corner still shares
- the wall board&#39;s icon mirrors Back&#39;s offsets, carries no QR, and opens no dialog
- no share icon with nobody watched, since there is then no npub to name

## Test plan

- [x] `flutter pub get &amp;&amp; dart format . &amp;&amp; flutter analyze &amp;&amp; flutter test` — 703 tests pass, no new analyzer issues
- [ ] Share a match from the board list on a device; confirm the link opens that match in the app and on the web
- [ ] Share from the wall board in landscape; confirm the popover anchors on iPad

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUo75zQ6ozahYQEf1emtzq



## Summary by CodeRabbit

- **New Features**
  - Added one-tap sharing for individual live scoreboard matches.
  - Added compact share controls to match cards when sharing is available.
  - Match links include the relevant organizer and open directly to the selected match.
  - Standardized sharing for account and scoreboard links with localized messages and subjects.
- **Localization**
  - Added match-sharing text in English, Spanish, Japanese, and Portuguese.
- **Bug Fixes**
  - Improved share failure handling with a localized error message.
