### PR TITLE
refactor: move the Settings relay probe into the Rust crate

### DIFF
--- a/lib/features/settings/providers/relay_config_provider.dart
+++ b/lib/features/settings/providers/relay_config_provider.dart
@@ -3,8 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:web_socket_channel/web_socket_channel.dart';
-
+import '../../../services/nostr/relay/rust_relay_backend.dart';
 import '../../../shared/nostr_relays.dart';
 
 /// Error codes emitted by [RelayConfigNotifier].
@@ -357,44 +356,21 @@ class RelayConfigNotifier extends StateNotifier<RelayConfigState> {
     return trimmed.startsWith('wss://');
   }
 
-  /// Tests WebSocket connectivity to a relay.
-  /// Returns true if connection succeeds within timeout, false otherwise.
-  Future<bool> testRelayConnectivity(String url) async {
-    WebSocketChannel? channel;
-    try {
-      // Attempt connection with 5 second timeout
-      channel = WebSocketChannel.connect(Uri.parse(url.trim()));
-      await channel.ready.timeout(const Duration(seconds: 5));
+  /// How long [testRelayConnectivity] waits for the handshake before calling
+  /// the relay unreachable. The same five seconds the old Dart-side probe
+  /// used; long enough for venue wifi, short enough for the "Adding…" spinner.
+  static const Duration probeTimeout = Duration(seconds: 5);
 
-      // Send a simple ping-like message to verify it's a Nostr relay
-      channel.sink.add('["REQ","test",{}]');
-
-      // Wait briefly for any response (even an error confirms it's a relay)
-      await Future.delayed(const Duration(milliseconds: 500));
-
-      await channel.sink.close();
-      return true;
-    } on TimeoutException {
-      debugPrint('RelayConfigNotifier: Connection timeout to $url');
-      _closeQuietly(channel);
-      return false;
-    } catch (e) {
-      debugPrint('RelayConfigNotifier: Connection failed to $url: $e');
-      _closeQuietly(channel);
-      return false;
-    }
-  }
-
-  /// Best-effort close that never blocks.
+  /// Tests connectivity to a relay before it is saved.
+  /// Returns true if the WebSocket handshake completes within [probeTimeout].
   ///
-  /// When the handshake never completed (connection refused, silent host),
-  /// the sink's close future never resolves — awaiting it here is what used
-  /// to hang addRelay forever behind the "Adding…" spinner. The failure paths
-  /// fire it and move on; there is nothing to wait for on a socket that
-  /// never existed.
-  void _closeQuietly(WebSocketChannel? channel) {
-    if (channel == null) return;
-    unawaited(channel.sink.close().catchError((_) {}));
+  /// The handshake itself happens in the Rust crate, on a throwaway client
+  /// that never touches the app's relay pool — Dart opens no socket here
+  /// (see AGENTS.md: relay networking lives in Rust). Kept as an instance
+  /// method because it is the seam tests override to keep addRelay off the
+  /// network.
+  Future<bool> testRelayConnectivity(String url) {
+    return RustRelayBackend.probe(url.trim(), timeout: probeTimeout);
   }
 }
 

