### PR TITLE
docs: make the Rust boundary a binding rule in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,10 @@ cargo test --manifest-path rust/Cargo.toml
    `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`.
 5. Push and open a PR. On merge, only the tests re-run on `main`; the APK build
    runs on PRs. Releases are built from `v*` tags by `.github/workflows/release.yml`.
+6. **Agents: subscribe to the PR you just opened** (`subscribe_pr_activity`), and
+   stay subscribed until it is merged or closed. Opening a PR is not the end of
+   the task — CI failures and review comments on it are yours to drive to green
+   or to answer, without waiting to be asked.
 
 All commits, branches, PRs, and issues are written in **English** (see the top
 of this file).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ Rules for agents:
 Known deviation (do not copy): `testRelayConnectivity` in
 `lib/features/settings/providers/relay_config_provider.dart` opens a raw
 WebSocket from Dart to health-check a relay URL before saving it. It is the
-only Dart-side relay connection in the app, it should eventually move into the
-crate, and it is **not** a precedent for new Dart-side networking.
+only Dart-side relay connection in the app and it is **not** a precedent for
+new Dart-side networking. PR #158 moves it into the crate (`relay_probe`);
+once that merges, delete this paragraph.
 
 ## Project Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,41 @@ the l10n system (`lib/l10n/*.arb`) and legitimately contains other languages
 (English, Spanish, Portuguese, Japanese). Everything a developer writes stays in
 English regardless of the contributor's native language.
 
+## Sensitive code lives in Rust (non-negotiable)
+
+Dart is for UI and state. **Everything security-sensitive or protocol-critical
+is implemented in the Rust crate** (`rust/`) and reached only through the
+generated `flutter_rust_bridge` bindings (`lib/src/rust/`):
+
+- **Cryptography** — key generation, public-key derivation, event signing and
+  verification, NIP-19 (`npub`/`nsec`) encoding and decoding
+  (`rust/src/api/crypto.rs`)
+- **Nostr protocol** — event ids, serialization, subscriptions, publishing
+- **Relay networking** — every WebSocket a relay sees is opened by the Rust
+  relay pool (`rust/src/api/relay.rs`), never by Dart
+
+Rules for agents:
+
+1. **Never implement crypto in Dart** — no signing, no hashing keys, no bech32,
+   not even "temporarily". Call the `NostrCrypto` interface
+   (`lib/services/nostr/crypto/`), which is backed by `RustNostrCrypto`.
+2. **Never open connections to relays from Dart.** Relay traffic goes through
+   the `NostrRelayBackend` interface (`lib/services/nostr/relay/`), backed by
+   `RustRelayBackend`.
+3. **Never add Dart dependencies for crypto or Nostr networking** to
+   `pubspec.yaml`. If a capability is missing, extend the Rust crate under
+   `rust/src/api/`, regenerate the bindings, and expose it through the existing
+   Dart interfaces.
+4. The Dart interfaces are the seam: app code talks to `NostrCrypto` /
+   `NostrRelayBackend`, never to a crypto library or a socket directly. New
+   sensitive capability = new method on the interface + Rust implementation.
+
+Known deviation (do not copy): `testRelayConnectivity` in
+`lib/features/settings/providers/relay_config_provider.dart` opens a raw
+WebSocket from Dart to health-check a relay URL before saving it. It is the
+only Dart-side relay connection in the app, it should eventually move into the
+crate, and it is **not** a precedent for new Dart-side networking.
+
 ## Project Overview
 
 Choke is a modern decentralized BJJ (Brazilian Jiu-Jitsu) match scoring and
@@ -158,6 +193,8 @@ cargo test --manifest-path rust/Cargo.toml
 - Match data is published as Nostr addressable events, kind `31415`.
 - Key handling, NIP-19, signing, and the relay pool all live in the Rust crate —
   reach them through the generated bindings, never reimplement crypto in Dart.
+  See [Sensitive code lives in Rust](#sensitive-code-lives-in-rust-non-negotiable)
+  at the top of this file — those rules are binding.
 
 ## Security
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ generated `flutter_rust_bridge` bindings (`lib/src/rust/`):
   (`rust/src/api/crypto.rs`)
 - **Nostr protocol** — event ids, serialization, subscriptions, publishing
 - **Relay networking** — every WebSocket a relay sees is opened by the Rust
-  relay pool (`rust/src/api/relay.rs`), never by Dart
+  relay pool (`rust/src/api/relay.rs`), never by Dart (one deviation exists
+  today; it is named below, and it is being removed rather than extended)
 
 Rules for agents:
 


### PR DESCRIPTION
Docs only — `AGENTS.md`, +42 lines, no code touched.

## Why

The rule "crypto and the relay pool live in Rust, Dart is UI" is how the app is actually built, but it was written down in one line buried in the *Nostr Integration* section near the bottom: *"never reimplement crypto in Dart"*. That line says nothing about networking, nothing about dependencies, and sits far below where an agent stops reading.

I audited the code before writing any of this, and the codebase does hold the line:

- `rust/src/api/crypto.rs` owns key generation, pubkey derivation, signing, verification and NIP-19; `rust/src/api/relay.rs` owns the relay pool
- Dart talks to `NostrCrypto` and `NostrRelayBackend`, whose only implementations are `RustNostrCrypto` and `RustRelayBackend` — both thin wrappers over the generated bindings
- no crypto library in `pubspec.yaml`, no signing/hashing/bech32 implemented in Dart

So this PR does not change any rule. It writes down the one that is already being followed, in the place agents read first.

## What it adds

**A top-level section, "Sensitive code lives in Rust (non-negotiable)"**, placed right after the English-only rule, with four concrete prohibitions: no crypto in Dart, no relay connections from Dart, no Dart dependencies for crypto or Nostr networking, and the note that the way to add a sensitive capability is a new Rust function plus a method on the existing interface — not a Dart shortcut.

**The one known deviation, named explicitly** so nobody cites it as precedent: `testRelayConnectivity` opening a raw WebSocket to health-check a relay URL. It points at #158, which moves that probe into the crate, and says to delete the paragraph once #158 merges. If #158 lands first I will drop it here before merging.

**Two smaller edits**: the old *Nostr Integration* line now points at the new section, and the git workflow gains a step saying agents stay subscribed to a PR they open until it merges or closes — CI failures and review comments on it are theirs to drive to green or answer.

## Note on the branch name

`claude/8-vs-10-segundos-1a8lgm` was auto-generated from the question that started the session (about the 8-vs-10-second backstop in #155) and is in Spanish, which the repo's own English-only rule would not allow if it were mine to choose. The commits, the content and this description are all English. Happy to re-push under a clean name if you would rather the branch match the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWCRAtGgQ2WkLB1YQsi9SF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWCRAtGgQ2WkLB1YQsi9SF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added contributor guidance for handling security-sensitive and Nostr protocol functionality.
  - Clarified approved implementation boundaries and integration requirements.
  - Documented known relay connectivity considerations and ongoing pull request review expectations.
  - No changes were made to exported APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->