### PR TITLE
docs: the shared-match-links spec describes what shipped, and the gap it left

### DIFF
--- a/docs/specs/shared-match-links.md
+++ b/docs/specs/shared-match-links.md
@@ -1,7 +1,11 @@
 # Shared Match Links — Specification
 
-**Status:** Agreed — ready to implement. Nothing here is built yet.
+**Status:** Shipped, on the spectator surfaces only. Steps 1–4 of §9.3 are on
+`main` (#154, #155, #157), and choke-scoreboard's reader is on its own (#36, #38).
+**What is not built:** §5.3 — an organizer still cannot share their own match
+from anywhere they already are. §9.4 is the list of what is left.
 **Created:** 2026-07-31
+**Last revised:** 2026-08-01
 **Applies to:** choke (Flutter app) and choke-scoreboard (web board)
 **Companion document:** [`docs/deep-links.md`](../deep-links.md) — the existing board-level link
 
@@ -58,8 +62,8 @@ A link carrying `npub` but no `match` is a **board link** and keeps its current
 behaviour exactly. A link carrying `match` without a readable `npub` is broken —
 an id alone names nothing, because it is only unique within one author's events.
 
-The `pubkey` alias that used to sit beside `npub` is being removed separately;
-this spec assumes it is gone and names one parameter only.
+The `pubkey` alias that used to sit beside `npub` was removed separately (#153),
+leaving the single `kSharePubkeyParam` this section names.
 
 ### 2.1 Grammar of `match`
 
@@ -152,10 +156,12 @@ reaches the right organizer, one tap from the right match.
 The web board behaves the same way for a viewer on a cached bundle — with one
 caveat that is a **known limitation, not a clean fallback**. An older bundle
 opens the organizer's board and leaves `?match=…` sitting in the address bar,
-because `stripSharedPubkeyFromUrl` removes only the pubkey (§2.5). Refreshing or
+because the bundle it is running strips only the pubkey (§2.5). Refreshing or
 forwarding from that address bar yields a link carrying `match` and no `npub` —
-the broken form. Landing on the board is right; the URL left behind is not, and
-stays wrong until the strip fix of §2.5 ships.
+the broken form. Landing on the board is right; the URL left behind is not.
+
+The strip fix of §2.5 has shipped, so this now describes only *cached* bundles,
+and it ages out with them rather than needing further work.
 
 No version of this link produces an *error* on an old client, which is the
 property that makes it shippable. That is a weaker claim than "degrades
@@ -175,25 +181,25 @@ query string, and by then old links are in the wild.
 `match=` says what it names, and costs nothing today because nothing has shipped
 yet. **This is the last cheap moment to choose it.**
 
-Note the existing precedent runs the other way: `npub` and `pubkey` are both
-accepted (`kSharePubkeyParams`), but that pair exists to absorb historical drift
-between two readers, not because two names were ever wanted. A second alias for
-`match` should not be added.
+Note the precedent that existed when this was written ran the other way: `npub`
+and `pubkey` were both accepted, a pair that absorbed historical drift between
+two readers rather than two names anybody wanted. It has since been removed
+(#153). A second alias for `match` should not be added.
 
 ### 2.5 Both parameters are stripped together, or neither
 
-The web board wipes the pubkey from the address bar once it has been applied
-(`stripSharedPubkeyFromUrl` in choke-scoreboard's `share-link.ts`), so a later
-refresh does not re-apply a link the viewer has since navigated away from.
+**Shipped** in choke-scoreboard's #36. Recorded here because it is a contract
+obligation, not a web implementation detail: the string a viewer copies out of
+their address bar is a link that will be sent to somebody else.
 
-It strips only the pubkey params. Left as it is, a resolved match link leaves
-`?match=abcd` alone in the address bar — **which is precisely the broken form
-this contract defines**, since an id alone names nothing. A refresh or a
-copy-and-forward from that address bar then produces a link that cannot work.
+The web board wipes the pubkey from the address bar once it has been applied, so
+a later refresh does not re-apply a link the viewer has since navigated away
+from. Stripping only the pubkey would leave `?match=abcd` alone there — **which
+is precisely the broken form this contract defines**, since an id alone names
+nothing, and a refresh or copy-and-forward from that address bar would produce a
+link that cannot work.
 
-Whatever strips must strip **both or neither**. This is a contract obligation,
-not a web implementation detail, because the string a viewer copies out of their
-address bar is a link that will be sent to somebody else.
+Whatever strips must strip **both or neither**.
 
 ### 2.6 Nostr addressing
 
@@ -242,16 +248,18 @@ particular thing, and showing them a different thing is a lie they cannot catch.
 are fixed here rather than left to each reader:
 
 1. **Settled signal.** A lookup is settled once the subscription reports it has
-   sent everything it holds — NIP-01's `EOSE`. **Neither reader can act on it
-   today, for different reasons**, and both need work:
-   - choke: `NostrRelayBackend` exposes only `Stream<NostrEvent> get events`.
-     The signal never reaches Dart at all, so it has to be plumbed through.
-   - choke-scoreboard: `src/lib/nostr.ts` *does* receive it — `subscribeMany`
-     is given an `oneose` handler — but it only clears the shared `isLoading`
-     store, which an unconditional 10-second `setTimeout` also clears. A caller
-     watching that store cannot tell "the relays answered" from "ten seconds
-     passed", which is precisely the distinction this rule needs. The signal is
-     there; it needs its own channel.
+   sent everything it holds — NIP-01's `EOSE`. The two readers ended up in
+   different places, and the asymmetry is deliberate rather than forgotten:
+   - choke-scoreboard: **done.** `oneose` now has its own channel instead of
+     only clearing the shared `isLoading` store, which an unconditional
+     10-second `setTimeout` also cleared — a caller could not tell "the relays
+     answered" from "ten seconds passed". Landed in its #36.
+   - choke: **not done, and leaning on rule 2 alone.** `NostrRelayBackend`
+     exposes only `Stream<NostrEvent> get events`; the signal never reaches
+     Dart, and plumbing it through the backend and the Rust layer under it is
+     its own change. `kMatchLinkBackstop` in `share_link.dart` says so in
+     place, which is the condition this rule attaches to leaning on the
+     backstop: the code has to admit it out loud.
 2. **Backstop.** Without a settled signal, Pending ends **10 seconds** after the
    link opens. Long enough for a slow relay on venue wifi, short enough that
    nobody concludes the app has hung.
@@ -304,10 +312,10 @@ as `scoreboardMaxAgeSeconds` (choke) and `MATCH_MAX_AGE_SECONDS`
 make a single shared source impractical, so the obligation is a conformance one:
 **neither value moves without the other**.
 
-That obligation is currently unenforced in both repositories — nothing pins the
-number, so a one-character edit on either side would split the contract in half
-in silence. Each repo should assert its own constant equals 86400 in its test
-suite, which is a one-line addition on each side and belongs with this work.
+That obligation is now enforced on both sides: each repo asserts its own
+constant equals 86400 — `test/features/scoreboard/scoreboard_match_link_test.dart`
+here, `src/lib/constants.test.ts` there — so a one-character edit on either side
+fails a test instead of splitting the contract in silence.
 
 Both must also measure it the same way — from the event's `created_at`, against
 the same boundary — so any given link is Resolved in both readers or Unresolved
@@ -330,13 +338,13 @@ choice and not an accident:
   event archive under Event Page Pro). Giving away indefinite match permalinks
   for free spends that before it has been sold.
 
-The web side is already partway there: commit `ab8f81e` gave its expired-match
-page a dead end with an install CTA, reasoned around exactly this — matches age
-out after a day while links do not. Only the wording of *why* the match is gone
-needs to change there. Note also that its existing `match.notFoundBody` string
-("This match may not exist or hasn't been loaded yet") is currently doing the
-work of Pending *and* Unresolved at once — the very ambiguity §3.1 exists to
-remove. Implementing this replaces one string with two, rather than adding one.
+The web side was already partway there when this was written: commit `ab8f81e`
+gave its expired-match page a dead end with an install CTA, reasoned around
+exactly this — matches age out after a day while links do not. Its
+`match.notFoundBody` string ("This match may not exist or hasn't been loaded
+yet") was doing the work of Pending *and* Unresolved at once, the very ambiguity
+§3.1 exists to remove; #36 split it in two. This app says the same thing in
+`scoreboardMatchPending*` and `scoreboardMatchUnresolved*`.
 
 What this obliges: the Unresolved state must say the match *may have ended some
 time ago*, not merely that it does not exist. A recipient opening yesterday's
@@ -388,9 +396,20 @@ do the credit's job again, with more clutter, on the one surface that can least
 afford it. A venue-facing code belongs to the "venue mode" idea in the business
 plan (§9.1), not here.
 
-### 5.3 The organizer, when the match starts — later, same plumbing
+### 5.3 The organizer, when the match starts — still not built
 
-Not in this change, and noted so it is not re-derived later.
+Not in the change that shipped §5.1 and §5.2, and still the gap. It is worth
+being blunt about how the gap reads from inside the app, because "steps 1–4 are
+done" hides it:
+
+**An organizer cannot share their own match from anywhere they already are.**
+Home builds its cards without `onShare`, and `MatchControlScreen` — the screen
+somebody refereeing is actually looking at — offers nothing. Both share
+affordances live on the spectator board and are gated on a *watched* pubkey
+(`onShare` is null while `watchedHex` is), and the Scoreboard tab does not
+prefill the user's own key. So the only route to sharing your own fight is to
+paste your own npub into the tab meant for following somebody else. Nobody will
+find that, and nobody should have to.
 
 The peak-intent moment is the organizer's: a fight has just been created, the
 people who care are in the room or waiting on their phones, and ten minutes
@@ -400,8 +419,10 @@ organizer can project the QR at the venue"* — and that bullet has sat unbuilt
 because **it was waiting for this spec**: "share when creating a match" only
 means something once a match is a shareable thing.
 
-Once `MatchCard.onShare` and the match URL builder exist, wiring the home feed
-and the creation hand-off is small. That is where the QR belongs.
+`MatchCard.onShare`, `matchShareUrl` and `shareMatchLink` now all exist, so
+wiring the home feed and the creation hand-off is small — the plumbing this
+bullet was waiting on is built. That is where the QR belongs, and it is the
+next thing worth doing here.
 
 ### 5.4 Two share actions, two different links
 
@@ -423,14 +444,15 @@ end.
 The plumbing exists and is shared: `showQrDialog` in
 `lib/shared/widgets/qr_dialog.dart`, the share-sheet call with its
 `PlatformException` handling and `shareFailed` snackbar, and `liveBoardShareUrl`
-in `share_link.dart`. This adds a match URL builder beside that last one and
-reuses the rest.
+in `share_link.dart`. `matchShareUrl` went in beside that last one and
+`shareMatchLink` reuses the rest — the one share path both surfaces call.
 
 ### 5.6 Open question: chrome on a board that gets projected
 
-The wall board is projected onto a screen at a venue. It already carries a Back
-button permanently; §5.2 adds a second glyph beside it. Both are controls for
-whoever holds the phone, and neither means anything to a room.
+Still open, and now concrete rather than anticipated: the wall board is
+projected onto a screen at a venue, it already carried a Back button
+permanently, and §5.2 has since put a second glyph beside it. Both are controls
+for whoever holds the phone, and neither means anything to a room.
 
 The class already describes itself as asking for landscape "the way a video
 player does". The rest of that pattern fits: fade the chrome layer out after a
@@ -483,14 +505,22 @@ they must leave deliberately.
 
 ## 8. Acceptance
 
-- [ ] A link with `npub` + `match` opens that match directly, in the app and on the web.
-- [ ] A link with `npub` only behaves exactly as it does today (regression).
-- [ ] An installed **v2.0.0** app given a `match` link opens the board, not an error.
-- [ ] The recipient never sees "not available" before the feed has had a chance to answer.
-- [ ] An id that never arrives ends in a state that says so and mentions that the match may have ended.
-- [ ] A link to another match on the board already being watched navigates to it.
-- [ ] A link to the match already on screen does nothing.
-- [ ] A referee scoring a live match is not navigated away.
+Every box is checked against a test that pins it, named so the claim can be
+re-checked rather than trusted.
+
+- [x] A link with `npub` + `match` opens that match directly, in the app and on the web — `share_link_test.dart` "reads the link matchShareUrl actually builds", "asks for the match the link named"; web side in its #36.
+- [x] A link with `npub` only behaves exactly as it does today (regression) — `share_link_test.dart` "an empty match is no match, and leaves a board link intact", "a board link afterwards asks for no match".
+- [x] An installed **v2.0.0** app given a `match` link opens the board, not an error — by construction (§2.3): the parameter is ignored by a reader that does not know it.
+- [x] The recipient never sees "not available" before the feed has had a chance to answer — `scoreboard_match_link_test.dart` "waits, rather than saying the match is not there".
+- [x] An id that never arrives ends in a state that says so and mentions that the match may have ended — same file, "says the match may have ended once the backstop expires"; `scoreboardMatchUnresolvedBody` in all four locales.
+- [x] A link to another match on the board already being watched navigates to it — same file, "opens a different match on the board already watched".
+- [x] A link to the match already on screen does nothing — same file, "does nothing at all when the same link arrives again".
+- [x] A referee scoring a live match is not navigated away — `share_link_test.dart` "does not tear a guarded screen away from the user", untouched by this work.
+
+Not an acceptance criterion, and the reason §5.3 is still open: **none of the
+above is reachable by an organizer sharing their own match.** The list above
+tests what the link does once somebody sends one, not whether the person with
+the most reason to send one can.
 
 ---
 
@@ -535,18 +565,28 @@ So: parse first, resolve second, offer third.
 
 ### 9.3 Sequence
 
-| # | Step | Notes |
+| # | Step | Landed | Notes |
+|---|---|---|---|
+| 1 | `kShareMatchParam`, `matchShareUrl(npub, matchId)`, and `SharedMatch` returned by `readShareLink` | ✅ #154 | Pure functions, no UI. Cheapest step and the one everything else rests on. |
+| 2 | `openShareLink` handles `SharedMatch`, and the stack-clearing condition inverts per §6.1 | ✅ #154 | The referee protection of §6.2 kept passing untouched. |
+| 3 | Pending / Resolved / Unresolved on the read-only match view (§3.1) | ✅ #155 | Leans on the backstop alone, per §3.1 rule 1. |
+| 4 | `MatchCard.onShare` (§5.1) and the top-right icon (§5.2), plus their strings in all four locales | ✅ #157 | Spectator surfaces only — see §5.3 and §9.4. |
+
+The ordering constraint of §9.2 held: choke-scoreboard's reader (#36) landed
+alongside steps 1–3, before either repo offered a link carrying `match=`.
+
+### 9.4 What is left
+
+In the order it is worth doing.
+
+| # | Work | Why it is still open |
 |---|---|---|
-| 1 | `kShareMatchParam`, `matchShareUrl(npub, matchId)`, and `SharedMatch` returned by `readShareLink` | Pure functions, no UI. Cheapest step and the one everything else rests on. Extend `test/services/deep_links/share_link_test.dart` rather than starting a new file. |
-| 2 | `openShareLink` handles `SharedMatch`, and the stack-clearing condition inverts per §6.1 | Extend the existing tests; do not rewrite around them. The referee protection of §6.2 must keep passing untouched. |
-| 3 | Pending / Resolved / Unresolved on the read-only match view (§3.1) | The hard part, and the only step with real design left in it. Do not start it in the same change as step 4. |
-| 4 | `MatchCard.onShare` (§5.1) and the top-right icon (§5.2), plus their strings in all four locales | Small once 1–3 exist, and pointless before them. |
+| 5 | **§5.3 — the organizer's share, with the QR.** `MatchCard.onShare` on the home feed, and the hand-off when a match is created. | The gap that matters: today the only path to sharing your own match is pasting your own npub into the spectator tab. Every piece it needs now exists. |
+| 6 | **§3.1 rule 1 — plumb `EOSE` through `NostrRelayBackend`.** | Pending ends on a 10-second backstop with no settled signal. Correct per the spec, and coarser than the web reader, which has had its own channel since #36. |
+| 7 | **§5.6 — fade the chrome on a projected board.** | Improves what already ships, Back button included. Separable by design. |
 
-Steps 1–2 and step 3 are separable changes. Step 4 must not merge before step 3
-resolves, per §9.2.
-
-Cross-repo: choke-scoreboard's reader should land alongside step 1–2, before
-step 4 in either repo. See its companion doc.
+Not on this list: permanent permalinks (§4), `naddr1…` (§2.6) — both out of
+scope in §10 rather than pending.
 
 ## 10. Out of scope
 


### PR DESCRIPTION
## Why

The spec still opened with **"Agreed — ready to implement. Nothing here is built yet"** while steps 1–4 of its own §9.3 were on `main` (#154, #155, #157), and choke-scoreboard's reader had landed on its side (#36, #38). Its web twin was updated in that repo's #37; this is the other half.

## The part that matters

"All four steps done" is true and misleading, which is what prompted this. Both share affordances live on the spectator board and are gated on a **watched** pubkey — `onShare` is null while `watchedHex` is (`scoreboard_screen.dart:415`). The home feed builds its cards without `onShare`, `MatchControlScreen` offers nothing, and the Scoreboard tab does not prefill the user's own key.

So an organizer's only route to sharing their own match is pasting their own npub into the tab meant for following somebody else. §5.3 now says that in those words instead of "not in this change", and a new **§9.4** lists what is left in the order worth doing it: the organizer's share with the QR, then the `EOSE` plumbing (§3.1 rule 1), then the projected-board chrome (§5.6).

## Also brought up to date

- **§8** — every box checked, each against the named test that pins it, so the claim is re-checkable rather than trusted. Plus a closing note that none of it is reachable by an organizer.
- **§3.1 rule 1** — the two readers ended up asymmetric on purpose: the web has its own `oneose` channel (#36), this app leans on `kMatchLinkBackstop` alone and says so in place.
- **§4** — the 86400 assertion is no longer "currently unenforced"; both repos pin it.
- **§2.4 / §2** — the `pubkey` alias is gone (#153).
- **§2.5 / §2.3** — the strip fix shipped, so the leftover-`match=` caveat is about cached bundles, not pending work.

Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJYCWqakkrUjVVT311zVFU