### PR TITLE
feat: share a match from the home feed

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
+import '../../services/deep_links/share_link.dart';
+import '../../services/key_management/key_manager.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
 import '../../shared/widgets/status_filter_bar.dart';
@@ -18,6 +20,10 @@ class HomeScreen extends ConsumerWidget {
     final filteredMatches = ref.watch(filteredMatchListProvider);
     final allMatches = ref.watch(recentMatchListProvider);
     final statusFilter = ref.watch(statusFilterProvider);
+    // `valueOrNull`, not a `when`: the identity is read from storage and the
+    // list must not wait on it. A card that appears before the key does simply
+    // has no share icon for that frame.
+    final npub = ref.watch(npubProvider).valueOrNull;
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final tk = ChokeTokens.of(context);
@@ -103,7 +109,13 @@ class HomeScreen extends ConsumerWidget {
                         MediaQuery.of(context).padding.bottom + 80,
                       ),
                       itemCount: filteredMatches.length,
-                      itemBuilder: (context, index) {
+                      // Deliberately not shadowing `context` with the builder's
+                      // own: the share sheet asks its context for a RenderBox
+                      // to anchor a popover to, and a builder inside a
+                      // ListView hands back a RenderSliverList. The page's
+                      // context is a box, and is the right anchor anyway — the
+                      // sheet belongs to the screen, not to one row of it.
+                      itemBuilder: (_, index) {
                         final match = filteredMatches[index];
                         return Padding(
                           padding: const EdgeInsets.only(bottom: 11),
@@ -120,6 +132,24 @@ class HomeScreen extends ConsumerWidget {
                                 ),
                               );
                             },
+                            // The organizer's own feed, so the link names this
+                            // app's identity: the same icon and the same link
+                            // the scoreboard hands out, offered from the screen
+                            // the person who created the fight is already on.
+                            //
+                            // No npub means no key generated yet, and a link
+                            // with nobody in it names nothing — the card then
+                            // renders exactly as it did before there was a
+                            // share icon at all.
+                            onShare: npub == null
+                                ? null
+                                : () => shareMatchLink(
+                                      context,
+                                      ref,
+                                      npub: npub,
+                                      matchId: match.id,
+                                      logTag: 'HomeScreen',
+                                    ),
                           ),
                         );
                       },
@@ -199,5 +229,4 @@ class HomeScreen extends ConsumerWidget {
       ),
     );
   }
-
 }

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -39,31 +39,44 @@ String matchShareUrl(String npub, String matchId) =>
 
 /// Hand one match to the platform share sheet.
 ///
-/// Two surfaces send a match — a card in the scoreboard list, and the wall
-/// board while it is on screen — and what they send has to be the same thing:
-/// the same npub encoding, the same `&match=` link, and the same pair of
-/// strings, because "watch this fight" is one promise however it was reached.
-/// Written once here, next to [matchShareUrl], so that promise cannot drift
-/// into two slightly different ones.
+/// Three surfaces send a match — a card in the scoreboard list, the wall board
+/// while it is on screen, and a card in the organizer's own home feed — and
+/// what they send has to be the same thing: the same npub encoding, the same
+/// `&match=` link, and the same pair of strings, because "watch this fight" is
+/// one promise however it was reached. Written once here, next to
+/// [matchShareUrl], so that promise cannot drift into three slightly different
+/// ones.
 ///
-/// [watchedHex] is the organizer's key, not the recipient's: an id names
-/// nothing on its own, and it is encoded to an npub here rather than by each
-/// caller. [logTag] is the only thing the two surfaces differ by, and it names
-/// which one in the debug line [shareLink] writes.
+/// The key named is the *organizer's*, never the recipient's — an id names
+/// nothing on its own — and it arrives in whichever form the caller already
+/// holds. Pass [watchedHex] when watching somebody else's board, which is what
+/// the scoreboard has; pass [npub] when it is the app's own identity, which is
+/// what home has (`npubProvider` keeps it encoded). Exactly one of the two.
+/// Requiring hex everywhere would put a decode-then-re-encode on the caller
+/// that already holds the finished thing.
+///
+/// [logTag] is the only other thing the surfaces differ by, and it names which
+/// one in the debug line [shareLink] writes.
 Future<void> shareMatchLink(
   BuildContext context,
   WidgetRef ref, {
-  required String watchedHex,
+  String? watchedHex,
+  String? npub,
   required String matchId,
   required String logTag,
 }) {
+  assert(
+    (watchedHex == null) != (npub == null),
+    'name the organizer once: watchedHex or npub, not both and not neither',
+  );
+
   final l10n = AppLocalizations.of(context);
-  final npub = ref.read(nostrCryptoProvider).npubEncode(watchedHex);
+  final encoded = npub ?? ref.read(nostrCryptoProvider).npubEncode(watchedHex!);
 
   return shareLink(
     context,
     message: l10n.scoreboardShareMatchMessage,
-    url: matchShareUrl(npub, matchId),
+    url: matchShareUrl(encoded, matchId),
     subject: l10n.scoreboardShareMatch,
     logTag: logTag,
   );

--- a/lib/services/deep_links/share_link.dart
+++ b/lib/services/deep_links/share_link.dart
@@ -65,10 +65,15 @@ Future<void> shareMatchLink(
   required String matchId,
   required String logTag,
 }) {
-  assert(
-    (watchedHex == null) != (npub == null),
-    'name the organizer once: watchedHex or npub, not both and not neither',
-  );
+  // Thrown, not asserted: an assert is compiled out of a release build, which
+  // is where this would matter. Naming nobody would otherwise surface as a null
+  // check failing inside the encode below — a crash that says nothing about the
+  // caller — and naming twice would silently pick one.
+  if ((watchedHex == null) == (npub == null)) {
+    throw ArgumentError(
+      'name the organizer once: watchedHex or npub, not both and not neither',
+    );
+  }
 
   final l10n = AppLocalizations.of(context);
   final encoded = npub ?? ref.read(nostrCryptoProvider).npubEncode(watchedHex!);

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:choke/services/wakelock/screen_wakelock.dart';
 import 'package:choke/shared/theme/app_theme.dart';
 
 import '../../support/nostr_fakes.dart';
+import '../../support/share_channel.dart';
 
 /// A NostrService that never reaches a relay, so tapping into the match
 /// control screen cannot try to publish anything.
@@ -94,6 +95,11 @@ void main() {
         // Tapping through to the control screen would otherwise reach a real
         // method channel that nothing answers in a test.
         screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+        // No identity by default, which is what every test here but the
+        // sharing ones is about — and what keeps them looking at the card they
+        // have always looked at. Declared here rather than added later:
+        // updateOverrides can change an override, never add one.
+        npubProvider.overrideWith((ref) async => null),
       ],
     );
   });
