### PR TITLE
feat: read an announcement without trusting anything about it

### DIFF
--- a/lib/features/announcements/announcement_publishers.dart
+++ b/lib/features/announcements/announcement_publishers.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+
+import '../../services/nostr/crypto/nostr_crypto.dart';
+
+/// The keys allowed to publish announcements — the whole trust model (§3.1).
+///
+/// A list rather than a single value, and the plural is the point: a hardcoded
+/// singular key that is lost or leaked kills the channel until a Play review
+/// completes, which is measured in days. A list lets a successor key ship
+/// *before* it is needed.
+///
+/// Two rules on what goes in here:
+///
+/// 1. **Not the maintainer's personal key.** A dedicated key, kept offline,
+///    used for nothing else. If the announcement key is also the key that
+///    arbitrates matches, then losing a phone loses both.
+/// 2. **`npub`, never hex.** It is what a human checks against the value
+///    published elsewhere, and every surface in this app speaks `npub`.
+///    Decoding happens in the crate (AGENTS.md), never in Dart.
+///
+/// Empty on purpose: the dedicated offline key does not exist yet, and an
+/// empty allowlist is inert by construction — no authors means no
+/// subscription, so shipping this cannot open a channel nobody can speak on.
+/// Adding the real key is a one-line change here.
+const List<String> kAnnouncementPublishers = <String>[];
+
+/// The hex keys a subscription filter needs, from the npubs in [npubs].
+///
+/// An entry that fails to decode is dropped with a [debugPrint] and the rest
+/// still work: a typo in one constant must not silence the channel (§3.1).
+///
+/// Duplicates are collapsed, so an npub listed twice — or a successor key that
+/// turns out to be the same key — never makes a filter name one author twice.
+List<String> decodeAnnouncementPublishers(
+  NostrCrypto crypto, {
+  List<String> npubs = kAnnouncementPublishers,
+}) {
+  final hex = <String>{};
+  for (final npub in npubs) {
+    final decoded = crypto.npubDecode(npub);
+    if (decoded == null) {
+      // Safe to log: this is a public key, and a wrong one at that.
+      debugPrint('Announcements: dropping undecodable publisher "$npub"');
+      continue;
+    }
+    hex.add(decoded);
+  }
+  return List.unmodifiable(hex);
+}

--- a/lib/features/announcements/models/announcement.dart
+++ b/lib/features/announcements/models/announcement.dart
@@ -1,0 +1,308 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../../../services/nostr/nostr_service.dart'
+    show NostrEvent, addressableSupersedes;
+import 'app_version.dart';
+
+/// The announcement kind: addressable, adjacent to the match kind 31415.
+const int kAnnouncementKind = 31416;
+
+/// The only content schema version this build understands. An event with any
+/// other `v` is ignored rather than rendered best-effort (§2.2).
+const int kAnnouncementSchemaVersion = 1;
+
+/// Exactly the locales the app ships. An announcement must carry all four and
+/// no others: there is no fallback, because a fallback is a bug that ships
+/// quietly — the reader gets a language they did not choose and nobody finds
+/// out (§2.2). Pinned to `AppLocalizations.supportedLocales` by test.
+const Set<String> kAnnouncementLocales = {'en', 'es', 'ja', 'pt'};
+
+const int kAnnouncementTitleMaxLength = 80;
+const int kAnnouncementBodyMaxLength = 500;
+
+/// One locale's copy.
+@immutable
+class AnnouncementText {
+  final String title;
+  final String body;
+
+  const AnnouncementText({required this.title, required this.body});
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnnouncementText && other.title == title && other.body == body;
+
+  @override
+  int get hashCode => Object.hash(title, body);
+}
+
+/// Which revision of an announcement this is.
+///
+/// Both halves matter. `created_at` alone does not order two events — a
+/// correction republished within the same second is an ordinary outcome of
+/// fixing a typo and hitting publish, and with a bare timestamp the winner is
+/// whichever relay answered first, which is two phones showing two different
+/// texts of the same announcement (§3.3).
+@immutable
+class AnnouncementRevision {
+  final int createdAt;
+  final String eventId;
+
+  const AnnouncementRevision({required this.createdAt, required this.eventId});
+
+  /// Whether this revision replaces [held].
+  ///
+  /// Delegates to [addressableSupersedes] rather than restating NIP-01's rule:
+  /// there is one definition of "which is newer" in this app, and two would be
+  /// exactly how they stop agreeing.
+  bool supersedes(AnnouncementRevision held) => addressableSupersedes(
+        arrivingCreatedAt: createdAt,
+        arrivingId: eventId,
+        heldCreatedAt: held.createdAt,
+        heldId: held.eventId,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnnouncementRevision &&
+      other.createdAt == createdAt &&
+      other.eventId == eventId;
+
+  @override
+  int get hashCode => Object.hash(createdAt, eventId);
+
+  @override
+  String toString() => 'AnnouncementRevision($createdAt, $eventId)';
+}
+
+/// A validated announcement: everything §2 requires, and nothing a relay could
+/// have made up.
+///
+/// Construction only happens through [tryParse], so holding one of these means
+/// the schema, the locales, the lengths and the version bounds already checked
+/// out. Whether it is *fresh*, *unexpired* and *signed by an allowed key* is
+/// not this class's business — that is §3, enforced by the service above it.
+@immutable
+class Announcement {
+  /// `31416:<publisher hex>:<d>` — the addressable identity, which is what
+  /// everything downstream keys by. Never the `d` alone: the allowlist is a
+  /// list, so two keys can pick the same `d` (§3.3).
+  final String address;
+
+  /// Hex pubkey of the key that signed it.
+  final String publisher;
+
+  /// The `d` tag: the sender's id for this announcement.
+  final String announcementId;
+
+  final AnnouncementRevision revision;
+
+  /// NIP-40 expiry, unix seconds. Required by §2.
+  final int expiration;
+
+  /// All four locales, always. See [kAnnouncementLocales].
+  final Map<String, AnnouncementText> locales;
+
+  /// The single action link, or null — absent, or present but not something
+  /// this app will open (§7: a bad url is dropped, the announcement still
+  /// renders).
+  final Uri? url;
+
+  /// Inclusive lower bound on the app version this is for.
+  final AppVersion? minVersion;
+
+  /// **Exclusive** upper bound: `max_version: 2.1` is the announcement that
+  /// 2.1 is out, and the people already on 2.1 are exactly who must not see
+  /// it (§2.1).
+  final AppVersion? maxVersion;
+
+  const Announcement({
+    required this.address,
+    required this.publisher,
+    required this.announcementId,
+    required this.revision,
+    required this.expiration,
+    required this.locales,
+    this.url,
+    this.minVersion,
+    this.maxVersion,
+  });
+
+  int get createdAt => revision.createdAt;
+
+  /// The announcement in [languageCode].
+  ///
+  /// Always resolves for a code the app can render: [tryParse] rejects any
+  /// event whose locale set is not exactly [kAnnouncementLocales], and that
+  /// set is pinned to the app's own locales by test. The guard below is for
+  /// the impossible case only — a missing translation is not worth crashing a
+  /// release build over.
+  AnnouncementText textFor(String languageCode) {
+    final text = locales[languageCode];
+    if (text != null) return text;
+    debugPrint('Announcement: no copy for "$languageCode" in $address');
+    return locales.values.first;
+  }
+
+  /// Whether this announcement targets [appVersion].
+  bool appliesTo(AppVersion appVersion) {
+    if (minVersion != null && appVersion < minVersion!) return false;
+    if (maxVersion != null && appVersion >= maxVersion!) return false;
+    return true;
+  }
+
+  /// The announcement in [event], or null if the event is not a valid one.
+  ///
+  /// Every rejection is silent by design (§4.4): there is nothing a user could
+  /// do about a malformed announcement, and "an announcement failed to parse"
+  /// is itself a message from a source we have not verified. Details go to
+  /// [debugPrint], per the AGENTS.md rule on raw exceptions.
+  static Announcement? tryParse(NostrEvent event) {
+    if (event.kind != kAnnouncementKind) {
+      return _reject(event, 'kind ${event.kind} is not an announcement');
+    }
+
+    final id = _tag(event, 'd');
+    if (id == null || id.isEmpty) return _reject(event, 'no d tag');
+
+    final expirationTag = _tag(event, 'expiration');
+    final expiration =
+        expirationTag == null ? null : int.tryParse(expirationTag);
+    if (expiration == null) return _reject(event, 'no readable expiration');
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(event.content);
+    } catch (e) {
+      return _reject(event, 'content is not JSON: $e');
+    }
+    if (decoded is! Map<String, dynamic>) {
+      return _reject(event, 'content is not a JSON object');
+    }
+
+    if (decoded['v'] != kAnnouncementSchemaVersion) {
+      return _reject(event, 'unknown schema version ${decoded['v']}');
+    }
+
+    final locales = _parseLocales(event, decoded['locales']);
+    if (locales == null) return null;
+
+    // An unreadable bound is a targeting instruction that failed, and showing
+    // the message to everyone is the wrong way to fail it (§2.1).
+    final minTag = _tag(event, 'min_version');
+    final AppVersion? minVersion;
+    if (minTag == null) {
+      minVersion = null;
+    } else {
+      minVersion = AppVersion.tryParse(minTag);
+      if (minVersion == null) {
+        return _reject(event, 'unparseable min_version "$minTag"');
+      }
+    }
+
+    final maxTag = _tag(event, 'max_version');
+    final AppVersion? maxVersion;
+    if (maxTag == null) {
+      maxVersion = null;
+    } else {
+      maxVersion = AppVersion.tryParse(maxTag);
+      if (maxVersion == null) {
+        return _reject(event, 'unparseable max_version "$maxTag"');
+      }
+    }
+
+    return Announcement(
+      address: '$kAnnouncementKind:${event.pubkey}:$id',
+      publisher: event.pubkey,
+      announcementId: id,
+      revision: AnnouncementRevision(
+        createdAt: event.createdAt,
+        eventId: event.id,
+      ),
+      expiration: expiration,
+      locales: Map.unmodifiable(locales),
+      url: _parseUrl(event, decoded['url']),
+      minVersion: minVersion,
+      maxVersion: maxVersion,
+    );
+  }
+
+  /// All four locale blocks, or null if any of them is missing, extra, or
+  /// malformed. One bad block invalidates the whole announcement: the sender
+  /// publishes once, by hand, and a partial render is how they never find out.
+  static Map<String, AnnouncementText>? _parseLocales(
+    NostrEvent event,
+    Object? raw,
+  ) {
+    if (raw is! Map<String, dynamic>) {
+      return _reject(event, 'locales is not an object');
+    }
+    if (raw.length != kAnnouncementLocales.length ||
+        !kAnnouncementLocales.containsAll(raw.keys)) {
+      return _reject(
+        event,
+        'locales are ${raw.keys.toList()}, '
+        'expected exactly ${kAnnouncementLocales.toList()}',
+      );
+    }
+
+    final parsed = <String, AnnouncementText>{};
+    for (final code in kAnnouncementLocales) {
+      final block = raw[code];
+      if (block is! Map<String, dynamic>) {
+        return _reject(event, 'locale "$code" is not an object');
+      }
+
+      final title = _text(block['title'], max: kAnnouncementTitleMaxLength);
+      if (title == null) return _reject(event, 'bad title in "$code"');
+
+      final body = _text(block['body'], max: kAnnouncementBodyMaxLength);
+      if (body == null) return _reject(event, 'bad body in "$code"');
+
+      parsed[code] = AnnouncementText(title: title, body: body);
+    }
+    return parsed;
+  }
+
+  /// A non-empty string of at most [max] characters after trimming, or null.
+  static String? _text(Object? raw, {required int max}) {
+    if (raw is! String) return null;
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty || trimmed.length > max) return null;
+    return trimmed;
+  }
+
+  /// The action link, if it is one this app will open.
+  ///
+  /// Anything else is dropped and the announcement still renders (§7): the
+  /// copy is the message, the link is an extra, and a sender who typo'd a
+  /// scheme should not silence the text as well.
+  static Uri? _parseUrl(NostrEvent event, Object? raw) {
+    if (raw == null) return null;
+    if (raw is! String) {
+      debugPrint('Announcement ${event.id}: url is not a string');
+      return null;
+    }
+
+    final url = Uri.tryParse(raw);
+    if (url == null || url.scheme != 'https' || url.host.isEmpty) {
+      debugPrint('Announcement ${event.id}: dropping url "$raw"');
+      return null;
+    }
+    return url;
+  }
+
+  static String? _tag(NostrEvent event, String name) {
+    for (final tag in event.tags) {
+      if (tag.length > 1 && tag[0] == name) return tag[1];
+    }
+    return null;
+  }
+
+  static Null _reject(NostrEvent event, String why) {
+    debugPrint('Announcement: ignoring event ${event.id} — $why');
+    return null;
+  }
+}