--- a/lib/services/nostr/relay/rust_relay_backend.dart
+++ b/lib/services/nostr/relay/rust_relay_backend.dart
@@ -82,8 +82,23 @@ class RustRelayBackend implements NostrRelayBackend {
   /// the Rust crate on a throwaway client (`relay_probe`), so a candidate URL
   /// inherits no subscriptions and leaves nothing behind if the user walks
   /// away. Dart opens no socket here — relay networking stays in Rust.
-  static Future<bool> probe(String url, {required Duration timeout}) {
-    return rust.relayProbe(url: url, timeoutMs: timeout.inMilliseconds);
+  /// Answers `false` rather than throwing when the call itself fails — a
+  /// `PanicException` out of the crate, an uninitialized binding, anything.
+  /// The caller is a tap on "Add", and it awaits this *outside* its own
+  /// `try`: an escaping exception would leave the sheet spinning on "Adding…"
+  /// with nothing to dismiss it, on top of surfacing a raw error. Unreachable
+  /// is also the honest answer — a probe that could not run has not found a
+  /// relay.
+  static Future<bool> probe(String url, {required Duration timeout}) async {
+    try {
+      return await rust.relayProbe(
+        url: url,
+        timeoutMs: timeout.inMilliseconds,
+      );
+    } catch (e) {
+      debugPrint('RustRelayBackend: probe of $url failed: $e');
+      return false;
+    }
   }
 
   @override

--- a/lib/services/nostr/relay/rust_relay_backend.dart
+++ b/lib/services/nostr/relay/rust_relay_backend.dart
@@ -75,6 +75,17 @@ class RustRelayBackend implements NostrRelayBackend {
     }
   }
 
+  /// Whether [url] answers a relay's WebSocket handshake within [timeout].
+  ///
+  /// Settings vets a URL with this before saving it. Static, because it
+  /// deliberately does not touch this backend's pool: the handshake happens in
+  /// the Rust crate on a throwaway client (`relay_probe`), so a candidate URL
+  /// inherits no subscriptions and leaves nothing behind if the user walks
+  /// away. Dart opens no socket here — relay networking stays in Rust.
+  static Future<bool> probe(String url, {required Duration timeout}) {
+    return rust.relayProbe(url: url, timeoutMs: timeout.inMilliseconds);
+  }
+
   @override
   Stream<NostrEvent> get events => _eventController.stream;
 

--- a/lib/src/rust/api/relay.dart
+++ b/lib/src/rust/api/relay.dart
@@ -67,6 +67,21 @@ Future<bool> relayPublish(
         {required String url, required SignedEventData event}) =>
     RustLib.instance.api.crateApiRelayRelayPublish(url: url, event: event);
 
+/// Whether `url` answers a relay's WebSocket handshake within `timeout_ms`.
+///
+/// Settings vets a URL with this before saving it. The question is "is
+/// something listening there", nothing more — success is the handshake
+/// completing, not any Nostr traffic — which mirrors what the app accepted
+/// before this probe existed.
+///
+/// Runs on a throwaway client, never the app's pool: the candidate joins no
+/// registry, inherits none of the pool's subscriptions, and a URL the user
+/// then decides not to save leaves nothing behind. `shutdown` reaps the
+/// throwaway's tasks whichever way the probe went.
+Future<bool> relayProbe({required String url, required int timeoutMs}) =>
+    RustLib.instance.api
+        .crateApiRelayRelayProbe(url: url, timeoutMs: timeoutMs);
+
 Future<void> relaySubscribe(
         {required String subscriptionId, required FilterData filter}) =>
     RustLib.instance.api.crateApiRelayRelaySubscribe(

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -71,7 +71,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => -465090834;
+  int get rustContentHash => -392479397;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -109,6 +109,9 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiRelayRelayDisconnect();
 
   Stream<SignedEventData> crateApiRelayRelayEventStream();
+
+  Future<bool> crateApiRelayRelayProbe(
+      {required String url, required int timeoutMs});
 
   Future<bool> crateApiRelayRelayPublish(
       {required String url, required SignedEventData event});
@@ -449,6 +452,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<bool> crateApiRelayRelayProbe(
+      {required String url, required int timeoutMs}) {
+    return handler.executeNormal(NormalTask(
+      callFfi: (port_) {
+        final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_String(url, serializer);
+        sse_encode_u_32(timeoutMs, serializer);
+        pdeCallFfi(generalizedFrbRustBinding, serializer,
+            funcId: 14, port: port_);
+      },
+      codec: SseCodec(
+        decodeSuccessData: sse_decode_bool,
+        decodeErrorData: null,
+      ),
+      constMeta: kCrateApiRelayRelayProbeConstMeta,
+      argValues: [url, timeoutMs],
+      apiImpl: this,
+    ));
+  }
+
+  TaskConstMeta get kCrateApiRelayRelayProbeConstMeta => const TaskConstMeta(
+        debugName: "relay_probe",
+        argNames: ["url", "timeoutMs"],
+      );
+
+  @override
   Future<bool> crateApiRelayRelayPublish(
       {required String url, required SignedEventData event}) {
     return handler.executeNormal(NormalTask(
@@ -457,7 +486,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(url, serializer);
         sse_encode_box_autoadd_signed_event_data(event, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 14, port: port_);
+            funcId: 15, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -480,7 +509,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 15, port: port_);
+            funcId: 16, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -505,7 +534,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(url, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 16, port: port_);
+            funcId: 17, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -530,7 +559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_relay_status_data_Sse(sink, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 17, port: port_);
+            funcId: 18, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -558,7 +587,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(subscriptionId, serializer);
         sse_encode_box_autoadd_filter_data(filter, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 18, port: port_);
+            funcId: 19, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -583,7 +612,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(subscriptionId, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 19, port: port_);
+            funcId: 20, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -607,7 +636,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 20, port: port_);
+            funcId: 21, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_String,
@@ -630,7 +659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(eventJson, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -653,7 +682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_signed_event_data(event, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1194,7 +1194,7 @@ packages:
     source: hosted
     version: "1.1.1"
   web_socket_channel:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: web_socket_channel
       sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,10 +56,6 @@ dependencies:
 
   # Native share sheet (share the bjjscore.live live-board link)
   share_plus: ^10.1.4
-
-  # Still used to ping relays from the Settings screen when the user adds one.
-  # Not the app's Nostr transport any more — that is the Rust crate.
-  web_socket_channel: ^2.4.0
   rust_lib_choke:
     path: rust_builder
   flutter_rust_bridge: 2.12.0

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,10 @@ nostr = { version = "=0.44.4", default-features = false, features = ["std"] }
 nostr-sdk = "=0.44.1"
 tokio = { version = "1.52.3", features = ["rt"] }
 
+[dev-dependencies]
+# The probe tests are async; "macros" brings #[tokio::test], nothing else.
+tokio = { version = "1.52.3", features = ["rt", "macros"] }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }
 

--- a/rust/src/api/relay.rs
+++ b/rust/src/api/relay.rs
@@ -347,17 +347,22 @@ pub async fn relay_probe(url: String, timeout_ms: u32) -> bool {
     // A URL that cannot be parsed is unreachable by definition. The caller
     // hears `false` rather than an error, because "can this be my relay?"
     // has exactly two answers.
-    if probe.add_relay(&url).await.is_err() {
-        return false;
-    }
-
-    let connected = probe
-        .try_connect_relay(
-            &url,
-            std::time::Duration::from_millis(u64::from(timeout_ms)),
-        )
-        .await
-        .is_ok();
+    //
+    // Written as one expression so `shutdown` below is on every path,
+    // including this one. Dropping the client would very likely be enough —
+    // nothing is connected when `add_relay` fails — but "very likely enough"
+    // is a worse thing to leave behind than one branch.
+    let connected = if probe.add_relay(&url).await.is_err() {
+        false
+    } else {
+        probe
+            .try_connect_relay(
+                &url,
+                std::time::Duration::from_millis(u64::from(timeout_ms)),
+            )
+            .await
+            .is_ok()
+    };
 
     probe.shutdown().await;
     connected
@@ -530,8 +535,15 @@ mod tests {
 
     #[tokio::test]
     async fn probe_reports_a_refused_connection_as_unreachable() {
-        // Port 1 on loopback: privileged, nothing listens there.
-        assert!(!relay_probe("ws://127.0.0.1:1".to_string(), 2_000).await);
+        // A port this test held and let go, rather than a low one assumed to
+        // be free: the kernel hands out one nothing is listening on, and
+        // dropping the listener leaves it refusing. A hardcoded port is only
+        // unused until the machine running the tests disagrees.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        assert!(!relay_probe(format!("ws://127.0.0.1:{port}"), 2_000).await);
     }
 
     #[tokio::test]
@@ -542,6 +554,16 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
 
-        assert!(!relay_probe(format!("ws://127.0.0.1:{port}"), 1_500).await);
+        // The outer deadline is the point: if the probe's own timeout ever
+        // stops firing, this fails in three seconds instead of hanging the
+        // suite until CI gives up on the whole job.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            relay_probe(format!("ws://127.0.0.1:{port}"), 1_500),
+        )
+        .await
+        .expect("relay probe exceeded the outer test deadline");
+
+        assert!(!result);
     }
 }

--- a/rust/src/api/relay.rs
+++ b/rust/src/api/relay.rs
@@ -330,6 +330,39 @@ pub async fn relay_publish(url: String, event: SignedEventData) -> Result<bool, 
     }
 }
 
+/// Whether `url` answers a relay's WebSocket handshake within `timeout_ms`.
+///
+/// Settings vets a URL with this before saving it. The question is "is
+/// something listening there", nothing more — success is the handshake
+/// completing, not any Nostr traffic — which mirrors what the app accepted
+/// before this probe existed.
+///
+/// Runs on a throwaway client, never the app's pool: the candidate joins no
+/// registry, inherits none of the pool's subscriptions, and a URL the user
+/// then decides not to save leaves nothing behind. `shutdown` reaps the
+/// throwaway's tasks whichever way the probe went.
+pub async fn relay_probe(url: String, timeout_ms: u32) -> bool {
+    let probe = Client::default();
+
+    // A URL that cannot be parsed is unreachable by definition. The caller
+    // hears `false` rather than an error, because "can this be my relay?"
+    // has exactly two answers.
+    if probe.add_relay(&url).await.is_err() {
+        return false;
+    }
+
+    let connected = probe
+        .try_connect_relay(
+            &url,
+            std::time::Duration::from_millis(u64::from(timeout_ms)),
+        )
+        .await
+        .is_ok();
+
+    probe.shutdown().await;
+    connected
+}
+
 pub async fn relay_subscribe(subscription_id: String, filter: FilterData) -> Result<(), String> {
     let mut f = Filter::new();
 
@@ -478,5 +511,37 @@ pub async fn relay_status_stream(sink: StreamSink<RelayStatusData>) {
             }
             Err(broadcast::error::RecvError::Closed) => break,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The probe's failure paths are testable without any relay: garbage, a
+    // refused port, and a socket that accepts and then says nothing. The
+    // success path needs a live WebSocket server, which the Dart side already
+    // owns — `rust_relay_probe_test.dart` runs it against this same binary.
+
+    #[tokio::test]
+    async fn probe_rejects_a_url_that_does_not_parse() {
+        assert!(!relay_probe("not a relay url".to_string(), 1_000).await);
+    }
+
+    #[tokio::test]
+    async fn probe_reports_a_refused_connection_as_unreachable() {
+        // Port 1 on loopback: privileged, nothing listens there.
+        assert!(!relay_probe("ws://127.0.0.1:1".to_string(), 2_000).await);
+    }
+
+    #[tokio::test]
+    async fn probe_times_out_on_a_socket_that_never_completes_the_handshake() {
+        // A TCP listener that is never accepted from: the kernel completes
+        // the TCP handshake out of the backlog, and then nothing ever
+        // answers the WebSocket upgrade — the timeout is the only way out.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        assert!(!relay_probe(format!("ws://127.0.0.1:{port}"), 1_500).await);
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -465090834;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -392479397;
 
 // Section: executor
 
@@ -469,6 +469,45 @@ fn wire__crate__api__relay__relay_event_stream_impl(
                         let output_ok = Result::<_, ()>::Ok({
                             crate::api::relay::relay_event_stream(api_sink).await;
                         })?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__relay__relay_probe_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "relay_probe",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_url = <String>::sse_decode(&mut deserializer);
+            let api_timeout_ms = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, ()>(
+                    (move || async move {
+                        let output_ok = Result::<_, ()>::Ok(
+                            crate::api::relay::relay_probe(api_url, api_timeout_ms).await,
+                        )?;
                         Ok(output_ok)
                     })()
                     .await,
@@ -1059,13 +1098,14 @@ fn pde_ffi_dispatcher_primary_impl(
         11 => wire__crate__api__relay__relay_connected_impl(port, ptr, rust_vec_len, data_len),
         12 => wire__crate__api__relay__relay_disconnect_impl(port, ptr, rust_vec_len, data_len),
         13 => wire__crate__api__relay__relay_event_stream_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__relay__relay_publish_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__relay__relay_reconnect_all_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__relay__relay_remove_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__relay__relay_status_stream_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__relay__relay_subscribe_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__relay__relay_unsubscribe_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__relay__relay_urls_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__relay__relay_probe_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__relay__relay_publish_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__relay__relay_reconnect_all_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__relay__relay_remove_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__relay__relay_status_stream_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__relay__relay_subscribe_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__relay__relay_unsubscribe_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__relay__relay_urls_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1085,8 +1125,8 @@ fn pde_ffi_dispatcher_sync_impl(
         6 => wire__crate__api__crypto__nsec_decode_impl(ptr, rust_vec_len, data_len),
         7 => wire__crate__api__crypto__nsec_encode_impl(ptr, rust_vec_len, data_len),
         8 => wire__crate__api__crypto__public_key_from_secret_impl(ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__crypto__verify_event_impl(ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__crypto__verify_event_data_impl(ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__crypto__verify_event_impl(ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__crypto__verify_event_data_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/test/features/settings/providers/relay_config_provider_test.dart
+++ b/test/features/settings/providers/relay_config_provider_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -523,97 +522,12 @@ void main() {
     });
   });
 
-  group('testRelayConnectivity', () {
-    // These use loopback sockets only — nothing leaves the machine.
-
-    test('succeeds against a live local WebSocket endpoint', () async {
-      // Arrange — a WebSocket server on 127.0.0.1; the method does not care
-      // about the scheme, only the notifier's validator does, so ws:// keeps
-      // TLS out of the test
-      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-      final sockets = <WebSocket>[];
-      server.listen((request) async {
-        final ws = await WebSocketTransformer.upgrade(request);
-        sockets.add(ws);
-        ws.listen((_) {});
-      });
-      addTearDown(() async {
-        for (final ws in sockets) {
-          await ws.close();
-        }
-        await server.close(force: true);
-      });
-      final notifier = RelayConfigNotifier(
-          RelayConfigService(secureStorage: InMemorySecureStorage()));
-      await pumpEventQueue();
-
-      // Act
-      final reachable =
-          await notifier.testRelayConnectivity('ws://127.0.0.1:${server.port}');
-
-      // Assert
-      expect(reachable, isTrue);
-    });
-
-    test('returns false when the URL cannot even be parsed', () async {
-      // Arrange — Uri.parse throws before any channel exists, which is the
-      // only failure whose cleanup path can actually finish (see below)
-      final notifier = RelayConfigNotifier(
-          RelayConfigService(secureStorage: InMemorySecureStorage()));
-      await pumpEventQueue();
-
-      // Act — unterminated IPv6 literal: FormatException, synchronously
-      final reachable = await notifier.testRelayConnectivity('ws://[::1');
-
-      // Assert
-      expect(reachable, isFalse);
-    });
-
-    test('reports a refused connection as unreachable, promptly', () async {
-      // Arrange — port 1 on loopback: privileged, nothing listens there
-      final notifier = RelayConfigNotifier(
-          RelayConfigService(secureStorage: InMemorySecureStorage()));
-      await pumpEventQueue();
-
-      // Act — regression guard: this used to hang forever, because the
-      // failure path awaited `channel.sink.close()` on a socket whose
-      // handshake never completed. The method must now RETURN false itself;
-      // if the hang comes back, the test-level timeout fails this test.
-      final reachable =
-          await notifier.testRelayConnectivity('ws://127.0.0.1:1');
-
-      // Assert
-      expect(reachable, isFalse);
-    }, timeout: const Timeout(Duration(seconds: 15)));
-
-    test('times out against a socket that never completes the handshake',
-        () async {
-      // Arrange — a raw TCP listener that accepts and then says nothing, so
-      // channel.ready can only end by the 5 second timeout. This test costs
-      // those 5 real seconds; it is the only way to reach the timeout branch.
-      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-      final held = <Socket>[];
-      server.listen(held.add);
-      addTearDown(() async {
-        for (final socket in held) {
-          socket.destroy();
-        }
-        await server.close();
-      });
-      final notifier = RelayConfigNotifier(
-          RelayConfigService(secureStorage: InMemorySecureStorage()));
-      await pumpEventQueue();
-
-      // Act — regression guard for the same hang: after the 5s ready timeout
-      // fires, the method must return false on its own instead of wedging on
-      // a close() that can never complete.
-      final reachable =
-          await notifier.testRelayConnectivity('ws://127.0.0.1:${server.port}');
-
-      // Assert
-      expect(reachable, isFalse);
-    }, timeout: const Timeout(Duration(seconds: 15)));
-  });
+  // The real connectivity probe lives in the Rust crate now (`relay_probe`,
+  // reached through RustRelayBackend.probe) and needs the native library, so
+  // its socket-level tests — live endpoint, garbage URL, refused port, silent
+  // socket — live in test/services/nostr/relay/rust_relay_probe_test.dart,
+  // tagged 'rust'. What stays here is everything above the seam: addRelay
+  // consults testRelayConnectivity, and the fakes override it.
 
   group('providers', () {
     test('relayConfigServiceProvider builds a service', () {

--- a/test/features/settings/providers/relay_config_provider_test.dart
+++ b/test/features/settings/providers/relay_config_provider_test.dart
@@ -529,6 +529,49 @@ void main() {
   // tagged 'rust'. What stays here is everything above the seam: addRelay
   // consults testRelayConnectivity, and the fakes override it.
 
+  group('a probe that cannot run', () {
+    // This file never calls `RustLib.init`, so the binding underneath the
+    // probe is not loaded — which is exactly the shape of every way the call
+    // itself can fail, a panic out of the crate included. No native library
+    // needed to test it, and none wanted: the point is what happens when the
+    // crate is not reachable.
+
+    test('reports unreachable instead of throwing', () async {
+      // Arrange
+      final notifier = RelayConfigNotifier(
+        RelayConfigService(secureStorage: InMemorySecureStorage()),
+      );
+      await pumpEventQueue();
+
+      // Act + Assert — the caller awaits this outside its own try, so an
+      // escaping exception would strand the sheet on "Adding…"
+      await expectLater(
+        notifier.testRelayConnectivity('wss://relay.example'),
+        completion(isFalse),
+      );
+    });
+
+    test('leaves addRelay saying unreachable, not spinning', () async {
+      // Arrange
+      final storage = InMemorySecureStorage();
+      final notifier = RelayConfigNotifier(
+        RelayConfigService(secureStorage: storage),
+      );
+      await pumpEventQueue();
+      final before = storage.writeCount;
+
+      // Act
+      final added = await notifier.addRelay('wss://relay.example');
+
+      // Assert — refused, said so, and finished: isLoading back to false is
+      // the whole regression this guards
+      expect(added, isFalse);
+      expect(notifier.state.error, RelayError.unreachable);
+      expect(notifier.state.isLoading, isFalse);
+      expect(storage.writeCount, before);
+    });
+  });
+
   group('providers', () {
     test('relayConfigServiceProvider builds a service', () {
       // Arrange

--- a/test/services/nostr/relay/rust_relay_probe_test.dart
+++ b/test/services/nostr/relay/rust_relay_probe_test.dart
@@ -1,0 +1,159 @@
+@Tags(['rust'])
+library;
+
+import 'dart:io';
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/settings/providers/relay_config_provider.dart';
+import 'package:choke/services/nostr/relay/rust_relay_backend.dart';
+import 'package:choke/src/rust/frb_generated.dart';
+
+import '../../../support/relay_fakes.dart';
+
+/// The connectivity probe Settings runs before saving a relay URL.
+///
+/// The handshake lives in the Rust crate (`relay_probe`), so these are the
+/// socket-level tests that used to sit next to RelayConfigNotifier when the
+/// probe was a Dart WebSocket. Same cases, same loopback-only rule: nothing
+/// here leaves the machine. The Rust crate's own tests cover the failure
+/// paths too; what only this side can supply is a live WebSocket endpoint.
+void main() {
+  final libraryPath = _findNativeLibrary();
+  if (libraryPath == null) {
+    group('relay probe', skip: 'native library not built', () {
+      test('needs cargo build --manifest-path rust/Cargo.toml', () {});
+    });
+    return;
+  }
+
+  setUpAll(() async {
+    await RustLib.init(externalLibrary: ExternalLibrary.open(libraryPath));
+  });
+
+  group('RustRelayBackend.probe', () {
+    test('succeeds against a live local WebSocket endpoint', () async {
+      // Arrange — a WebSocket server on 127.0.0.1; the probe does not care
+      // about the scheme, only the notifier's validator does, so ws:// keeps
+      // TLS out of the test.
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final sockets = <WebSocket>[];
+      server.listen((request) async {
+        final ws = await WebSocketTransformer.upgrade(request);
+        sockets.add(ws);
+        ws.listen((_) {});
+      });
+      addTearDown(() async {
+        for (final ws in sockets) {
+          await ws.close();
+        }
+        await server.close(force: true);
+      });
+
+      // Act
+      final reachable = await RustRelayBackend.probe(
+        'ws://127.0.0.1:${server.port}',
+        timeout: const Duration(seconds: 5),
+      );
+
+      // Assert
+      expect(reachable, isTrue);
+    });
+
+    test('returns false when the URL cannot even be parsed', () async {
+      // Act — unterminated IPv6 literal: rejected before any socket exists
+      final reachable = await RustRelayBackend.probe(
+        'ws://[::1',
+        timeout: const Duration(seconds: 5),
+      );
+
+      // Assert
+      expect(reachable, isFalse);
+    });
+
+    test('reports a refused connection as unreachable, promptly', () async {
+      // Arrange — port 1 on loopback: privileged, nothing listens there.
+      // Regression guard inherited from the Dart-era probe: this path used to
+      // hang forever behind the "Adding…" spinner. The probe must return
+      // false on its own; if a hang comes back, the test-level timeout fails.
+      final reachable = await RustRelayBackend.probe(
+        'ws://127.0.0.1:1',
+        timeout: const Duration(seconds: 5),
+      );
+
+      // Assert
+      expect(reachable, isFalse);
+    }, timeout: const Timeout(Duration(seconds: 15)));
+
+    test('times out against a socket that never completes the handshake',
+        () async {
+      // Arrange — a TCP listener nobody accepts from: the kernel completes
+      // the TCP handshake out of the backlog and the WebSocket upgrade is
+      // never answered, so the probe's own timeout is the only way out. A
+      // short timeout keeps the test cheap; the production value is the
+      // notifier's business, not the probe's.
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final held = <Socket>[];
+      server.listen(held.add);
+      addTearDown(() async {
+        for (final socket in held) {
+          socket.destroy();
+        }
+        await server.close();
+      });
+
+      // Act
+      final reachable = await RustRelayBackend.probe(
+        'ws://127.0.0.1:${server.port}',
+        timeout: const Duration(seconds: 2),
+      );
+
+      // Assert
+      expect(reachable, isFalse);
+    }, timeout: const Timeout(Duration(seconds: 15)));
+  });
+
+  group('RelayConfigNotifier.testRelayConnectivity', () {
+    test('reaches the Rust probe end to end', () async {
+      // Arrange — the notifier's seam, unfaked: the same call addRelay makes
+      // must land in the crate and come back true against a live endpoint.
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final sockets = <WebSocket>[];
+      server.listen((request) async {
+        final ws = await WebSocketTransformer.upgrade(request);
+        sockets.add(ws);
+        ws.listen((_) {});
+      });
+      addTearDown(() async {
+        for (final ws in sockets) {
+          await ws.close();
+        }
+        await server.close(force: true);
+      });
+      final notifier = RelayConfigNotifier(
+          RelayConfigService(secureStorage: InMemorySecureStorage()));
+      await pumpEventQueue();
+
+      // Act
+      final reachable =
+          await notifier.testRelayConnectivity('ws://127.0.0.1:${server.port}');
+
+      // Assert
+      expect(reachable, isTrue);
+    });
+  });
+}
+
+String? _findNativeLibrary() {
+  final name = Platform.isMacOS
+      ? 'librust_lib_choke.dylib'
+      : Platform.isWindows
+          ? 'rust_lib_choke.dll'
+          : 'librust_lib_choke.so';
+
+  for (final profile in ['debug', 'release']) {
+    final path = 'rust/target/$profile/$name';
+    if (File(path).existsSync()) return path;
+  }
+  return null;
+}


### PR DESCRIPTION
## The problem

The one WebSocket Dart still opened was `testRelayConnectivity` in `RelayConfigNotifier`: a raw `web_socket_channel` handshake used by Settings to vet a relay URL before saving it. Everything else relay-shaped already goes through the Rust crate — this was the last Dart-side relay connection in the app, and the reason `web_socket_channel` was still a direct dependency.

## What moves where

**Rust** (`rust/src/api/relay.rs`): a new `relay_probe(url, timeout_ms) -> bool`. It runs on a **throwaway `nostr-sdk` client**, never the app's pool: the candidate URL joins no registry, inherits none of the pool's subscriptions, and `shutdown` reaps the throwaway's tasks whichever way the probe went. An unparseable URL answers `false` rather than erroring — "can this be my relay?" has exactly two answers.

**Dart**: `RustRelayBackend.probe(url, timeout:)` is the services-layer wrapper (static, because it deliberately does not touch the backend's pool), and `testRelayConnectivity` becomes a one-line delegation to it. The method stays on the notifier because it is the seam the tests already override (`TestableRelayConfigNotifier`) — none of the add-relay tests change. The old 5-second timeout survives as `RelayConfigNotifier.probeTimeout`.

**Gone**: `web_socket_channel` as a direct dependency, and the hand-rolled close-quietly machinery that existed to keep a half-open socket from hanging `addRelay` behind the "Adding…" spinner.

## Semantics preserved, deliberately

The old probe reported `true` on a completed WebSocket handshake — the `["REQ","test",{}]` it sent was fire-and-forget; no response was ever awaited. `relay_probe` keeps exactly that bar (handshake completes within the timeout), so no URL that used to be accepted is now rejected, or vice versa.

## Tests

The socket-level tests move with the probe, twice over:

- **Crate-side** (`cargo test`, 3 new): garbage URL, refused port, and a TCP listener that never answers the upgrade — the failure paths, including the two regression guards for the old hang. Needs a tiny `[dev-dependencies]` tokio addition for `#[tokio::test]`.
- **Dart-side** (`test/services/nostr/relay/rust_relay_probe_test.dart`, tagged `rust`, 5 new): the same cases against the real native library, plus the one thing only Dart can supply cheaply — a live loopback WebSocket endpoint for the success path — and an end-to-end check that `testRelayConnectivity` reaches the crate. Loopback only; nothing leaves the machine.
- The old socket tests in `relay_config_provider_test.dart` are removed in favour of the above (they would otherwise call into an uninitialized binding); a comment there points at the new file.

Bindings regenerated with `flutter_rust_bridge_codegen` 2.12.0.

## Checks

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: **13/13** (3 new)
- `flutter analyze`: no new issues (pre-existing infos unchanged)
- `flutter test`: **681/681**
- `flutter test --tags rust`: **59/59** (5 new)

Related: the AGENTS.md rule on the branch `claude/8-vs-10-segundos-1a8lgm` names this probe as the one known Dart-side networking deviation — once this merges, that note can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWCRAtGgQ2WkLB1YQsi9SF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWCRAtGgQ2WkLB1YQsi9SF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relay connectivity probing with a five-second timeout.
  * Relay checks now return clear success or failure results for invalid, refused, or slow connections.

* **Bug Fixes**
  * Improved handling of relay handshake timeouts and failed connections.
  * Ensured temporary connectivity checks close cleanly.

* **Tests**
  * Added coverage for successful probes, invalid URLs, refused connections, timeouts, and notifier integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->