@@ -342,5 +348,55 @@ void main() {
     // Assert — the tapped match became the active one and the screen opened
     expect(find.byType(MatchControlScreen), findsOneWidget);
     expect(scope.read(activeMatchProvider)?.id, 'bbbb');
+  });
+
+  group('sharing a match from the feed', () {
+    testWidgets('sends a link naming this app own identity and that match',
+        (tester) async {
+      // Arrange — the organizer's own feed, so the link carries this app's
+      // npub. The card is the one surface the person who created the fight is
+      // already looking at; before this it could only be shared by watching
+      // one's own board from the spectator tab.
+      final calls = mockShareChannel(tester);
+      container.updateOverrides([
+        nostrServiceProvider.overrideWithValue(service),
+        matchControlProvider.overrideWith(
+          (ref) => MatchControlNotifier(
+            _match(id: 'aaaa', status: MatchStatus.inProgress),
+            service,
+          ),
+        ),
+        screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+        npubProvider.overrideWith((ref) async => 'npub1fake'),
+      ]);
+      await container.read(npubProvider.future);
+      await pumpHome(tester);
+      addMatch(_match(id: 'cccd', status: MatchStatus.inProgress));
+      await tester.pump();
+
+      // Act
+      await tester.tap(find.byIcon(Icons.ios_share).first);
+      await tester.pumpAndSettle();
+
+      // Assert — one link, naming the organizer AND the match. Both halves
+      // matter: an id alone names nothing, because ids are only unique within
+      // one author's events.
+      expect(calls, hasLength(1));
+      expect(calls.single['text'], contains('npub=npub1fake'));
+      expect(calls.single['text'], contains('match=cccd'));
+    });
+
+    testWidgets('offers no share icon before an identity exists',
+        (tester) async {
+      // Arrange — no key generated yet, so there is no organizer to name and a
+      // link would name nothing. The card renders as it did before there was a
+      // share icon at all.
+      await pumpHome(tester);
+      addMatch(_match(id: 'cccd', status: MatchStatus.inProgress));
+      await tester.pump();
+
+      // Assert
+      expect(find.byIcon(Icons.ios_share), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Why

The share icon lived only on the spectator board, gated on a **watched** pubkey. So an organizer's only route to sharing their own fight was to paste their own npub into the tab meant for following somebody else — nobody finds that. The moment that matters most, a match just created with people waiting on their phones, had no button at all.

This is `docs/specs/shared-match-links.md` §5.3, minus the QR at match creation.

## What changed

- **`home_screen.dart`** — every card gets `onShare`, naming this app's own identity and that match. `MatchCard.onShare` was built additive for exactly this, so the card itself is untouched: same icon, same link, same strings. What changes is which surface offers it.
- **`shareMatchLink`** — now takes the organizer's key in whichever form the caller already holds: `watchedHex` for the scoreboard, `npub` for home (where `npubProvider` keeps it encoded). Exactly one of the two, asserted. Requiring hex everywhere would have meant decoding the npub to re-encode it a line later.
- **No identity yet → no icon.** A link with nobody in it names nothing; the same rule the scoreboard applies to a board with nobody watched.

## One bug the tests caught

The item builder was shadowing the page `context`. The share sheet asks its context for a `RenderBox` to anchor an iPad popover to, and a builder inside a `ListView` hands back a `RenderSliverList` — a straight `_TypeError` on tap. It now uses the page's context, which is the right anchor anyway: the sheet belongs to the screen, not to one row of it.

## Tests

Two new, in the existing home suite:

- the shared link carries **both** `npub=` and `match=` — an id alone names nothing, since ids are only unique within one author's events
- no share icon before an identity exists

`flutter test`: **708/708**. `flutter analyze`: no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJYCWqakkrUjVVT311zVFU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sharing for match cards when an organizer identity is available.
  * Match links can now be shared using either an encoded identity or a hexadecimal key.
* **Bug Fixes**
  * Match sharing is hidden when no organizer identity is available.
  * Improved share-sheet positioning when sharing from the home screen.
* **Tests**
  * Added coverage for sharing matches and hiding sharing when identity information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->