--- a/lib/features/announcements/models/announcement.dart
+++ b/lib/features/announcements/models/announcement.dart
@@ -132,6 +132,30 @@ class Announcement {
 
   int get createdAt => revision.createdAt;
 
+  /// Two announcements are the same one when they are the same revision at the
+  /// same address.
+  ///
+  /// Not a field-by-field comparison, and it does not need to be: everything
+  /// else here is derived from one signed event, and the event id inside
+  /// [revision] commits to that event's contents. Two values that agree on
+  /// address and revision cannot disagree on anything else without the
+  /// signature having been broken first.
+  ///
+  /// Defined at all because a cached announcement and a freshly parsed one are
+  /// different objects, and identity equality would report the two as
+  /// different for no reason a caller could see.
+  @override
+  bool operator ==(Object other) =>
+      other is Announcement &&
+      other.address == address &&
+      other.revision == revision;
+
+  @override
+  int get hashCode => Object.hash(address, revision);
+
+  @override
+  String toString() => 'Announcement($address, ${revision.eventId})';
+
   /// The announcement in [languageCode].
   ///
   /// Always resolves for a code the app can render: [tryParse] rejects any
@@ -211,6 +235,21 @@ class Announcement {
       if (maxVersion == null) {
         return _reject(event, 'unparseable max_version "$maxTag"');
       }
+    }
+
+    // A range that holds nobody is the same class of failure as a bound
+    // nobody can read: the targeting instruction did not work, and the sender
+    // gets no signal either way because nothing is ever shown. The boundary is
+    // `>=` because max_version is exclusive — min and max at the same version
+    // is an empty range, not a single-version one. The publisher tool refuses
+    // this before signing, and refusing it here too is what keeps the two ends
+    // agreeing on what a range means.
+    if (minVersion != null && maxVersion != null && minVersion >= maxVersion) {
+      return _reject(
+        event,
+        'min_version "$minTag" is not below max_version "$maxTag", '
+        'so this announcement targets nobody',
+      );
     }
 
     return Announcement(

--- a/lib/features/announcements/models/app_version.dart
+++ b/lib/features/announcements/models/app_version.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart' show listEquals;
+
+/// A semantic version, as far as announcement targeting needs one.
+///
+/// Two things this parses, and one it deliberately refuses:
+///
+/// - The app's own version, which `package_info_plus` reports as the pubspec
+///   version **without** the build number — `2.0.1`, never `2.0.1+454`.
+/// - A `min_version` / `max_version` bound written by the sender, which may be
+///   shorter (`2.1`) or carry a pre-release suffix (`2.1.0-beta.1`).
+/// - **Build metadata is rejected**, not ignored. Semver excludes it from
+///   precedence, so `2.1.0+454` and `2.1.0` compare equal — accepting the
+///   bound would mean silently dropping the part the sender clearly meant
+///   something by. An unreadable bound invalidates the announcement (§2.1),
+///   which is the loud failure that gets it fixed.
+///
+/// See docs/specs/announcement-channel.md §2.1.
+class AppVersion implements Comparable<AppVersion> {
+  final int major;
+  final int minor;
+  final int patch;
+
+  /// The dot-separated identifiers after `-`, empty for a release version.
+  final List<String> preRelease;
+
+  const AppVersion._(this.major, this.minor, this.patch, this.preRelease);
+
+  static final RegExp _numeric = RegExp(r'^\d+$');
+  static final RegExp _identifier = RegExp(r'^[0-9A-Za-z-]+$');
+
+  /// The version in [raw], or null if it is not one.
+  ///
+  /// Null rather than throwing: every caller of this is reading a value some
+  /// human typed into a tag, which is not a programming error.
+  static AppVersion? tryParse(String raw) {
+    final text = raw.trim();
+    if (text.isEmpty) return null;
+
+    // Build metadata: rejected outright, before anything else can make sense
+    // of the rest. See the class comment.
+    if (text.contains('+')) return null;
+
+    final dash = text.indexOf('-');
+    final core = dash == -1 ? text : text.substring(0, dash);
+    final suffix = dash == -1 ? '' : text.substring(dash + 1);
+
+    final numbers = core.split('.');
+    if (numbers.isEmpty || numbers.length > 3) return null;
+    for (final part in numbers) {
+      if (!_numeric.hasMatch(part)) return null;
+    }
+
+    final List<String> preRelease;
+    if (dash == -1) {
+      preRelease = const [];
+    } else {
+      // A trailing `-` or an empty identifier (`2.1.0-beta..1`) is malformed,
+      // not an empty pre-release.
+      if (suffix.isEmpty) return null;
+      preRelease = suffix.split('.');
+      for (final identifier in preRelease) {
+        if (identifier.isEmpty) return null;
+        if (!_identifier.hasMatch(identifier)) return null;
+      }
+    }
+
+    int at(int index) => index < numbers.length ? int.parse(numbers[index]) : 0;
+
+    return AppVersion._(at(0), at(1), at(2), List.unmodifiable(preRelease));
+  }
+
+  @override
+  int compareTo(AppVersion other) {
+    if (major != other.major) return major.compareTo(other.major);
+    if (minor != other.minor) return minor.compareTo(other.minor);
+    if (patch != other.patch) return patch.compareTo(other.patch);
+
+    // A pre-release precedes its own release: 2.1.0-beta.1 < 2.1.0.
+    if (preRelease.isEmpty && other.preRelease.isEmpty) return 0;
+    if (preRelease.isEmpty) return 1;
+    if (other.preRelease.isEmpty) return -1;
+
+    final shared = preRelease.length < other.preRelease.length
+        ? preRelease.length
+        : other.preRelease.length;
+    for (var i = 0; i < shared; i++) {
+      final result = _compareIdentifiers(preRelease[i], other.preRelease[i]);
+      if (result != 0) return result;
+    }
+
+    // Every shared identifier is equal, so the longer set wins:
+    // 2.1.0-alpha < 2.1.0-alpha.1.
+    return preRelease.length.compareTo(other.preRelease.length);
+  }
+
+  /// Semver's rule for two pre-release identifiers: numeric ones compare
+  /// numerically, everything else compares ASCII, and numeric always ranks
+  /// below non-numeric.
+  static int _compareIdentifiers(String a, String b) {
+    final aNumeric = _numeric.hasMatch(a);
+    final bNumeric = _numeric.hasMatch(b);
+    if (aNumeric && bNumeric) return int.parse(a).compareTo(int.parse(b));
+    if (aNumeric) return -1;
+    if (bNumeric) return 1;
+    return a.compareTo(b);
+  }
+
+  bool operator <(AppVersion other) => compareTo(other) < 0;
+  bool operator <=(AppVersion other) => compareTo(other) <= 0;
+  bool operator >(AppVersion other) => compareTo(other) > 0;
+  bool operator >=(AppVersion other) => compareTo(other) >= 0;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AppVersion &&
+      other.major == major &&
+      other.minor == minor &&
+      other.patch == patch &&
+      listEquals(other.preRelease, preRelease);
+
+  @override
+  int get hashCode =>
+      Object.hash(major, minor, patch, Object.hashAll(preRelease));
+
+  @override
+  String toString() {
+    final core = '$major.$minor.$patch';
+    return preRelease.isEmpty ? core : '$core-${preRelease.join('.')}';
+  }
+}

--- a/lib/features/announcements/models/app_version.dart
+++ b/lib/features/announcements/models/app_version.dart
@@ -57,21 +57,35 @@ class AppVersion implements Comparable<AppVersion> {
       // A trailing `-` or an empty identifier (`2.1.0-beta..1`) is malformed,
       // not an empty pre-release.
       if (suffix.isEmpty) return null;
-      preRelease = suffix.split('.');
-      for (final identifier in preRelease) {
+      final identifiers = suffix.split('.');
+      for (final identifier in identifiers) {
         if (identifier.isEmpty) return null;
         if (!_identifier.hasMatch(identifier)) return null;
       }
+      // Numeric identifiers are normalized rather than kept verbatim, so that
+      // `==` agrees with [compareTo]: the comparison reads 007 and 7 as the
+      // same number, and two "equal" versions that a Set keeps both of is the
+      // kind of disagreement nothing downstream would ever explain. Semver
+      // forbids the leading zeros anyway.
+      preRelease = [
+        for (final identifier in identifiers)
+          _numeric.hasMatch(identifier)
+              ? _stripLeadingZeros(identifier)
+              : identifier,
+      ];
     }
 
-    // Digits alone are not a number: a component too long for a 64-bit int
-    // parses as a match here and throws in int.parse. The input is a tag a
-    // relay handed us, so it has to fail as "not a version" rather than as an
-    // exception thrown out of the middle of parsing.
+    // Digits alone are not a number, and the two platforms disagree about how
+    // they are not one: on the VM a component too long for a 64-bit int makes
+    // int.tryParse return null, while on the web an int *is* a double, so the
+    // same digits round to something and parse "successfully". This app builds
+    // for web too, so the round-trip is what decides — digits that do not
+    // survive being printed back were never this number.
     final components = <int>[];
     for (final part in numbers) {
       final value = int.tryParse(part);
       if (value == null) return null;
+      if (value.toString() != _stripLeadingZeros(part)) return null;
       components.add(value);
     }
     int at(int index) => index < components.length ? components[index] : 0;
@@ -115,6 +129,10 @@ class AppVersion implements Comparable<AppVersion> {
     return a.compareTo(b);
   }
 
+  /// `007` → `7`, `000` → `0`. Never an empty string.
+  static String _stripLeadingZeros(String digits) =>
+      digits.replaceFirst(RegExp(r'^0+(?=\d)'), '');
+
   /// Two runs of digits, compared as numbers, without parsing either.
   ///
   /// Semver puts no ceiling on a numeric pre-release identifier, so `int.parse`
@@ -122,8 +140,8 @@ class AppVersion implements Comparable<AppVersion> {
   /// parsing came off a relay. Stripping leading zeros makes the comparison
   /// exact: longer wins, and equal lengths compare digit by digit.
   static int _compareNumeric(String a, String b) {
-    final x = a.replaceFirst(RegExp(r'^0+(?=\d)'), '');
-    final y = b.replaceFirst(RegExp(r'^0+(?=\d)'), '');
+    final x = _stripLeadingZeros(a);
+    final y = _stripLeadingZeros(b);
     if (x.length != y.length) return x.length.compareTo(y.length);
     return x.compareTo(y);
   }

--- a/lib/features/announcements/models/app_version.dart
+++ b/lib/features/announcements/models/app_version.dart
@@ -64,7 +64,17 @@ class AppVersion implements Comparable<AppVersion> {
       }
     }
 
-    int at(int index) => index < numbers.length ? int.parse(numbers[index]) : 0;
+    // Digits alone are not a number: a component too long for a 64-bit int
+    // parses as a match here and throws in int.parse. The input is a tag a
+    // relay handed us, so it has to fail as "not a version" rather than as an
+    // exception thrown out of the middle of parsing.
+    final components = <int>[];
+    for (final part in numbers) {
+      final value = int.tryParse(part);
+      if (value == null) return null;
+      components.add(value);
+    }
+    int at(int index) => index < components.length ? components[index] : 0;
 
     return AppVersion._(at(0), at(1), at(2), List.unmodifiable(preRelease));
   }
@@ -99,10 +109,23 @@ class AppVersion implements Comparable<AppVersion> {
   static int _compareIdentifiers(String a, String b) {
     final aNumeric = _numeric.hasMatch(a);
     final bNumeric = _numeric.hasMatch(b);
-    if (aNumeric && bNumeric) return int.parse(a).compareTo(int.parse(b));
+    if (aNumeric && bNumeric) return _compareNumeric(a, b);
     if (aNumeric) return -1;
     if (bNumeric) return 1;
     return a.compareTo(b);
+  }
+
+  /// Two runs of digits, compared as numbers, without parsing either.
+  ///
+  /// Semver puts no ceiling on a numeric pre-release identifier, so `int.parse`
+  /// is a crash waiting for a long enough one — and the string it would be
+  /// parsing came off a relay. Stripping leading zeros makes the comparison
+  /// exact: longer wins, and equal lengths compare digit by digit.
+  static int _compareNumeric(String a, String b) {
+    final x = a.replaceFirst(RegExp(r'^0+(?=\d)'), '');
+    final y = b.replaceFirst(RegExp(r'^0+(?=\d)'), '');
+    if (x.length != y.length) return x.length.compareTo(y.length);
+    return x.compareTo(y);
   }
 
   bool operator <(AppVersion other) => compareTo(other) < 0;

--- a/test/features/announcements/announcement_publishers_test.dart
+++ b/test/features/announcements/announcement_publishers_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/announcements/announcement_publishers.dart';
+
+import '../../support/nostr_fakes.dart';
+
+/// Decodes exactly the npubs a test names, and nothing else.
+///
+/// Decoding is bech32 and bech32 lives in the crate (AGENTS.md), so the unit
+/// under test is *which* entries survive, never the decoding itself — that is
+/// pinned by the crypto contract tests.
+class _StubCrypto extends FakeNostrCrypto {
+  _StubCrypto(this.table);
+
+  final Map<String, String> table;
+
+  @override
+  String? npubDecode(String npub) => table[npub];
+}
+
+void main() {
+  group('decodeAnnouncementPublishers', () {
+    test('maps each allowlisted npub to the hex a filter needs', () {
+      // Arrange
+      final crypto = _StubCrypto({
+        'npub1first': 'aa' * 32,
+        'npub1second': 'bb' * 32,
+      });
+
+      // Act
+      final hex = decodeAnnouncementPublishers(
+        crypto,
+        npubs: const ['npub1first', 'npub1second'],
+      );
+
+      // Assert
+      expect(hex, ['aa' * 32, 'bb' * 32]);
+    });
+
+    test('drops an entry that fails to decode and keeps the rest', () {
+      // Arrange — a typo in one constant must not silence the channel (§3.1)
+      final crypto = _StubCrypto({'npub1good': 'aa' * 32});
+
+      // Act
+      final hex = decodeAnnouncementPublishers(
+        crypto,
+        npubs: const ['npub1typo', 'npub1good'],
+      );
+
+      // Assert
+      expect(hex, ['aa' * 32]);
+    });
+
+    test('returns nothing when no entry decodes', () {
+      // Arrange
+      final crypto = _StubCrypto(const {});
+
+      // Act
+      final hex = decodeAnnouncementPublishers(
+        crypto,
+        npubs: const ['npub1typo'],
+      );
+
+      // Assert — the caller opens no subscription rather than an unfiltered one
+      expect(hex, isEmpty);
+    });
+
+    test('returns nothing for an empty allowlist', () {
+      // Arrange
+      final crypto = _StubCrypto({'npub1first': 'aa' * 32});
+
+      // Act
+      final hex = decodeAnnouncementPublishers(crypto, npubs: const []);
+
+      // Assert
+      expect(hex, isEmpty);
+    });
+
+    test('drops duplicates so a filter never names one author twice', () {
+      // Arrange — the same key reachable under two entries
+      final crypto = _StubCrypto({
+        'npub1first': 'aa' * 32,
+        'npub1firstAgain': 'aa' * 32,
+      });
+
+      // Act
+      final hex = decodeAnnouncementPublishers(
+        crypto,
+        npubs: const ['npub1first', 'npub1firstAgain'],
+      );
+
+      // Assert
+      expect(hex, ['aa' * 32]);
+    });
+  });
+
+  group('the shipped allowlist', () {
+    test('holds npubs, never hex', () {
+      // Assert — the constant is what a human checks against the value
+      // published elsewhere, and the app's surfaces speak npub (§3.1)
+      for (final entry in kAnnouncementPublishers) {
+        expect(entry, startsWith('npub1'));
+      }
+    });
+
+    test('is empty until a dedicated offline key exists', () {
+      // Assert — an empty allowlist is inert by construction: nothing to
+      // decode means no authors, and §4.1 opens no subscription without them.
+      // Delete this test in the commit that adds the real key.
+      expect(kAnnouncementPublishers, isEmpty);
+    });
+  });
+}

--- a/test/features/announcements/models/announcement_test.dart
+++ b/test/features/announcements/models/announcement_test.dart
@@ -241,11 +241,16 @@ void main() {
       final scheme = _event(url: 'javascript:alert(1)');
       final garbage = _event(url: ':::');
 
-      // Assert — §7: ignored while the announcement still renders
-      expect(Announcement.tryParse(insecure)?.url, isNull);
-      expect(Announcement.tryParse(scheme)?.url, isNull);
-      expect(Announcement.tryParse(garbage)?.url, isNull);
-      expect(Announcement.tryParse(insecure), isNotNull);
+      // Assert — §7: ignored while the announcement still renders. The
+      // non-null check is per case on purpose: `tryParse(x)?.url` is null both
+      // when the url was dropped and when the whole event was rejected, so
+      // asserting only the url would pass on a regression that threw the
+      // announcement away with it.
+      for (final event in [insecure, scheme, garbage]) {
+        final announcement = Announcement.tryParse(event);
+        expect(announcement, isNotNull);
+        expect(announcement!.url, isNull);
+      }
     });
 
     test('drops a url that is not a string', () {
@@ -339,6 +344,21 @@ void main() {
       expect(announcement.appliesTo(AppVersion.tryParse('2.1.1')!), isFalse);
     });
 
+    test('a range that holds nobody is refused', () {
+      // Assert — max_version is exclusive, so equal bounds are an empty range
+      // rather than a single-version one. A targeting instruction that reaches
+      // nobody fails the same way an unreadable one does, and the sender gets
+      // no signal either way.
+      expect(
+        Announcement.tryParse(_event(minVersion: '2.1.0', maxVersion: '2.1.0')),
+        isNull,
+      );
+      expect(
+        Announcement.tryParse(_event(minVersion: '3.0.0', maxVersion: '2.0.0')),
+        isNull,
+      );
+    });
+
     test('both bounds together describe a half-open range', () {
       // Arrange
       final announcement = Announcement.tryParse(
@@ -371,6 +391,40 @@ void main() {
         expect(announcement.textFor(code).title, 'title-$code');
         expect(announcement.textFor(code).body, 'body-$code');
       }
+    });
+  });
+
+  group('equality', () {
+    test('a re-parse of the same event equals the first parse', () {
+      // Arrange — a cached announcement and a freshly parsed one are different
+      // objects, and identity equality would call them different for no reason
+      // a caller could see
+      final first = Announcement.tryParse(_event())!;
+      final second = Announcement.tryParse(_event())!;
+
+      // Assert
+      expect(first, second);
+      expect(first.hashCode, second.hashCode);
+      expect({first, second}, hasLength(1));
+    });
+
+    test('a different revision at the same address is a different value', () {
+      // Arrange — the correction, and what it corrects
+      final held = Announcement.tryParse(_event(id: 'e1'))!;
+      final correction =
+          Announcement.tryParse(_event(id: 'e2', createdAt: 1754006401))!;
+
+      // Assert
+      expect(correction, isNot(held));
+    });
+
+    test('the same d from two keys is two different values', () {
+      // Arrange — the address is not the d alone (§3.3)
+      final mine = Announcement.tryParse(_event(pubkey: 'aa11'))!;
+      final theirs = Announcement.tryParse(_event(pubkey: 'bb22'))!;
+
+      // Assert
+      expect(mine, isNot(theirs));
     });
   });
 

--- a/test/features/announcements/models/announcement_test.dart
+++ b/test/features/announcements/models/announcement_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/features/announcements/models/announcement.dart';
 import 'package:choke/features/announcements/models/app_version.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
 import 'package:choke/services/nostr/nostr_service.dart';
 
 const Object _unset = Object();
@@ -287,6 +288,16 @@ void main() {
       expect(Announcement.tryParse(_event(maxVersion: '2.1.0+454')), isNull);
     });
 
+    test('a bound no int could hold is rejected, not thrown', () {
+      // Arrange — a hostile relay writes digits until int.parse gives up
+      final event = _event(minVersion: '99999999999999999999999.0.0');
+
+      // Assert — parsing an event must never throw at its caller: every
+      // failure of this feature is silent (§4.4)
+      expect(() => Announcement.tryParse(event), returnsNormally);
+      expect(Announcement.tryParse(event), isNull);
+    });
+
     test('parses both bounds when they are readable', () {
       // Arrange
       final event = _event(minVersion: '2.0.0', maxVersion: '2.1');
@@ -397,10 +408,16 @@ void main() {
   });
 
   group('the locale set', () {
-    test('matches the locales the app itself ships', () {
-      // Assert — §2.2 pins the schema to AppLocalizations.supportedLocales;
-      // if a locale is ever added, this fails until the schema follows
-      expect(kAnnouncementLocales, {'en', 'es', 'ja', 'pt'});
+    test('is exactly the set of locales the app itself ships', () {
+      // Arrange — §2.2 pins the schema to the app's own locales, so this has
+      // to read them rather than repeat them: a fifth locale added to the app
+      // must fail here until the schema follows it
+      final shipped = AppLocalizations.supportedLocales
+          .map((locale) => locale.languageCode)
+          .toSet();
+
+      // Assert
+      expect(kAnnouncementLocales, shipped);
     });
   });
 }

--- a/test/features/announcements/models/announcement_test.dart
+++ b/test/features/announcements/models/announcement_test.dart
@@ -1,0 +1,406 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/announcements/models/announcement.dart';
+import 'package:choke/features/announcements/models/app_version.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+
+const Object _unset = Object();
+
+/// The four locale blocks §2.2 requires, so a test only has to name the one
+/// thing it is changing.
+Map<String, dynamic> _locales({
+  String title = 'Version 2.1 is out',
+  String body = 'It fixes the clock drifting on long matches.',
+  Set<String> only = kAnnouncementLocales,
+}) {
+  return {
+    for (final code in only) code: {'title': title, 'body': body},
+  };
+}
+
+/// A well-formed announcement event, with hooks for the piece under test.
+NostrEvent _event({
+  int kind = kAnnouncementKind,
+  String pubkey = 'aa11',
+  String? dTag = 'release-2-1',
+  String? expiration = '4102444800', // 2100-01-01
+  int createdAt = 1754006400,
+  String id = 'e1',
+  Object? content = _unset,
+  Map<String, dynamic>? locales,
+  String? url,
+  String? minVersion,
+  String? maxVersion,
+  int? schemaVersion = kAnnouncementSchemaVersion,
+}) {
+  final body = <String, dynamic>{
+    if (schemaVersion != null) 'v': schemaVersion,
+    'locales': locales ?? _locales(),
+    if (url != null) 'url': url,
+  };
+
+  return NostrEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: createdAt,
+    kind: kind,
+    tags: [
+      if (dTag != null) ['d', dTag],
+      if (expiration != null) ['expiration', expiration],
+      if (minVersion != null) ['min_version', minVersion],
+      if (maxVersion != null) ['max_version', maxVersion],
+    ],
+    content: identical(content, _unset) ? jsonEncode(body) : content as String,
+    sig: 'f' * 128,
+  );
+}
+
+void main() {
+  group('tryParse — the happy path', () {
+    test('reads every field of a well-formed announcement', () {
+      // Arrange
+      final event = _event(url: 'https://bjjscore.live/notes/2-1');
+
+      // Act
+      final announcement = Announcement.tryParse(event);
+
+      // Assert
+      expect(announcement, isNotNull);
+      expect(announcement!.announcementId, 'release-2-1');
+      expect(announcement.publisher, 'aa11');
+      expect(announcement.expiration, 4102444800);
+      expect(announcement.url, Uri.parse('https://bjjscore.live/notes/2-1'));
+      expect(announcement.minVersion, isNull);
+      expect(announcement.maxVersion, isNull);
+    });
+
+    test('the address is the full addressable identity, not the d tag', () {
+      // Arrange — two allowlisted keys may pick the same d (§3.3)
+      final mine = _event(pubkey: 'aa11');
+      final theirs = _event(pubkey: 'bb22');
+
+      // Act
+      final a = Announcement.tryParse(mine)!;
+      final b = Announcement.tryParse(theirs)!;
+
+      // Assert
+      expect(a.address, '$kAnnouncementKind:aa11:release-2-1');
+      expect(b.address, '$kAnnouncementKind:bb22:release-2-1');
+      expect(a.address, isNot(b.address));
+    });
+
+    test('the revision carries both created_at and the event id', () {
+      // Arrange
+      final event = _event(createdAt: 1754006400, id: 'abc');
+
+      // Act
+      final announcement = Announcement.tryParse(event)!;
+
+      // Assert
+      expect(announcement.revision.createdAt, 1754006400);
+      expect(announcement.revision.eventId, 'abc');
+      expect(announcement.createdAt, 1754006400);
+    });
+
+    test('trims the title and body it stores', () {
+      // Arrange
+      final event =
+          _event(locales: _locales(title: '  Hi  ', body: '  There '));
+
+      // Act
+      final announcement = Announcement.tryParse(event)!;
+
+      // Assert
+      expect(announcement.textFor('en').title, 'Hi');
+      expect(announcement.textFor('en').body, 'There');
+    });
+  });
+
+  group('tryParse — the event shell', () {
+    test('ignores any kind but the announcement kind', () {
+      // Assert — a match event must never be read as an announcement
+      expect(Announcement.tryParse(_event(kind: 31415)), isNull);
+    });
+
+    test('ignores an event with no usable d tag', () {
+      // Assert — without a d there is no address to key anything by
+      expect(Announcement.tryParse(_event(dTag: null)), isNull);
+      expect(Announcement.tryParse(_event(dTag: '')), isNull);
+    });
+
+    test('ignores an event whose expiration is missing or unreadable', () {
+      // Assert — expiration is required (§2, §3.4)
+      expect(Announcement.tryParse(_event(expiration: null)), isNull);
+      expect(Announcement.tryParse(_event(expiration: 'soon')), isNull);
+      expect(Announcement.tryParse(_event(expiration: '')), isNull);
+    });
+  });
+
+  group('tryParse — the content schema', () {
+    test('ignores content that is not a JSON object', () {
+      // Assert
+      expect(Announcement.tryParse(_event(content: 'not json')), isNull);
+      expect(Announcement.tryParse(_event(content: '[]')), isNull);
+      expect(Announcement.tryParse(_event(content: '')), isNull);
+    });
+
+    test('ignores an unknown or missing schema version', () {
+      // Assert — an unknown v is ignored, not rendered best-effort (§2.2)
+      expect(Announcement.tryParse(_event(schemaVersion: 2)), isNull);
+      expect(Announcement.tryParse(_event(schemaVersion: null)), isNull);
+    });
+
+    test('requires exactly the four locales the app ships', () {
+      // Arrange — three of four, and four plus a fifth
+      final missing = _event(locales: _locales(only: {'en', 'es', 'ja'}));
+      final extra = _event(
+        locales: {
+          ..._locales(),
+          'de': {'title': 'Hallo', 'body': 'Welt'},
+        },
+      );
+
+      // Assert — no fallback exists to cover either case (§2.2)
+      expect(Announcement.tryParse(missing), isNull);
+      expect(Announcement.tryParse(extra), isNull);
+    });
+
+    test('ignores a locales value that is not a map of blocks', () {
+      // Assert
+      expect(Announcement.tryParse(_event(locales: {})), isNull);
+      expect(
+        Announcement.tryParse(_event(content: '{"v":1,"locales":"en"}')),
+        isNull,
+      );
+      expect(
+        Announcement.tryParse(
+          _event(locales: {for (final c in kAnnouncementLocales) c: 'text'}),
+        ),
+        isNull,
+      );
+    });
+
+    test('ignores a block with a missing, blank or non-string field', () {
+      // Arrange
+      final noTitle = _event(
+        locales: {
+          for (final c in kAnnouncementLocales) c: {'body': 'b'},
+        },
+      );
+      final blankBody = _event(locales: _locales(body: '   '));
+      final numericTitle = _event(
+        locales: {
+          for (final c in kAnnouncementLocales) c: {'title': 7, 'body': 'b'},
+        },
+      );
+
+      // Assert
+      expect(Announcement.tryParse(noTitle), isNull);
+      expect(Announcement.tryParse(blankBody), isNull);
+      expect(Announcement.tryParse(numericTitle), isNull);
+    });
+
+    test('enforces the length limits after trimming', () {
+      // Arrange
+      final atLimit = _event(
+        locales: _locales(title: 'a' * 80, body: 'b' * 500),
+      );
+      final longTitle = _event(locales: _locales(title: 'a' * 81));
+      final longBody = _event(locales: _locales(body: 'b' * 501));
+      final paddedToLimit = _event(
+        locales: _locales(title: '  ${'a' * 80}  '),
+      );
+
+      // Assert
+      expect(Announcement.tryParse(atLimit), isNotNull);
+      expect(Announcement.tryParse(longTitle), isNull);
+      expect(Announcement.tryParse(longBody), isNull);
+      expect(Announcement.tryParse(paddedToLimit), isNotNull);
+    });
+
+    test('one bad locale invalidates the announcement, not just that one', () {
+      // Arrange — es is over length, the other three are fine
+      final event = _event(
+        locales: {
+          ..._locales(),
+          'es': {'title': 'a' * 81, 'body': 'b'},
+        },
+      );
+
+      // Assert
+      expect(Announcement.tryParse(event), isNull);
+    });
+  });
+
+  group('tryParse — the url', () {
+    test('drops a non-https url and still renders the announcement', () {
+      // Arrange
+      final insecure = _event(url: 'http://bjjscore.live');
+      final scheme = _event(url: 'javascript:alert(1)');
+      final garbage = _event(url: ':::');
+
+      // Assert — §7: ignored while the announcement still renders
+      expect(Announcement.tryParse(insecure)?.url, isNull);
+      expect(Announcement.tryParse(scheme)?.url, isNull);
+      expect(Announcement.tryParse(garbage)?.url, isNull);
+      expect(Announcement.tryParse(insecure), isNotNull);
+    });
+
+    test('drops a url that is not a string', () {
+      // Arrange
+      final event = _event(
+        content: jsonEncode({
+          'v': kAnnouncementSchemaVersion,
+          'locales': _locales(),
+          'url': 42,
+        }),
+      );
+
+      // Assert
+      expect(Announcement.tryParse(event)?.url, isNull);
+      expect(Announcement.tryParse(event), isNotNull);
+    });
+
+    test('keeps an https url with a host', () {
+      // Arrange
+      final event = _event(url: 'https://bjjscore.live/notes');
+
+      // Assert
+      expect(
+        Announcement.tryParse(event)!.url,
+        Uri.parse('https://bjjscore.live/notes'),
+      );
+    });
+
+    test('drops an https url with no host', () {
+      // Assert — "https:///x" names nothing to open
+      expect(Announcement.tryParse(_event(url: 'https:///x'))?.url, isNull);
+    });
+  });
+
+  group('version bounds', () {
+    test('an unparseable bound invalidates the announcement', () {
+      // Assert — a bound nobody can read is a targeting instruction that
+      // failed; showing it to everyone is the wrong way to fail it (§2.1)
+      expect(Announcement.tryParse(_event(minVersion: 'latest')), isNull);
+      expect(Announcement.tryParse(_event(maxVersion: '2.1.0+454')), isNull);
+    });
+
+    test('parses both bounds when they are readable', () {
+      // Arrange
+      final event = _event(minVersion: '2.0.0', maxVersion: '2.1');
+
+      // Act
+      final announcement = Announcement.tryParse(event)!;
+
+      // Assert
+      expect(announcement.minVersion, AppVersion.tryParse('2.0.0'));
+      expect(announcement.maxVersion, AppVersion.tryParse('2.1.0'));
+    });
+
+    test('an unbounded announcement applies to every version', () {
+      // Arrange
+      final announcement = Announcement.tryParse(_event())!;
+
+      // Assert
+      expect(announcement.appliesTo(AppVersion.tryParse('0.0.1')!), isTrue);
+      expect(announcement.appliesTo(AppVersion.tryParse('99.0.0')!), isTrue);
+    });
+
+    test('min_version is inclusive', () {
+      // Arrange
+      final announcement = Announcement.tryParse(_event(minVersion: '2.1.0'))!;
+
+      // Assert
+      expect(announcement.appliesTo(AppVersion.tryParse('2.0.9')!), isFalse);
+      expect(announcement.appliesTo(AppVersion.tryParse('2.1.0')!), isTrue);
+      expect(announcement.appliesTo(AppVersion.tryParse('2.1.1')!), isTrue);
+    });
+
+    test('max_version is exclusive, so 2.1 never hears that 2.1 is out', () {
+      // Arrange — the case the whole bound exists for (§2.1)
+      final announcement = Announcement.tryParse(_event(maxVersion: '2.1.0'))!;
+
+      // Assert
+      expect(announcement.appliesTo(AppVersion.tryParse('2.0.9')!), isTrue);
+      expect(announcement.appliesTo(AppVersion.tryParse('2.1.0')!), isFalse);
+      expect(announcement.appliesTo(AppVersion.tryParse('2.1.1')!), isFalse);
+    });
+
+    test('both bounds together describe a half-open range', () {
+      // Arrange
+      final announcement = Announcement.tryParse(
+        _event(minVersion: '2.0.0', maxVersion: '2.1.0'),
+      )!;
+
+      // Assert
+      expect(announcement.appliesTo(AppVersion.tryParse('1.9.9')!), isFalse);
+      expect(announcement.appliesTo(AppVersion.tryParse('2.0.0')!), isTrue);
+      expect(announcement.appliesTo(AppVersion.tryParse('2.0.9')!), isTrue);
+      expect(announcement.appliesTo(AppVersion.tryParse('2.1.0')!), isFalse);
+    });
+  });
+
+  group('textFor', () {
+    test('every one of the four locales resolves to its own copy', () {
+      // Arrange
+      final event = _event(
+        locales: {
+          for (final code in kAnnouncementLocales)
+            code: {'title': 'title-$code', 'body': 'body-$code'},
+        },
+      );
+
+      // Act
+      final announcement = Announcement.tryParse(event)!;
+
+      // Assert
+      for (final code in kAnnouncementLocales) {
+        expect(announcement.textFor(code).title, 'title-$code');
+        expect(announcement.textFor(code).body, 'body-$code');
+      }
+    });
+  });
+
+  group('AnnouncementRevision', () {
+    test('a newer created_at supersedes an older one', () {
+      // Arrange
+      const older = AnnouncementRevision(createdAt: 10, eventId: 'aa');
+      const newer = AnnouncementRevision(createdAt: 11, eventId: 'zz');
+
+      // Assert
+      expect(newer.supersedes(older), isTrue);
+      expect(older.supersedes(newer), isFalse);
+    });
+
+    test('on a tie the lowest event id wins, as NIP-01 says', () {
+      // Arrange — the same rule NostrService already applies to matches
+      const held = AnnouncementRevision(createdAt: 10, eventId: 'bb');
+      const lower = AnnouncementRevision(createdAt: 10, eventId: 'aa');
+      const higher = AnnouncementRevision(createdAt: 10, eventId: 'cc');
+
+      // Assert
+      expect(lower.supersedes(held), isTrue);
+      expect(higher.supersedes(held), isFalse);
+    });
+
+    test('a revision does not supersede itself', () {
+      // Arrange — a redelivery of the same event must not re-announce
+      const revision = AnnouncementRevision(createdAt: 10, eventId: 'bb');
+
+      // Assert
+      expect(revision.supersedes(revision), isFalse);
+      expect(
+          revision, const AnnouncementRevision(createdAt: 10, eventId: 'bb'));
+    });
+  });
+
+  group('the locale set', () {
+    test('matches the locales the app itself ships', () {
+      // Assert — §2.2 pins the schema to AppLocalizations.supportedLocales;
+      // if a locale is ever added, this fails until the schema follows
+      expect(kAnnouncementLocales, {'en', 'es', 'ja', 'pt'});
+    });
+  });
+}

--- a/test/features/announcements/models/app_version_test.dart
+++ b/test/features/announcements/models/app_version_test.dart
@@ -65,6 +65,53 @@ void main() {
       expect(AppVersion.tryParse('1.99999999999999999999999.0'), isNull);
     });
 
+    test('never returns a version that is not the one it was handed', () {
+      // Arrange — where a component is rejected differs by platform: the VM
+      // fails anything past 64 bits, the web fails anything past 2^53 because
+      // an int there is a double. What must not differ is the *shape* of the
+      // failure — a rounded number silently standing in for the one written.
+      const inputs = [
+        '9007199254740991.0.0', // exactly representable everywhere
+        '9007199254740993.0.0', // a real int on the VM, rounds on the web
+        '18446744073709551617.0.0', // past 64 bits
+        '99999999999999999999999.0.0',
+      ];
+
+      for (final input in inputs) {
+        // Act
+        final version = AppVersion.tryParse(input);
+
+        // Assert — accepted or refused, never quietly altered
+        if (version != null) {
+          expect(version.toString(), input, reason: input);
+        }
+      }
+    });
+
+    test('keeps the largest component that is exactly representable', () {
+      // Assert — the guard rejects what rounds, not what is merely large
+      final version = AppVersion.tryParse('9007199254740991.0.0');
+      expect(version, isNotNull);
+      expect(version!.major, 9007199254740991);
+    });
+
+    test('normalizes leading zeros in a numeric pre-release identifier', () {
+      // Arrange — semver forbids them, and keeping them verbatim would make
+      // `==` disagree with compareTo
+      final padded = AppVersion.tryParse('2.1.0-007')!;
+
+      // Assert
+      expect(padded.preRelease, ['7']);
+      expect(padded, AppVersion.tryParse('2.1.0-7'));
+      expect(padded.hashCode, AppVersion.tryParse('2.1.0-7')!.hashCode);
+      expect({padded, AppVersion.tryParse('2.1.0-7')!}, hasLength(1));
+    });
+
+    test('leaves an alphanumeric identifier alone', () {
+      // Assert — only numeric identifiers are numbers
+      expect(AppVersion.tryParse('2.1.0-007a')!.preRelease, ['007a']);
+    });
+
     test('tolerates surrounding whitespace', () {
       // Arrange + Act
       final version = AppVersion.tryParse('  2.0.1  ');

--- a/test/features/announcements/models/app_version_test.dart
+++ b/test/features/announcements/models/app_version_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/announcements/models/app_version.dart';
+
+void main() {
+  group('tryParse', () {
+    test('parses the three-component form the app itself produces', () {
+      // Arrange + Act
+      final version = AppVersion.tryParse('2.0.1');
+
+      // Assert
+      expect(version, isNotNull);
+      expect(version!.major, 2);
+      expect(version.minor, 0);
+      expect(version.patch, 1);
+      expect(version.preRelease, isEmpty);
+    });
+
+    test('treats missing components as zero', () {
+      // Arrange + Act — a sender writing "2.1" means 2.1.0
+      final short = AppVersion.tryParse('2.1');
+      final bare = AppVersion.tryParse('2');
+
+      // Assert
+      expect(short, AppVersion.tryParse('2.1.0'));
+      expect(bare, AppVersion.tryParse('2.0.0'));
+    });
+
+    test('parses a pre-release suffix into its identifiers', () {
+      // Arrange + Act
+      final version = AppVersion.tryParse('2.1.0-beta.1');
+
+      // Assert
+      expect(version, isNotNull);
+      expect(version!.patch, 0);
+      expect(version.preRelease, ['beta', '1']);
+    });
+
+    test('rejects build metadata rather than ignoring it', () {
+      // Arrange + Act — semver excludes build metadata from precedence, so
+      // accepting it would mean silently dropping part of what the sender
+      // wrote (§2.1)
+
+      // Assert
+      expect(AppVersion.tryParse('2.1.0+454'), isNull);
+      expect(AppVersion.tryParse('2.1.0-beta.1+454'), isNull);
+    });
+
+    test('rejects anything that is not a version', () {
+      // Assert
+      expect(AppVersion.tryParse(''), isNull);
+      expect(AppVersion.tryParse('   '), isNull);
+      expect(AppVersion.tryParse('latest'), isNull);
+      expect(AppVersion.tryParse('2.x'), isNull);
+      expect(AppVersion.tryParse('2.1.0.3'), isNull);
+      expect(AppVersion.tryParse('-1.0.0'), isNull);
+      expect(AppVersion.tryParse('2.1.0-'), isNull);
+      expect(AppVersion.tryParse('2.1.0-beta..1'), isNull);
+    });
+
+    test('tolerates surrounding whitespace', () {
+      // Arrange + Act
+      final version = AppVersion.tryParse('  2.0.1  ');
+
+      // Assert
+      expect(version, AppVersion.tryParse('2.0.1'));
+    });
+  });
+
+  group('ordering', () {
+    test('orders by major, then minor, then patch', () {
+      // Arrange
+      final versions = [
+        AppVersion.tryParse('2.0.1')!,
+        AppVersion.tryParse('10.0.0')!,
+        AppVersion.tryParse('2.1.0')!,
+        AppVersion.tryParse('2.0.10')!,
+      ]..sort();
+
+      // Assert — 2.0.10 after 2.0.1 is the case a string compare gets wrong
+      expect(
+        versions.map((v) => v.toString()).toList(),
+        ['2.0.1', '2.0.10', '2.1.0', '10.0.0'],
+      );
+    });
+
+    test('a pre-release precedes its own release', () {
+      // Arrange
+      final beta = AppVersion.tryParse('2.1.0-beta.1')!;
+      final release = AppVersion.tryParse('2.1.0')!;
+
+      // Assert
+      expect(beta.compareTo(release), lessThan(0));
+      expect(release.compareTo(beta), greaterThan(0));
+    });
+
+    test('orders pre-release identifiers the way semver does', () {
+      // Arrange — numeric identifiers compare numerically, alphanumeric ones
+      // lexically, numeric ranks below alphanumeric, and a longer set of
+      // identifiers wins a tie on the shared prefix
+      final ordered = [
+        '2.1.0-alpha',
+        '2.1.0-alpha.1',
+        '2.1.0-alpha.2',
+        '2.1.0-alpha.10',
+        '2.1.0-alpha.beta',
+        '2.1.0-beta',
+        '2.1.0',
+      ].map((raw) => AppVersion.tryParse(raw)!).toList();
+
+      // Act
+      final shuffled = ordered.reversed.toList()..sort();
+
+      // Assert
+      expect(shuffled, ordered);
+    });
+
+    test('equal versions compare equal and hash alike', () {
+      // Arrange
+      final a = AppVersion.tryParse('2.1.0-beta.1')!;
+      final b = AppVersion.tryParse('2.1.0-beta.1')!;
+
+      // Assert
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a.compareTo(b), 0);
+    });
+  });
+
+  group('toString', () {
+    test('round-trips through tryParse', () {
+      // Arrange + Act + Assert
+      for (final raw in ['2.0.1', '2.1.0-beta.1', '0.0.0']) {
+        expect(AppVersion.tryParse(raw).toString(), raw);
+      }
+    });
+  });
+}

--- a/test/features/announcements/models/app_version_test.dart
+++ b/test/features/announcements/models/app_version_test.dart
@@ -57,6 +57,14 @@ void main() {
       expect(AppVersion.tryParse('2.1.0-beta..1'), isNull);
     });
 
+    test('rejects a component too large to be a number', () {
+      // Assert — digits alone are not a number: this is a tag off a relay, so
+      // it has to fail as "not a version", never as an exception thrown out of
+      // the middle of parsing
+      expect(AppVersion.tryParse('99999999999999999999999.0.0'), isNull);
+      expect(AppVersion.tryParse('1.99999999999999999999999.0'), isNull);
+    });
+
     test('tolerates surrounding whitespace', () {
       // Arrange + Act
       final version = AppVersion.tryParse('  2.0.1  ');
@@ -112,6 +120,27 @@ void main() {
 
       // Assert
       expect(shuffled, ordered);
+    });
+
+    test('orders numeric pre-release identifiers no int could hold', () {
+      // Arrange — semver puts no ceiling on a numeric identifier, and the
+      // string being compared came off a relay
+      final huge = AppVersion.tryParse('2.1.0-99999999999999999999999')!;
+      final small = AppVersion.tryParse('2.1.0-1')!;
+
+      // Act + Assert
+      expect(huge.compareTo(small), greaterThan(0));
+      expect(small.compareTo(huge), lessThan(0));
+    });
+
+    test('ignores leading zeros when comparing numeric identifiers', () {
+      // Arrange
+      final padded = AppVersion.tryParse('2.1.0-007')!;
+      final plain = AppVersion.tryParse('2.1.0-7')!;
+
+      // Assert
+      expect(padded.compareTo(plain), 0);
+      expect(padded.compareTo(AppVersion.tryParse('2.1.0-8')!), lessThan(0));
     });
 
     test('equal versions compare equal and hash alike', () {

--- a/test/features/match/match_control_wakelock_test.dart
+++ b/test/features/match/match_control_wakelock_test.dart
@@ -122,7 +122,8 @@ void main() {
     expect(wakelock.requests, everyElement(isTrue));
   });
 
-  testWidgets('re-asserts the hold as the clock ticks, so a dropped request '
+  testWidgets(
+      're-asserts the hold as the clock ticks, so a dropped request '
       'gets made again', (tester) async {
     // Arrange
     await pumpScreen(tester, _runningMatch());

--- a/test/features/scoreboard/providers/scoreboard_providers_test.dart
+++ b/test/features/scoreboard/providers/scoreboard_providers_test.dart
@@ -25,9 +25,8 @@ class _SpyNostrService extends NostrService {
   final cached = <NostrEvent>[];
 
   @override
-  List<NostrEvent> cachedEventsOf(int kind, String pubkey) => cached
-      .where((e) => e.kind == kind && e.pubkey == pubkey)
-      .toList();
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) =>
+      cached.where((e) => e.kind == kind && e.pubkey == pubkey).toList();
 
   @override
   Stream<NostrEvent> get eventStream => controller.stream;
@@ -71,7 +70,8 @@ NostrEvent _eventOf(Match match,
 }
 
 void main() {
-  const watched = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const watched =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
   group('parsePubkey', () {
     final crypto = FakeNostrCrypto();
@@ -413,8 +413,8 @@ void main() {
     test('a live event still supersedes the cached one', () async {
       // Arrange
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-      nostr.cached
-          .add(_eventOf(_match(f1Pt2: 1), pubkey: watched, createdAt: now - 60));
+      nostr.cached.add(
+          _eventOf(_match(f1Pt2: 1), pubkey: watched, createdAt: now - 60));
       final feed = ScoreboardFeedNotifier(nostr, watched);
       addTearDown(feed.dispose);
 

--- a/test/features/scoreboard/scoreboard_screens_test.dart
+++ b/test/features/scoreboard/scoreboard_screens_test.dart
@@ -544,7 +544,8 @@ void main() {
           reason: 'the card, by contrast, is meant to be seen through');
       expect(BoardPalette.dark.bannerOutlined, isFalse,
           reason: 'the dark banner never had a border or a shadow');
-      expect(BoardPalette.light.bannerOutlined, isTrue, reason: '3A asks for both');
+      expect(BoardPalette.light.bannerOutlined, isTrue,
+          reason: '3A asks for both');
     });
 
     test('preserves the dark surfaces it started from', () {

--- a/test/main_lifecycle_test.dart
+++ b/test/main_lifecycle_test.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:choke/main.dart';

--- a/test/services/nostr/nostr_service_behavior_test.dart
+++ b/test/services/nostr/nostr_service_behavior_test.dart
@@ -646,8 +646,10 @@ void main() {
     // behaviour here in a way nothing observed: an equal-timestamp event used
     // to be dropped unconditionally, so it never reached eventStream, and a
     // lower-id one is now forwarded.
-    const lowId = 'aaaa11111111111111111111111111111111111111111111111111111111';
-    const highId = 'ffff11111111111111111111111111111111111111111111111111111111';
+    const lowId =
+        'aaaa11111111111111111111111111111111111111111111111111111111';
+    const highId =
+        'ffff11111111111111111111111111111111111111111111111111111111';
 
     /// Deliver two revisions of one match, stamped the same second, in [ids]
     /// order, and report which ids reached the stream.
@@ -738,8 +740,10 @@ void main() {
     test('works on real 64-character ids, not just short fixtures', () {
       // The short ids elsewhere in this group would pass a rule that broke on
       // the length or shape of an actual event id.
-      const low = 'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
-      const high = 'f1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+      const low =
+          'a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
+      const high =
+          'f1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90';
       expect(wins(100, low, 100, high), isTrue);
       expect(wins(100, high, 100, low), isFalse);
     });

--- a/test/services/wakelock/screen_wakelock_test.dart
+++ b/test/services/wakelock/screen_wakelock_test.dart
@@ -202,7 +202,8 @@ void main() {
       expect(toggle.calls, [true, false]);
     });
 
-    test("a dying screen's release cannot cancel another screen's hold", () async {
+    test("a dying screen's release cannot cancel another screen's hold",
+        () async {
       // The route-transition overlap: Flutter disposes a popped route after its
       // exit animation, so the arriving screen holds before the departing one
       // releases. With a shared boolean the stale release won — and if the


### PR DESCRIPTION
Phase 1 of 5 for [docs/specs/announcement-channel.md](docs/specs/announcement-channel.md), following the build order in §8: the pure functions everything else rests on. No UI, no network, no storage.

## What is here

| File | What it does |
|---|---|
| `models/app_version.dart` | semver parse + precedence, as far as `min_version`/`max_version` need it |
| `models/announcement.dart` | the §2 event contract: kind, tags, content schema, locales, lengths, bounds |
| `announcement_publishers.dart` | the §3.1 allowlist and its npub→hex decoding |

## Decisions worth arguing with

- **Build metadata is rejected, not ignored.** Semver excludes it from precedence, so `2.1.0+454` and `2.1.0` compare equal — accepting the bound would silently drop the part the sender meant something by. §2.1 makes an unreadable bound invalidate the announcement, which is the loud failure that gets it fixed.
- **`max_version` is exclusive.** The bound exists so that "2.1 is out" does not reach the people already on 2.1. Inclusive `≤` would make it not do that.
- **A bad `url` is dropped; a bad version bound is fatal.** The copy is the message and the link is an extra, so a typo'd scheme must not silence the text. A targeting instruction nobody can read is different: showing the message to everyone is the wrong way to fail it.
- **Exactly four locales, no fallback.** A fallback to `en` is a bug that ships quietly — the Japanese reader gets English and the sender never finds out. §6's validator turns this into a hard stop at publish time.
- **The allowlist ships empty.** The dedicated offline key of §3.1 does not exist yet, and an empty allowlist is inert by construction: no authors means no subscription, so merging this cannot open a channel. Adding the key is a one-line change, and `announcement_publishers_test.dart` says which test to delete when it happens.

## Test plan

- [x] `flutter analyze` — no new issues
- [x] `flutter test` — 757 pass, 47 of them new
- [x] Parsing: every rejection path in §2 and §7's Content row
- [x] Ordering: the `(created_at, id)` tie-break, including that a redelivered revision does not supersede itself
- [x] Allowlist: one undecodable entry does not disable the rest
- [ ] Nothing here is reachable from the app yet — that starts in phase 2

## Stack

1. **this PR** — parsing, validation, allowlist (§2, §3.1)
2. fetch, verify, freshness, expiry, storage (§3.2–§3.4, §4.1–§4.2)
3. the Announcements setting (§5)
4. bell, screen, four locales of chrome (§4.3)
5. the `tool/` publisher script (§6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying structured announcements with localized titles and messages.
  * Announcements can target specific app versions and include expiration dates, revisions, and optional secure links.
  * Added semantic version handling for accurate announcement targeting.
  * Added publisher controls to ensure announcements are accepted only from approved sources.

* **Bug Fixes**
  * Invalid, incomplete, outdated, or unsupported announcements are safely ignored.
  * Invalid links are excluded without preventing the announcement from appearing.

* **Tests**
  * Added comprehensive coverage for announcement validation, localization, version targeting, revisions, and publisher filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->