### PR TITLE
feat: a QR for the organizer's own board, on home

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -5,6 +5,7 @@ import '../../services/deep_links/share_link.dart';
 import '../../services/key_management/key_manager.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
+import '../../shared/widgets/qr_dialog.dart';
 import '../../shared/widgets/status_filter_bar.dart';
 import '../match/create_match_screen.dart';
 import '../match/match_control_screen.dart';
@@ -83,6 +84,22 @@ class HomeScreen extends ConsumerWidget {
                       ],
                     ),
                   ),
+                  // The same code the scoreboard offers, for the board on the
+                  // other side of it: there it hands over the organizer being
+                  // watched, here it hands over this app's own. Same icon,
+                  // same dialog, same strings — a room pointing a camera at it
+                  // cannot tell whose phone is holding it up, and should not
+                  // have to.
+                  //
+                  // Hidden until an identity exists, like the cards' share
+                  // icon: a board link with nobody in it names nothing.
+                  if (npub != null)
+                    IconButton(
+                      onPressed: () => _showQr(context, npub),
+                      tooltip: l10n.showQr,
+                      color: tk.muted,
+                      icon: const Icon(Icons.qr_code_2),
+                    ),
                 ],
               ),
             ),
@@ -158,6 +175,24 @@ class HomeScreen extends ConsumerWidget {
           ],
         ),
       ),
+    );
+  }
+
+  /// This app's own board, as a code for the room.
+  ///
+  /// The organizer holds up or projects it and the crowd points a camera at
+  /// it — nothing typed, no key exchanged. Deliberately the same dialog and the
+  /// same strings the scoreboard uses (`scoreboardQrTitle` / `scoreboardQrHint`)
+  /// rather than new copy: it is the same board link, and the only difference
+  /// is whose. Not the account screen's QR, which carries the raw public key
+  /// for importing an identity — a different thing that happens to be square.
+  void _showQr(BuildContext context, String npub) {
+    final l10n = AppLocalizations.of(context);
+    showQrDialog(
+      context,
+      title: l10n.scoreboardQrTitle,
+      data: liveBoardShareUrl(npub),
+      caption: l10n.scoreboardQrHint,
     );
   }
 

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:choke/features/home/home_screen.dart';
 import 'package:choke/features/home/providers/home_providers.dart';
@@ -9,10 +10,12 @@ import 'package:choke/features/match/match_control_screen.dart';
 import 'package:choke/features/match/models/match.dart';
 import 'package:choke/features/match/providers/match_control_provider.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/deep_links/share_link.dart';
 import 'package:choke/services/key_management/key_manager.dart';
 import 'package:choke/services/nostr/nostr_service.dart';
 import 'package:choke/services/wakelock/screen_wakelock.dart';
 import 'package:choke/shared/theme/app_theme.dart';
+import 'package:choke/shared/widgets/qr_dialog.dart';
 
 import '../../support/nostr_fakes.dart';
 import '../../support/share_channel.dart';
@@ -384,6 +387,38 @@ void main() {
       expect(calls, hasLength(1));
       expect(calls.single['text'], contains('npub=npub1fake'));
       expect(calls.single['text'], contains('match=cccd'));
+    });
+
+    testWidgets('offers this app own board as a code, for the room',
+        (tester) async {
+      // Arrange — the organizer's own identity, so the code carries their
+      // board. The scoreboard's code carries whoever is being watched; this is
+      // the same dialog on the other side of that.
+      container.updateOverrides([
+        nostrServiceProvider.overrideWithValue(service),
+        matchControlProvider.overrideWith(
+          (ref) => MatchControlNotifier(
+            _match(id: 'aaaa', status: MatchStatus.inProgress),
+            service,
+          ),
+        ),
+        screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+        npubProvider.overrideWith((ref) async => 'npub1fake'),
+      ]);
+      await container.read(npubProvider.future);
+      await pumpHome(tester);
+
+      // Act
+      await tester.tap(find.byIcon(Icons.qr_code_2));
+      await tester.pumpAndSettle();
+
+      // Assert — the board link, and the scoreboard's own strings: one dialog,
+      // not two that drifted apart
+      expect(find.byType(QrImageView), findsOneWidget);
+      final dialog = tester.widget<QrDialog>(find.byType(QrDialog));
+      expect(dialog.data, liveBoardShareUrl('npub1fake'));
+      expect(find.text(l10n.scoreboardQrTitle), findsOneWidget);
+      expect(find.text(l10n.scoreboardQrHint), findsOneWidget);
     });
 
     testWidgets('offers no share icon before an identity exists',


### PR DESCRIPTION
## Why

The scoreboard has had a QR since #150, and it hands over **whoever is being watched** — somebody else's board, from somebody else's app. The organizer had no way to project their own. The code that turns a room full of strangers into spectators was reachable from every phone except the one actually running the event.

## What changed

Home's header gets the same icon in the trailing position, opening the **same dialog with the same strings** — `scoreboardQrTitle` and `scoreboardQrHint`, not new copy. It is the same board link and the only difference is whose; a second wording would be two names for one thing.

Deliberately *not* the account screen's QR, which carries the raw public key for importing an identity — a different thing that happens to be square.

Hidden until an identity exists, the rule the cards' share icon already follows: a board link with nobody in it names nothing.

## Tests

One new, beside the home sharing tests: tapping the icon opens a dialog whose `data` is `liveBoardShareUrl(npub)`, carrying the scoreboard's own title and caption — asserted so the two cannot drift into two dialogs.

`flutter test`: **709/709**. `flutter analyze`: no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJYCWqakkrUjVVT311zVFU