### PR TITLE
docs: the relay-networking rule has no exceptions left

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ generated `flutter_rust_bridge` bindings (`lib/src/rust/`):
   (`rust/src/api/crypto.rs`)
 - **Nostr protocol** — event ids, serialization, subscriptions, publishing
 - **Relay networking** — every WebSocket a relay sees is opened by the Rust
-  relay pool (`rust/src/api/relay.rs`), never by Dart (one deviation exists
-  today; it is named below, and it is being removed rather than extended)
+  relay pool (`rust/src/api/relay.rs`), never by Dart. Including the
+  connectivity probe Settings runs before saving a relay URL: that is
+  `relay_probe`, on a throwaway client, and it was the last exception
 
 Rules for agents:
 
@@ -52,12 +53,9 @@ Rules for agents:
    `NostrRelayBackend`, never to a crypto library or a socket directly. New
    sensitive capability = new method on the interface + Rust implementation.
 
-Known deviation (do not copy): `testRelayConnectivity` in
-`lib/features/settings/providers/relay_config_provider.dart` opens a raw
-WebSocket from Dart to health-check a relay URL before saving it. It is the
-only Dart-side relay connection in the app and it is **not** a precedent for
-new Dart-side networking. PR #158 moves it into the crate (`relay_probe`);
-once that merges, delete this paragraph.
+There are no deviations. The rule above describes the code as it is, not a
+direction it is heading in, so a Dart-side socket or crypto call is a bug
+rather than a precedent.
 
 ## Project Overview
 


### PR DESCRIPTION
Docs only — `AGENTS.md`, +6 −8. The follow-up #158 asked for.

## Why now

`AGENTS.md` carried two texts about the one place Dart still opened a socket to a relay, and both named the event that would retire them:

- the parenthetical on the **Relay networking** bullet — *"(one deviation exists today; it is named below, and it is being removed rather than extended)"*
- the **Known deviation** paragraph about `testRelayConnectivity`, ending *"PR #158 moves it into the crate (`relay_probe`); once that merges, delete this paragraph."*

#158 merged. Verified against the tree rather than taken on trust: `grep` for `WebSocketChannel` / `web_socket_channel` across `lib/` and `pubspec.yaml` returns nothing outside the generated bindings.

## What changes

The bullet now says the probe is **covered**, not excepted:

```
- **Relay networking** — every WebSocket a relay sees is opened by the Rust
  relay pool (`rust/src/api/relay.rs`), never by Dart. Including the
  connectivity probe Settings runs before saving a relay URL: that is
  `relay_probe`, on a throwaway client, and it was the last exception
```

Naming it matters: "check whether this URL answers" is the obvious reason to reach for a Dart socket, and an agent that does not know the crate already does it will write one.

The deviation paragraph is replaced by a line saying there are none, and that the rule describes the code as it is rather than a direction of travel — so a Dart-side socket or crypto call is a bug, not a precedent.

No CI runs on this: `rust.yml`'s path filters do not match `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWCRAtGgQ2WkLB1YQsi9SF

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWCRAtGgQ2WkLB1YQsi9SF)_