### PR TITLE
feat: fetch announcements, and keep only what still holds

### DIFF
--- a/lib/features/announcements/announcement_inbox.dart
+++ b/lib/features/announcements/announcement_inbox.dart
@@ -217,7 +217,9 @@ class AnnouncementInbox extends StateNotifier<AnnouncementInboxState> {
     _read.clear();
     _dismissed.clear();
     _publish();
-    await _store.clear();
+    // Behind the same chain as every other write: a save from an event that
+    // arrived a moment ago must not land after this and put it all back.
+    await _enqueueWrite(_store.clear);
   }
 
   void _onEvent(NostrEvent event) {
@@ -353,21 +355,37 @@ class AnnouncementInbox extends StateNotifier<AnnouncementInboxState> {
     );
   }
 
+  /// The tail of the write chain. Every write to storage queues behind it.
+  ///
+  /// A burst of events is one relay redelivering on reconnect, so overlapping
+  /// writes are the ordinary case rather than the exotic one — and two
+  /// unordered `setString` calls can land newest-first, leaving storage a
+  /// state the app was in two events ago. The snapshot is taken here, when the
+  /// caller asks, so the chain replays the states in the order they happened.
+  Future<void> _writes = Future.value();
+
+  Future<void> _enqueueWrite(Future<void> Function() write) {
+    final next = _writes.then((_) => write());
+    // The chain must survive one failed write, or a single storage error
+    // would wedge every write after it. The store logs its own failures.
+    _writes = next.catchError((_) {});
+    return next;
+  }
+
   Future<void> _persist() {
-    return _store.save(
-      AnnouncementCache(
-        events: _held.values.map((held) => held.event).toList(),
-        read: Map.of(_read),
-        dismissed: Map.of(_dismissed),
-      ),
+    final snapshot = AnnouncementCache(
+      events: _held.values.map((held) => held.event).toList(),
+      read: Map.of(_read),
+      dismissed: Map.of(_dismissed),
     );
+    return _enqueueWrite(() => _store.save(snapshot));
   }
 
   @override
   void dispose() {
-    _events?.cancel();
-    _events = null;
-    _isOpen = false;
+    // Through close(), so the relays are told: cancelling the listener alone
+    // leaves a REQ open on every socket, feeding a stream nobody reads.
+    close();
     super.dispose();
   }
 }

--- a/lib/features/announcements/announcement_inbox.dart
+++ b/lib/features/announcements/announcement_inbox.dart
@@ -1,0 +1,373 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../services/nostr/crypto/nostr_crypto.dart';
+import '../../services/nostr/nostr_service.dart';
+import '../../services/nostr/relay/nostr_relay_backend.dart' show Filter;
+import 'announcement_store.dart';
+import 'models/announcement.dart';
+import 'models/app_version.dart';
+
+/// Nothing older than this is news, however long a relay has been serving it.
+const Duration kAnnouncementMaxAge = Duration(days: 30);
+
+/// Clock skew, not tolerance for post-dating: an announcement dated next week
+/// must not sit at the top of every inbox until then (§3.3).
+const Duration kAnnouncementClockSkew = Duration(minutes: 5);
+
+/// How many announcements are kept, newest first.
+const int kAnnouncementCacheLimit = 20;
+
+/// The subscription id. One channel, one subscription, and a REQ that repeats
+/// an id replaces it.
+const String kAnnouncementSubscriptionId = 'announcements';
+
+/// One announcement as the UI needs it.
+@immutable
+class AnnouncementEntry {
+  final Announcement announcement;
+  final bool isRead;
+
+  const AnnouncementEntry({required this.announcement, required this.isRead});
+
+  String get address => announcement.address;
+}
+
+/// Everything shown, newest first, with the dismissed ones already gone.
+@immutable
+class AnnouncementInboxState {
+  final List<AnnouncementEntry> entries;
+
+  const AnnouncementInboxState({this.entries = const []});
+
+  bool get hasUnread => entries.any((entry) => !entry.isRead);
+
+  int get unreadCount => entries.where((entry) => !entry.isRead).length;
+}
+
+/// The announcement channel: what arrives, what is kept, and what is shown.
+///
+/// Everything §3 asks for happens here, in one pass, over one definition of an
+/// acceptable announcement — an arriving event and a cached one go through the
+/// same door:
+///
+/// 1. the author is on the allowlist (§3.1)
+/// 2. the signature verifies, **in the crate, every time** (§3.2)
+/// 3. the schema of §2 parses
+/// 4. it is neither stale nor post-dated, and has not expired (§3.3, §3.4)
+/// 5. it targets this app version (§2.1)
+/// 6. it is the revision that wins at its address (§3.3)
+///
+/// Every rejection is silent. A user who never receives an announcement should
+/// not be able to tell that they didn't (§4.4).
+class AnnouncementInbox extends StateNotifier<AnnouncementInboxState> {
+  AnnouncementInbox({
+    required NostrService service,
+    required NostrCrypto crypto,
+    required AppVersion appVersion,
+    required List<String> publishers,
+    AnnouncementStore store = const AnnouncementStore(),
+    DateTime Function() now = DateTime.now,
+  })  : _service = service,
+        _crypto = crypto,
+        _appVersion = appVersion,
+        _publishers = Set.unmodifiable(publishers),
+        _store = store,
+        _now = now,
+        super(const AnnouncementInboxState());
+
+  final NostrService _service;
+  final NostrCrypto _crypto;
+  final AppVersion _appVersion;
+  final Set<String> _publishers;
+  final AnnouncementStore _store;
+  final DateTime Function() _now;
+
+  /// Address → the event and the announcement inside it. The event is kept
+  /// because it is what gets written back: a restore re-verifies rather than
+  /// trusting what we parsed last time.
+  final Map<String, ({NostrEvent event, Announcement announcement})> _held = {};
+  final Map<String, AnnouncementRevision> _read = {};
+  final Map<String, AnnouncementRevision> _dismissed = {};
+
+  StreamSubscription<NostrEvent>? _events;
+
+  /// Whether the channel is open. Events that arrive while it is not are
+  /// discarded rather than queued: switching the setting off must take effect
+  /// at the tap, not at the next background transition (§5).
+  bool _isOpen = false;
+
+  bool get isOpen => _isOpen;
+
+  int get _nowSeconds => _now().millisecondsSinceEpoch ~/ 1000;
+
+  /// Read the cache and re-run every rule over it.
+  ///
+  /// Not a fast path that trusts what it stored: the clock has moved, and the
+  /// allowlist or the app version may have changed since. An entry that no
+  /// longer passes is dropped here *and* removed from storage (§4.2).
+  Future<void> restore() async {
+    final cache = await _store.load();
+    if (cache.isEmpty) return;
+
+    for (final event in cache.events) {
+      _admit(event);
+    }
+
+    // Read and dismissed state only survives for an address that survived.
+    _read.addEntries(
+      cache.read.entries.where((entry) => _held.containsKey(entry.key)),
+    );
+    _dismissed.addEntries(
+      cache.dismissed.entries.where((entry) => _held.containsKey(entry.key)),
+    );
+
+    _publish();
+    // Whatever the clock or the allowlist just rejected is gone from disk too.
+    await _persist();
+  }
+
+  /// Open the channel: subscribe, and start listening.
+  ///
+  /// A no-op when the allowlist decodes to nothing. An unfiltered subscription
+  /// would be a request for every announcement-kind event on the relay, signed
+  /// by anyone, and the answer to "we have no key yet" is silence.
+  void open() {
+    if (_isOpen) return;
+    if (_publishers.isEmpty) {
+      debugPrint('Announcements: no publishers, opening no subscription');
+      return;
+    }
+
+    _isOpen = true;
+    _events = _service.eventStream.listen(_onEvent);
+    _service.subscribeWithFilter(
+      kAnnouncementSubscriptionId,
+      Filter(
+        kinds: const [kAnnouncementKind],
+        authors: _publishers.toList(),
+        since: _nowSeconds - kAnnouncementMaxAge.inSeconds,
+        limit: kAnnouncementCacheLimit,
+      ),
+    );
+  }
+
+  /// Close the channel, now.
+  ///
+  /// The listener is cancelled before the subscription is dropped, so anything
+  /// already on its way is discarded rather than processed. Off means the
+  /// subscription is not open, not that arriving events are hidden (§5).
+  void close() {
+    if (!_isOpen) return;
+    _isOpen = false;
+    _events?.cancel();
+    _events = null;
+    _service.unsubscribe(kAnnouncementSubscriptionId);
+  }
+
+  /// Re-check what is held against the current time.
+  ///
+  /// The offline case, and only that: freshness and expiry are enforced on
+  /// arrival, but a phone that spends five weeks in a gym basement receives
+  /// nothing to displace what it has. Without this, "we are down for
+  /// maintenance tonight" outlives its own expiration precisely because
+  /// nothing came in (§4.2).
+  Future<void> revalidate() async {
+    final stale = _held.entries
+        .where((entry) => !_isCurrent(entry.value.announcement))
+        .map((entry) => entry.key)
+        .toList();
+    if (stale.isEmpty) return;
+
+    for (final address in stale) {
+      _forget(address);
+    }
+    _publish();
+    await _persist();
+  }
+
+  /// Mark an announcement read. Idempotent.
+  Future<void> markRead(String address) async {
+    final held = _held[address];
+    if (held == null) return;
+    if (_read[address] == held.announcement.revision) return;
+
+    _read[address] = held.announcement.revision;
+    _publish();
+    await _persist();
+  }
+
+  /// Swipe it away. The address stays in the dismissed map so a redelivery of
+  /// the same revision does not bring it back.
+  Future<void> dismiss(String address) async {
+    final held = _held[address];
+    if (held == null) return;
+    if (_dismissed[address] == held.announcement.revision) return;
+
+    _dismissed[address] = held.announcement.revision;
+    _publish();
+    await _persist();
+  }
+
+  /// Forget everything, in memory and on disk. For the switch of §5.
+  Future<void> forgetEverything() async {
+    _held.clear();
+    _read.clear();
+    _dismissed.clear();
+    _publish();
+    await _store.clear();
+  }
+
+  void _onEvent(NostrEvent event) {
+    if (!_isOpen) return;
+    if (!_admit(event)) return;
+    _publish();
+    unawaited(_persist());
+  }
+
+  /// The one door. Returns whether anything changed.
+  bool _admit(NostrEvent event) {
+    if (event.kind != kAnnouncementKind) return false;
+
+    // The allowlist first, because it is a set lookup and verification is not.
+    if (!_publishers.contains(event.pubkey)) {
+      debugPrint('Announcements: ignoring event from an unlisted key');
+      return false;
+    }
+
+    // Verified here, in the crate, whatever the relay pool does or does not
+    // check on its own (§3.2). The pool's settings are a transport detail that
+    // can change under us; this is the only property the feature rests on.
+    bool verified;
+    try {
+      verified = _crypto.verifyEvent(event);
+    } catch (e) {
+      debugPrint('Announcements: verification threw: $e');
+      return false;
+    }
+    if (!verified) {
+      debugPrint('Announcements: dropping an event that failed verification');
+      return false;
+    }
+
+    final announcement = Announcement.tryParse(event);
+    if (announcement == null) return false;
+    if (!_isCurrent(announcement)) return false;
+
+    final held = _held[announcement.address];
+    if (held != null &&
+        !announcement.revision.supersedes(held.announcement.revision)) {
+      // Either a redelivery of what we have, or an older revision. Neither is
+      // news, and neither may re-announce.
+      return false;
+    }
+
+    if (held != null) {
+      // A correction the user has already read and dismissed must not arrive
+      // pre-dismissed — that loses it in exactly the case it was published
+      // for (§3.3).
+      _read.remove(announcement.address);
+      _dismissed.remove(announcement.address);
+    }
+
+    _held[announcement.address] = (event: event, announcement: announcement);
+    _evictBeyondLimit();
+    return true;
+  }
+
+  /// Freshness (§3.3), expiry (§3.4) and targeting (§2.1), against the clock
+  /// as it is right now.
+  bool _isCurrent(Announcement announcement) {
+    final now = _nowSeconds;
+
+    if (announcement.createdAt < now - kAnnouncementMaxAge.inSeconds) {
+      debugPrint('Announcements: ${announcement.address} is too old');
+      return false;
+    }
+    if (announcement.createdAt > now + kAnnouncementClockSkew.inSeconds) {
+      debugPrint('Announcements: ${announcement.address} is post-dated');
+      return false;
+    }
+    if (announcement.expiration <= now) {
+      debugPrint('Announcements: ${announcement.address} has expired');
+      return false;
+    }
+    if (!announcement.appliesTo(_appVersion)) {
+      debugPrint(
+        'Announcements: ${announcement.address} is not for $_appVersion',
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /// Keep the newest [kAnnouncementCacheLimit] and no more.
+  void _evictBeyondLimit() {
+    if (_held.length <= kAnnouncementCacheLimit) return;
+
+    final byAge = _held.entries.toList()
+      ..sort(
+        (a, b) => _compareNewestFirst(
+          a.value.announcement,
+          b.value.announcement,
+        ),
+      );
+    for (final entry in byAge.skip(kAnnouncementCacheLimit)) {
+      _forget(entry.key);
+    }
+  }
+
+  /// Drop an address everywhere at once. Nothing may reference an address that
+  /// is no longer held.
+  void _forget(String address) {
+    _held.remove(address);
+    _read.remove(address);
+    _dismissed.remove(address);
+  }
+
+  static int _compareNewestFirst(Announcement a, Announcement b) {
+    if (a.createdAt != b.createdAt) return b.createdAt.compareTo(a.createdAt);
+    // A stable tiebreak so two announcements published in the same second do
+    // not swap places between rebuilds.
+    return a.revision.eventId.compareTo(b.revision.eventId);
+  }
+
+  void _publish() {
+    final visible = _held.values
+        .map((held) => held.announcement)
+        .where((announcement) => !_dismissed.containsKey(announcement.address))
+        .toList()
+      ..sort(_compareNewestFirst);
+
+    state = AnnouncementInboxState(
+      entries: List.unmodifiable(
+        visible.map(
+          (announcement) => AnnouncementEntry(
+            announcement: announcement,
+            isRead: _read.containsKey(announcement.address),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _persist() {
+    return _store.save(
+      AnnouncementCache(
+        events: _held.values.map((held) => held.event).toList(),
+        read: Map.of(_read),
+        dismissed: Map.of(_dismissed),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _events?.cancel();
+    _events = null;
+    _isOpen = false;
+    super.dispose();
+  }
+}

--- a/lib/features/announcements/announcement_inbox.dart
+++ b/lib/features/announcements/announcement_inbox.dart
@@ -116,17 +116,28 @@ class AnnouncementInbox extends StateNotifier<AnnouncementInboxState> {
       _admit(event);
     }
 
-    // Read and dismissed state only survives for an address that survived.
-    _read.addEntries(
-      cache.read.entries.where((entry) => _held.containsKey(entry.key)),
-    );
-    _dismissed.addEntries(
-      cache.dismissed.entries.where((entry) => _held.containsKey(entry.key)),
-    );
+    // Read and dismissed state survives only for an address that survived,
+    // **at the revision it was recorded against**.
+    //
+    // The revision check is also what makes this safe to run in any order
+    // relative to the live subscription. On a slow cold start the app can be
+    // resumed before the post-frame callback that calls this, so open() may
+    // already have admitted a newer revision at a known address — and applying
+    // a read mark recorded against the revision it replaced would show a
+    // correction as something the user had already read. That is the one case
+    // the correction was published for (§3.3).
+    _read.addEntries(cache.read.entries.where(_isRevisionStillHeld));
+    _dismissed.addEntries(cache.dismissed.entries.where(_isRevisionStillHeld));
 
     _publish();
     // Whatever the clock or the allowlist just rejected is gone from disk too.
     await _persist();
+  }
+
+  /// Whether the announcement at this address is still the revision the entry
+  /// was recorded against.
+  bool _isRevisionStillHeld(MapEntry<String, AnnouncementRevision> entry) {
+    return _held[entry.key]?.announcement.revision == entry.value;
   }
 
   /// Open the channel: subscribe, and start listening.
@@ -364,11 +375,26 @@ class AnnouncementInbox extends StateNotifier<AnnouncementInboxState> {
   /// caller asks, so the chain replays the states in the order they happened.
   Future<void> _writes = Future.value();
 
+  /// The write chain, for a test that needs to read storage back.
+  ///
+  /// Persistence is deliberately fire-and-forget — nothing on screen waits for
+  /// a disk write — which leaves a test with no synchronization point and a
+  /// choice between guessing a delay and this.
+  @visibleForTesting
+  Future<void> get pendingWrites => _writes;
+
   Future<void> _enqueueWrite(Future<void> Function() write) {
-    final next = _writes.then((_) => write());
-    // The chain must survive one failed write, or a single storage error
-    // would wedge every write after it. The store logs its own failures.
-    _writes = next.catchError((_) {});
+    // Guarded twice, and both are load-bearing. The chain must survive one
+    // failed write, or a single storage error wedges every write after it —
+    // and the *returned* future must not carry the error either: half its
+    // callers are `unawaited`, where a rejection is an unhandled async error,
+    // and the other half are UI callbacks that have nothing to do with one.
+    // AnnouncementStore swallows its own failures today, but `store` is
+    // injectable and the next implementation is under no such obligation.
+    final next = _writes.then((_) => write()).catchError((Object e) {
+      debugPrint('Announcements: a write to storage failed: $e');
+    });
+    _writes = next;
     return next;
   }
 

--- a/lib/features/announcements/announcement_providers.dart
+++ b/lib/features/announcements/announcement_providers.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../services/nostr/crypto/nostr_crypto.dart';
+import '../../services/nostr/nostr_service.dart';
+import 'announcement_inbox.dart';
+import 'announcement_publishers.dart';
+import 'models/app_version.dart';
+
+/// The version this build reports, from `package_info_plus`.
+///
+/// Overridden in `main.dart`, like the crypto and the relay backend: reading a
+/// plugin is an async call, and version targeting has to answer synchronously
+/// for every event that arrives.
+final appVersionProvider = Provider<AppVersion>((ref) {
+  throw UnimplementedError(
+    'appVersionProvider must be overridden with the running app version',
+  );
+});
+
+/// The allowlist of §3.1, decoded to the hex a subscription filter needs.
+final announcementPublishersProvider = Provider<List<String>>((ref) {
+  return decodeAnnouncementPublishers(ref.watch(nostrCryptoProvider));
+});
+
+/// The announcement channel.
+final announcementInboxProvider =
+    StateNotifierProvider<AnnouncementInbox, AnnouncementInboxState>((ref) {
+  final inbox = AnnouncementInbox(
+    service: ref.watch(nostrServiceProvider),
+    crypto: ref.watch(nostrCryptoProvider),
+    appVersion: ref.watch(appVersionProvider),
+    publishers: ref.watch(announcementPublishersProvider),
+  );
+  ref.onDispose(inbox.close);
+  return inbox;
+});

--- a/lib/features/announcements/announcement_store.dart
+++ b/lib/features/announcements/announcement_store.dart
@@ -42,9 +42,13 @@ class AnnouncementCache {
 /// what it stored. Deciding what is still an announcement is
 /// `AnnouncementInbox`'s job, on the way out.
 class AnnouncementStore {
-  static const String eventsKey = 'choke:announcements:events';
-  static const String readKey = 'choke:announcements:read';
-  static const String dismissedKey = 'choke:announcements:dismissed';
+  /// One key, holding the whole cache.
+  ///
+  /// Three keys would have been the obvious shape and the wrong one:
+  /// `shared_preferences` has no transaction across keys, so a write that
+  /// stopped between them would leave a new event list beside an old read map,
+  /// and nothing would say so. One value lands or it does not.
+  static const String cacheKey = 'choke:announcements';
 
   const AnnouncementStore();
 
@@ -57,10 +61,16 @@ class AnnouncementStore {
   Future<AnnouncementCache> load() async {
     try {
       final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(cacheKey);
+      if (raw == null || raw.isEmpty) return const AnnouncementCache();
+
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return const AnnouncementCache();
+
       return AnnouncementCache(
-        events: _decodeEvents(prefs.getString(eventsKey)),
-        read: _decodeRevisions(prefs.getString(readKey)),
-        dismissed: _decodeRevisions(prefs.getString(dismissedKey)),
+        events: _decodeEvents(decoded['events']),
+        read: _decodeRevisions(decoded['read']),
+        dismissed: _decodeRevisions(decoded['dismissed']),
       );
     } catch (e) {
       debugPrint('AnnouncementStore: load failed: $e');
@@ -70,18 +80,20 @@ class AnnouncementStore {
 
   /// Replace everything stored with [cache].
   ///
-  /// A whole-cache write rather than three independent ones: the read map
-  /// points at addresses in the event list, and a partial write is how they
-  /// would come to disagree.
+  /// One `setString`, so the three pieces cannot disagree: the read map points
+  /// at addresses in the event list, and there is no moment at which half of
+  /// this has landed.
   Future<void> save(AnnouncementCache cache) async {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(
-        eventsKey,
-        jsonEncode(cache.events.map((e) => e.toJson()).toList()),
+        cacheKey,
+        jsonEncode({
+          'events': cache.events.map((e) => e.toJson()).toList(),
+          'read': _encodeRevisions(cache.read),
+          'dismissed': _encodeRevisions(cache.dismissed),
+        }),
       );
-      await prefs.setString(readKey, _encodeRevisions(cache.read));
-      await prefs.setString(dismissedKey, _encodeRevisions(cache.dismissed));
     } catch (e) {
       debugPrint('AnnouncementStore: save failed: $e');
     }
@@ -91,21 +103,17 @@ class AnnouncementStore {
   Future<void> clear() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(eventsKey);
-      await prefs.remove(readKey);
-      await prefs.remove(dismissedKey);
+      await prefs.remove(cacheKey);
     } catch (e) {
       debugPrint('AnnouncementStore: clear failed: $e');
     }
   }
 
-  static List<NostrEvent> _decodeEvents(String? raw) {
-    if (raw == null || raw.isEmpty) return const [];
-    final decoded = jsonDecode(raw);
-    if (decoded is! List) return const [];
+  static List<NostrEvent> _decodeEvents(Object? raw) {
+    if (raw is! List) return const [];
 
     final events = <NostrEvent>[];
-    for (final entry in decoded) {
+    for (final entry in raw) {
       try {
         events.add(NostrEvent.fromJson(entry as Map<String, dynamic>));
       } catch (e) {
@@ -117,13 +125,11 @@ class AnnouncementStore {
     return events;
   }
 
-  static Map<String, AnnouncementRevision> _decodeRevisions(String? raw) {
-    if (raw == null || raw.isEmpty) return const {};
-    final decoded = jsonDecode(raw);
-    if (decoded is! Map<String, dynamic>) return const {};
+  static Map<String, AnnouncementRevision> _decodeRevisions(Object? raw) {
+    if (raw is! Map<String, dynamic>) return const {};
 
     final revisions = <String, AnnouncementRevision>{};
-    decoded.forEach((address, value) {
+    raw.forEach((address, value) {
       if (value is! Map<String, dynamic>) return;
       final createdAt = value['created_at'];
       final id = value['id'];
@@ -134,13 +140,15 @@ class AnnouncementStore {
     return revisions;
   }
 
-  static String _encodeRevisions(Map<String, AnnouncementRevision> revisions) {
-    return jsonEncode({
+  static Map<String, dynamic> _encodeRevisions(
+    Map<String, AnnouncementRevision> revisions,
+  ) {
+    return {
       for (final entry in revisions.entries)
         entry.key: {
           'created_at': entry.value.createdAt,
           'id': entry.value.eventId,
         },
-    });
+    };
   }
 }

--- a/lib/features/announcements/announcement_store.dart
+++ b/lib/features/announcements/announcement_store.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../services/nostr/nostr_service.dart' show NostrEvent;
+import 'models/announcement.dart';
+
+/// What survives a restart: the announcements themselves and what the user has
+/// already done with them.
+@immutable
+class AnnouncementCache {
+  /// The signed events, exactly as they arrived.
+  ///
+  /// The *events*, not the parsed announcements, and that is the point: a
+  /// restore re-runs the whole pipeline — signature, allowlist, schema,
+  /// freshness, expiry, targeting — over them. There is one definition of an
+  /// acceptable announcement and the cache cannot hold something outside it,
+  /// so a key dropped from the allowlist takes its cached announcements with
+  /// it on the next launch.
+  final List<NostrEvent> events;
+
+  /// Address → the revision that was read.
+  final Map<String, AnnouncementRevision> read;
+
+  /// Address → the revision that was dismissed.
+  final Map<String, AnnouncementRevision> dismissed;
+
+  const AnnouncementCache({
+    this.events = const [],
+    this.read = const {},
+    this.dismissed = const {},
+  });
+
+  bool get isEmpty => events.isEmpty && read.isEmpty && dismissed.isEmpty;
+}
+
+/// The announcement cache in `shared_preferences`, following
+/// `match_sound_provider` and its neighbours.
+///
+/// Nothing here validates anything: it stores what it is given and returns
+/// what it stored. Deciding what is still an announcement is
+/// `AnnouncementInbox`'s job, on the way out.
+class AnnouncementStore {
+  static const String eventsKey = 'choke:announcements:events';
+  static const String readKey = 'choke:announcements:read';
+  static const String dismissedKey = 'choke:announcements:dismissed';
+
+  const AnnouncementStore();
+
+  /// Everything previously stored, or an empty cache.
+  ///
+  /// A read that fails or a value that no longer parses yields empty rather
+  /// than throwing: the worst case is a user who sees an announcement twice,
+  /// which is a great deal better than a launch that cannot get past the
+  /// announcement cache.
+  Future<AnnouncementCache> load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      return AnnouncementCache(
+        events: _decodeEvents(prefs.getString(eventsKey)),
+        read: _decodeRevisions(prefs.getString(readKey)),
+        dismissed: _decodeRevisions(prefs.getString(dismissedKey)),
+      );
+    } catch (e) {
+      debugPrint('AnnouncementStore: load failed: $e');
+      return const AnnouncementCache();
+    }
+  }
+
+  /// Replace everything stored with [cache].
+  ///
+  /// A whole-cache write rather than three independent ones: the read map
+  /// points at addresses in the event list, and a partial write is how they
+  /// would come to disagree.
+  Future<void> save(AnnouncementCache cache) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        eventsKey,
+        jsonEncode(cache.events.map((e) => e.toJson()).toList()),
+      );
+      await prefs.setString(readKey, _encodeRevisions(cache.read));
+      await prefs.setString(dismissedKey, _encodeRevisions(cache.dismissed));
+    } catch (e) {
+      debugPrint('AnnouncementStore: save failed: $e');
+    }
+  }
+
+  /// Forget everything. Used when the channel is switched off (§5).
+  Future<void> clear() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(eventsKey);
+      await prefs.remove(readKey);
+      await prefs.remove(dismissedKey);
+    } catch (e) {
+      debugPrint('AnnouncementStore: clear failed: $e');
+    }
+  }
+
+  static List<NostrEvent> _decodeEvents(String? raw) {
+    if (raw == null || raw.isEmpty) return const [];
+    final decoded = jsonDecode(raw);
+    if (decoded is! List) return const [];
+
+    final events = <NostrEvent>[];
+    for (final entry in decoded) {
+      try {
+        events.add(NostrEvent.fromJson(entry as Map<String, dynamic>));
+      } catch (e) {
+        // One unreadable row must not cost the others: the whole point of the
+        // cache is what the project last said.
+        debugPrint('AnnouncementStore: dropping unreadable event: $e');
+      }
+    }
+    return events;
+  }
+
+  static Map<String, AnnouncementRevision> _decodeRevisions(String? raw) {
+    if (raw == null || raw.isEmpty) return const {};
+    final decoded = jsonDecode(raw);
+    if (decoded is! Map<String, dynamic>) return const {};
+
+    final revisions = <String, AnnouncementRevision>{};
+    decoded.forEach((address, value) {
+      if (value is! Map<String, dynamic>) return;
+      final createdAt = value['created_at'];
+      final id = value['id'];
+      if (createdAt is! int || id is! String) return;
+      revisions[address] =
+          AnnouncementRevision(createdAt: createdAt, eventId: id);
+    });
+    return revisions;
+  }
+
+  static String _encodeRevisions(Map<String, AnnouncementRevision> revisions) {
+    return jsonEncode({
+      for (final entry in revisions.entries)
+        entry.key: {
+          'created_at': entry.value.createdAt,
+          'id': entry.value.eventId,
+        },
+    });
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 import 'shared/theme/app_theme.dart';
 import 'shared/providers/locale_provider.dart';
@@ -16,6 +17,8 @@ import 'services/deep_links/share_link.dart';
 import 'shared/providers/navigation_provider.dart';
 import 'features/settings/settings_screen.dart';
 import 'features/match/providers/submissions_provider.dart';
+import 'features/announcements/announcement_providers.dart';
+import 'features/announcements/models/app_version.dart';
 import 'features/settings/providers/relay_config_provider.dart';
 import 'services/key_management/key_manager.dart';
 import 'services/nostr/crypto/nostr_crypto.dart';
@@ -83,6 +86,20 @@ void main() async {
     debugPrint('NostrService initialization failed: $e\n$st');
   }
 
+  // The version that version targeting compares against (§2.1 of the
+  // announcement spec). PackageInfo.version is the pubspec version without the
+  // build number — 2.0.1, never 2.0.1+454 — which is exactly the form a bound
+  // is written in. A version that will not parse falls back to 0.0.0: that
+  // hides any announcement carrying a lower bound, which is the safe direction
+  // to fail in for something nobody asked for.
+  var appVersion = AppVersion.tryParse('0.0.0')!;
+  try {
+    final packageInfo = await PackageInfo.fromPlatform();
+    appVersion = AppVersion.tryParse(packageInfo.version) ?? appVersion;
+  } catch (e, st) {
+    debugPrint('App version lookup failed: $e\n$st');
+  }
+
   // Load saved preferences before first frame to avoid flash
   final savedThemeMode = await ThemeModeNotifier.loadSavedThemeMode();
   final savedLocale = await LocaleNotifier.loadSavedLocale();
@@ -102,6 +119,7 @@ void main() async {
     ProviderScope(
       overrides: [
         nostrCryptoProvider.overrideWithValue(crypto),
+        appVersionProvider.overrideWithValue(appVersion),
         keyManagerProvider.overrideWithValue(keyManager),
         nostrServiceProvider.overrideWithValue(nostrService),
         relayConfigServiceProvider.overrideWithValue(relayConfigService),
@@ -140,6 +158,23 @@ class _ChokeAppState extends ConsumerState<ChokeApp>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _handleLaunchLink();
+    _startAnnouncements();
+  }
+
+  /// Read the cached announcements, then open the channel.
+  ///
+  /// After the first frame, because both touch providers. Restore comes first
+  /// so what the project last said is on screen before any relay answers —
+  /// and so an arriving revision has something to supersede rather than
+  /// landing beside a copy of itself.
+  void _startAnnouncements() {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      final inbox = ref.read(announcementInboxProvider.notifier);
+      await inbox.restore();
+      if (!mounted) return;
+      inbox.open();
+    });
   }
 
   @override
@@ -152,6 +187,17 @@ class _ChokeAppState extends ConsumerState<ChokeApp>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       ref.read(nostrServiceProvider).reconnectAll();
+
+      // The clock moved while we were away, and nothing arrived to displace
+      // what is cached — an announcement can have aged past its window or its
+      // expiration with the app closed (§4.2). Re-check before reopening, so
+      // the channel never renders something it would now reject.
+      final inbox = ref.read(announcementInboxProvider.notifier);
+      inbox.revalidate();
+      inbox.open();
+    } else if (state == AppLifecycleState.paused) {
+      // No background work of any kind (§4.1, §9).
+      ref.read(announcementInboxProvider.notifier).close();
     }
   }
 

--- a/lib/services/nostr/nostr_service.dart
+++ b/lib/services/nostr/nostr_service.dart
@@ -264,6 +264,17 @@ class NostrService {
   static String _shortKey(String pubkey) =>
       pubkey.length <= 16 ? pubkey : pubkey.substring(0, 16);
 
+  /// Subscribe with a filter the caller built itself.
+  ///
+  /// The match subscriptions above are shaped alike — one kind, one author —
+  /// and the announcement channel is not: a fixed kind, a fixed *list* of
+  /// authors, `since` and `limit` (§4.1 of the announcement spec). Rather than
+  /// grow a second nearly-identical helper per filter shape, a caller whose
+  /// filter is its own business passes it. The pairing [unsubscribe] is
+  /// already general in exactly the same way.
+  void subscribeWithFilter(String subscriptionId, Filter filter) =>
+      _backend.subscribe(subscriptionId, filter);
+
   /// Unsubscribe from a subscription
   void unsubscribe(String subscriptionId) =>
       _backend.unsubscribe(subscriptionId);

--- a/test/features/announcements/announcement_inbox_test.dart
+++ b/test/features/announcements/announcement_inbox_test.dart
@@ -1,0 +1,705 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/announcements/announcement_inbox.dart';
+import 'package:choke/features/announcements/announcement_store.dart';
+import 'package:choke/features/announcements/models/announcement.dart';
+import 'package:choke/features/announcements/models/app_version.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+
+import '../../support/nostr_fakes.dart';
+
+const String _publisher = 'aa11';
+const String _stranger = 'ff99';
+
+/// Wall clock every test shares, so "31 days old" is a fixed number.
+final DateTime _now = DateTime.utc(2026, 8, 2, 12);
+int get _nowSeconds => _now.millisecondsSinceEpoch ~/ 1000;
+
+/// Verifies everything except the events a test names as tampered with.
+class _Verifier extends FakeNostrCrypto {
+  final Set<String> rejected = {};
+  final Set<String> throwing = {};
+  int verifyCalls = 0;
+
+  @override
+  bool verifyEvent(NostrEvent event) {
+    verifyCalls++;
+    if (throwing.contains(event.id)) throw StateError('native boom');
+    return !rejected.contains(event.id);
+  }
+}
+
+NostrEvent _event({
+  String id = 'e1',
+  String pubkey = _publisher,
+  String d = 'release-2-1',
+  int? createdAt,
+  int? expiration,
+  int kind = kAnnouncementKind,
+  String title = 'Version 2.1 is out',
+  String? minVersion,
+  String? maxVersion,
+}) {
+  return NostrEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: createdAt ?? _nowSeconds - 60,
+    kind: kind,
+    tags: [
+      ['d', d],
+      ['expiration', '${expiration ?? _nowSeconds + 86400}'],
+      if (minVersion != null) ['min_version', minVersion],
+      if (maxVersion != null) ['max_version', maxVersion],
+    ],
+    content: jsonEncode({
+      'v': kAnnouncementSchemaVersion,
+      'locales': {
+        for (final code in kAnnouncementLocales)
+          code: {'title': title, 'body': 'body'},
+      },
+    }),
+    sig: 'f' * 128,
+  );
+}
+
+/// An inbox wired to fakes, with the clock and the allowlist under the test's
+/// control.
+({
+  AnnouncementInbox inbox,
+  RecordingRelayBackend backend,
+  NostrService service,
+  _Verifier crypto,
+}) _build({
+  List<String> publishers = const [_publisher],
+  String appVersion = '2.0.1',
+  DateTime? clock,
+}) {
+  final backend = RecordingRelayBackend();
+  final crypto = _Verifier();
+  final service = NostrService(
+    KeyManager(crypto: crypto),
+    crypto: crypto,
+    backend: backend,
+  );
+  final inbox = AnnouncementInbox(
+    service: service,
+    crypto: crypto,
+    appVersion: AppVersion.tryParse(appVersion)!,
+    publishers: publishers,
+    now: () => clock ?? _now,
+  );
+  return (inbox: inbox, backend: backend, service: service, crypto: crypto);
+}
+
+/// Push an event through the relay and let the stream turn.
+Future<void> _deliver(RecordingRelayBackend backend, NostrEvent event) async {
+  backend.eventsController.add(event);
+  await Future<void>.delayed(Duration.zero);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('the allowlist', () {
+    test('an event from an allowed key is accepted', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event());
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(1));
+      expect(w.inbox.state.entries.single.announcement.publisher, _publisher);
+      expect(w.inbox.state.hasUnread, isTrue);
+    });
+
+    test('an event from any other key is ignored', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act — a relay can serve anything it likes
+      await _deliver(w.backend, _event(pubkey: _stranger));
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('an empty allowlist opens no subscription at all', () async {
+      // Arrange — the state this ships in, until the offline key exists
+      final w = _build(publishers: const []);
+
+      // Act
+      w.inbox.open();
+
+      // Assert
+      expect(w.inbox.isOpen, isFalse);
+      expect(w.backend.subscriptions, isEmpty);
+    });
+
+    test('the filter asks for the kind, the authors, and 30 days', () async {
+      // Arrange
+      final w = _build(publishers: const [_publisher, _stranger]);
+
+      // Act
+      w.inbox.open();
+
+      // Assert
+      final filter = w.backend.subscriptions[kAnnouncementSubscriptionId]!;
+      expect(filter.kinds, [kAnnouncementKind]);
+      expect(filter.authors, [_publisher, _stranger]);
+      expect(filter.limit, kAnnouncementCacheLimit);
+      expect(filter.since, _nowSeconds - kAnnouncementMaxAge.inSeconds);
+    });
+  });
+
+  group('verification', () {
+    test('every accepted event is verified in the crate', () async {
+      // Arrange — asserted where it is used, not assumed of the relay pool
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event());
+
+      // Assert
+      expect(w.crypto.verifyCalls, 1);
+    });
+
+    test('an event that fails verification is dropped silently', () async {
+      // Arrange
+      final w = _build();
+      w.crypto.rejected.add('tampered');
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(id: 'tampered'));
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('verification throwing drops the event, not the app', () async {
+      // Arrange — the native library is a foreign function call
+      final w = _build();
+      w.crypto.throwing.add('boom');
+      w.inbox.open();
+
+      // Act + Assert
+      await _deliver(w.backend, _event(id: 'boom'));
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('an unlisted key is never even verified', () async {
+      // Arrange — the cheap check comes first
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(pubkey: _stranger));
+
+      // Assert
+      expect(w.crypto.verifyCalls, 0);
+    });
+  });
+
+  group('freshness', () {
+    test('an announcement older than 30 days is ignored', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(
+        w.backend,
+        _event(createdAt: _nowSeconds - const Duration(days: 31).inSeconds),
+      );
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('an announcement dated ten minutes ahead is ignored', () async {
+      // Arrange — post-dating must not park a message at the top of the inbox
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(createdAt: _nowSeconds + 600));
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('a minute of clock skew is tolerated', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(createdAt: _nowSeconds + 60));
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(1));
+    });
+  });
+
+  group('expiry', () {
+    test('an event already expired on arrival is dropped', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(expiration: _nowSeconds - 1));
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+  });
+
+  group('version targeting', () {
+    test('an announcement below min_version is not for this build', () async {
+      // Arrange — running 2.0.1
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(minVersion: '2.1.0'));
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('2.0.1 still hears that 2.1 is out', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act — max_version is exclusive
+      await _deliver(w.backend, _event(maxVersion: '2.1.0'));
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(1));
+    });
+
+    test('2.1.0 does not hear that 2.1 is out', () async {
+      // Arrange
+      final w = _build(appVersion: '2.1.0');
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(maxVersion: '2.1.0'));
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+  });
+
+  group('replay and revisions', () {
+    test('the same event delivered twice does not re-announce', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+      await w.inbox.markRead(w.inbox.state.entries.single.address);
+
+      // Act — relays redeliver on reconnect
+      await _deliver(w.backend, _event());
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(1));
+      expect(w.inbox.state.hasUnread, isFalse);
+    });
+
+    test('a newer revision replaces and re-announces', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event(title: 'Sunday at 9'));
+      final address = w.inbox.state.entries.single.address;
+      await w.inbox.markRead(address);
+
+      // Act — the correction
+      await _deliver(
+        w.backend,
+        _event(id: 'e2', createdAt: _nowSeconds - 30, title: 'Sunday at 10'),
+      );
+
+      // Assert — read state is cleared, or the fix arrives already read
+      expect(w.inbox.state.entries, hasLength(1));
+      expect(
+        w.inbox.state.entries.single.announcement.textFor('en').title,
+        'Sunday at 10',
+      );
+      expect(w.inbox.state.hasUnread, isTrue);
+    });
+
+    test('a correction resurfaces something already dismissed', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+      await w.inbox.dismiss(w.inbox.state.entries.single.address);
+      expect(w.inbox.state.entries, isEmpty);
+
+      // Act
+      await _deliver(
+        w.backend,
+        _event(id: 'e2', createdAt: _nowSeconds - 30, title: 'Correction'),
+      );
+
+      // Assert — the case the correction was published for
+      expect(w.inbox.state.entries, hasLength(1));
+      expect(w.inbox.state.hasUnread, isTrue);
+    });
+
+    test('an older revision of the same address is ignored', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event(id: 'e2', createdAt: _nowSeconds - 30));
+
+      // Act — a relay serving what it still had
+      await _deliver(w.backend, _event(id: 'e1', createdAt: _nowSeconds - 60));
+
+      // Assert
+      expect(w.inbox.state.entries.single.announcement.revision.eventId, 'e2');
+    });
+
+    test('on a created_at tie the lowest event id wins', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event(id: 'bb', createdAt: _nowSeconds - 30));
+
+      // Act
+      await _deliver(w.backend, _event(id: 'aa', createdAt: _nowSeconds - 30));
+      await _deliver(w.backend, _event(id: 'cc', createdAt: _nowSeconds - 30));
+
+      // Assert — NIP-01, and the same rule NostrService applies to matches
+      expect(w.inbox.state.entries.single.announcement.revision.eventId, 'aa');
+    });
+
+    test('the same d from two allowed keys is two announcements', () async {
+      // Arrange — the reason the address is not the d alone (§3.3)
+      final w = _build(publishers: const [_publisher, _stranger]);
+      w.inbox.open();
+
+      // Act
+      await _deliver(w.backend, _event(id: 'e1'));
+      await _deliver(w.backend, _event(id: 'e2', pubkey: _stranger));
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(2));
+    });
+
+    test('reading one key does not read the other key at the same d', () async {
+      // Arrange
+      final w = _build(publishers: const [_publisher, _stranger]);
+      w.inbox.open();
+      await _deliver(w.backend, _event(id: 'e1'));
+      await _deliver(w.backend, _event(id: 'e2', pubkey: _stranger));
+
+      // Act
+      await w.inbox.markRead('$kAnnouncementKind:$_publisher:release-2-1');
+
+      // Assert
+      expect(w.inbox.state.unreadCount, 1);
+    });
+  });
+
+  group('ordering and the cap', () {
+    test('newest first', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      await _deliver(
+        w.backend,
+        _event(id: 'old', d: 'a', createdAt: _nowSeconds - 900),
+      );
+      await _deliver(
+        w.backend,
+        _event(id: 'new', d: 'b', createdAt: _nowSeconds - 60),
+      );
+
+      // Assert
+      expect(
+        w.inbox.state.entries.map((e) => e.announcement.announcementId),
+        ['b', 'a'],
+      );
+    });
+
+    test('keeps only the twenty most recent', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act — 25 announcements, ageing backwards
+      for (var i = 0; i < 25; i++) {
+        await _deliver(
+          w.backend,
+          _event(id: 'e$i', d: 'a$i', createdAt: _nowSeconds - i * 60),
+        );
+      }
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(kAnnouncementCacheLimit));
+      expect(w.inbox.state.entries.first.announcement.announcementId, 'a0');
+      expect(w.inbox.state.entries.last.announcement.announcementId, 'a19');
+    });
+  });
+
+  group('read and dismiss', () {
+    test('marking read clears the unread flag and persists', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+
+      // Act
+      await w.inbox.markRead(w.inbox.state.entries.single.address);
+
+      // Assert
+      expect(w.inbox.state.hasUnread, isFalse);
+      final cache = await const AnnouncementStore().load();
+      expect(cache.read.keys, ['$kAnnouncementKind:$_publisher:release-2-1']);
+    });
+
+    test('dismissing hides it and survives a restart', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+
+      // Act
+      await w.inbox.dismiss(w.inbox.state.entries.single.address);
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+      final restarted = _build();
+      await restarted.inbox.restore();
+      expect(restarted.inbox.state.entries, isEmpty);
+    });
+
+    test('marking an address nobody holds does nothing', () async {
+      // Arrange
+      final w = _build();
+
+      // Act + Assert
+      await w.inbox.markRead('31416:nobody:nothing');
+      expect(w.inbox.state.entries, isEmpty);
+    });
+  });
+
+  group('storage', () {
+    test('what arrived is what a restart shows', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+      await w.inbox.markRead(w.inbox.state.entries.single.address);
+
+      // Act
+      final restarted = _build();
+      await restarted.inbox.restore();
+
+      // Assert
+      expect(restarted.inbox.state.entries, hasLength(1));
+      expect(restarted.inbox.state.hasUnread, isFalse);
+    });
+
+    test('a restore verifies the cache again rather than trusting it',
+        () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+
+      // Act — the key that signed it is no longer allowed
+      final restarted = _build(publishers: const [_stranger]);
+      await restarted.inbox.restore();
+
+      // Assert — and it is gone from disk, not merely hidden
+      expect(restarted.inbox.state.entries, isEmpty);
+      expect((await const AnnouncementStore().load()).events, isEmpty);
+    });
+
+    test(
+        'a cached announcement that aged past the window while offline is '
+        'dropped and deleted', () async {
+      // Arrange — cached fresh, restored 31 days later with no relay in sight
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event(d: 'stale'));
+      expect((await const AnnouncementStore().load()).events, hasLength(1));
+
+      // Act
+      final later = _build(clock: _now.add(const Duration(days: 31)));
+      await later.inbox.restore();
+
+      // Assert — gone from both the screen and storage
+      expect(later.inbox.state.entries, isEmpty);
+      expect((await const AnnouncementStore().load()).events, isEmpty);
+    });
+
+    test('a cached announcement that expires while offline is swept', () async {
+      // Arrange — the expiration is in the real future as well as the fake
+      // one: NostrService applies NIP-40 against the wall clock on the way in,
+      // so a near expiry would make this pass without the sweep ever running
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event(expiration: _nowSeconds + 86400));
+      expect((await const AnnouncementStore().load()).events, hasLength(1));
+
+      // Act — two days later, still offline
+      final later = _build(clock: _now.add(const Duration(days: 2)));
+      await later.inbox.restore();
+
+      // Assert
+      expect(later.inbox.state.entries, isEmpty);
+      expect((await const AnnouncementStore().load()).events, isEmpty);
+    });
+
+    test('a valid neighbour survives the sweep', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(
+        w.backend,
+        _event(d: 'expiring', expiration: _nowSeconds + 86400),
+      );
+      await _deliver(
+        w.backend,
+        _event(id: 'e2', d: 'lasting', expiration: _nowSeconds + 8640000),
+      );
+      expect((await const AnnouncementStore().load()).events, hasLength(2));
+
+      // Act
+      final later = _build(clock: _now.add(const Duration(days: 2)));
+      await later.inbox.restore();
+
+      // Assert
+      expect(
+        later.inbox.state.entries.map((e) => e.announcement.announcementId),
+        ['lasting'],
+      );
+    });
+
+    test('a foreground revalidate drops what the clock invalidated', () async {
+      // Arrange — the app was open, then away long enough to matter
+      var clock = _now;
+      final backend = RecordingRelayBackend();
+      final crypto = _Verifier();
+      final inbox = AnnouncementInbox(
+        service: NostrService(
+          KeyManager(crypto: crypto),
+          crypto: crypto,
+          backend: backend,
+        ),
+        crypto: crypto,
+        appVersion: AppVersion.tryParse('2.0.1')!,
+        publishers: const [_publisher],
+        now: () => clock,
+      );
+      inbox.open();
+      await _deliver(backend, _event(expiration: _nowSeconds + 86400));
+      expect(inbox.state.entries, hasLength(1));
+
+      // Act — away for two days, so what was good for one has expired
+      clock = _now.add(const Duration(days: 2));
+      await inbox.revalidate();
+
+      // Assert
+      expect(inbox.state.entries, isEmpty);
+      expect((await const AnnouncementStore().load()).events, isEmpty);
+    });
+
+    test('a restore with nothing stored leaves an empty inbox', () async {
+      // Arrange
+      final w = _build();
+
+      // Act + Assert
+      await w.inbox.restore();
+      expect(w.inbox.state.entries, isEmpty);
+    });
+  });
+
+  group('consent', () {
+    test('nothing is delivered before the channel is opened', () async {
+      // Arrange
+      final w = _build();
+
+      // Act
+      await _deliver(w.backend, _event());
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('closing cancels the listener and drops the subscription', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      w.inbox.close();
+
+      // Assert
+      expect(w.inbox.isOpen, isFalse);
+      expect(w.backend.unsubscribed, [kAnnouncementSubscriptionId]);
+    });
+
+    test('an event queued behind a close is discarded, not processed',
+        () async {
+      // Arrange — the tap happens while an event is already in flight
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      w.backend.eventsController.add(_event());
+      w.inbox.close();
+      await Future<void>.delayed(Duration.zero);
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+    });
+
+    test('reopening resumes delivery', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      w.inbox.close();
+
+      // Act
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(1));
+    });
+
+    test('forgetting everything empties the screen and the storage', () async {
+      // Arrange
+      final w = _build();
+      w.inbox.open();
+      await _deliver(w.backend, _event());
+
+      // Act
+      await w.inbox.forgetEverything();
+
+      // Assert
+      expect(w.inbox.state.entries, isEmpty);
+      expect((await const AnnouncementStore().load()).isEmpty, isTrue);
+    });
+  });
+}

--- a/test/features/announcements/announcement_inbox_test.dart
+++ b/test/features/announcements/announcement_inbox_test.dart
@@ -76,6 +76,7 @@ NostrEvent _event({
   List<String> publishers = const [_publisher],
   String appVersion = '2.0.1',
   DateTime? clock,
+  AnnouncementStore store = const AnnouncementStore(),
 }) {
   final backend = RecordingRelayBackend();
   final crypto = _Verifier();
@@ -89,15 +90,62 @@ NostrEvent _event({
     crypto: crypto,
     appVersion: AppVersion.tryParse(appVersion)!,
     publishers: publishers,
+    store: store,
     now: () => clock ?? _now,
   );
   return (inbox: inbox, backend: backend, service: service, crypto: crypto);
 }
 
 /// Push an event through the relay and let the stream turn.
+///
+/// Reading storage back needs [_stored], not a delay: the inbox persists
+/// fire-and-forget — nothing on screen waits for a disk write — and guessing a
+/// duration is a flake waiting for a loaded CI box.
 Future<void> _deliver(RecordingRelayBackend backend, NostrEvent event) async {
   backend.eventsController.add(event);
   await Future<void>.delayed(Duration.zero);
+}
+
+/// A store that always hands back the same cache, whatever is written to it.
+///
+/// The ordering this exists to test — a live event admitted before the cache
+/// is read back — is not reachable through the real store: the live event's
+/// own write lands first and overwrites the very cache the test is about.
+class _SeededStore implements AnnouncementStore {
+  const _SeededStore(this.seed);
+
+  final AnnouncementCache seed;
+
+  @override
+  Future<AnnouncementCache> load() async => seed;
+
+  @override
+  Future<void> save(AnnouncementCache cache) async {}
+
+  @override
+  Future<void> clear() async {}
+}
+
+/// A store that fails every way it can. Nothing in the app supplies one; the
+/// point is that the inbox does not assume nothing does.
+class _FailingStore implements AnnouncementStore {
+  const _FailingStore();
+
+  @override
+  Future<AnnouncementCache> load() async => throw StateError('disk is gone');
+
+  @override
+  Future<void> save(AnnouncementCache cache) async =>
+      throw StateError('disk is gone');
+
+  @override
+  Future<void> clear() async => throw StateError('disk is gone');
+}
+
+/// What is on disk, once the inbox has finished putting it there.
+Future<AnnouncementCache> _stored(AnnouncementInbox inbox) async {
+  await inbox.pendingWrites;
+  return const AnnouncementStore().load();
 }
 
 void main() {
@@ -471,7 +519,7 @@ void main() {
 
       // Assert
       expect(w.inbox.state.hasUnread, isFalse);
-      final cache = await const AnnouncementStore().load();
+      final cache = await _stored(w.inbox);
       expect(cache.read.keys, ['$kAnnouncementKind:$_publisher:release-2-1']);
     });
 
@@ -531,7 +579,7 @@ void main() {
 
       // Assert — and it is gone from disk, not merely hidden
       expect(restarted.inbox.state.entries, isEmpty);
-      expect((await const AnnouncementStore().load()).events, isEmpty);
+      expect((await _stored(restarted.inbox)).events, isEmpty);
     });
 
     test(
@@ -541,7 +589,7 @@ void main() {
       final w = _build();
       w.inbox.open();
       await _deliver(w.backend, _event(d: 'stale'));
-      expect((await const AnnouncementStore().load()).events, hasLength(1));
+      expect((await _stored(w.inbox)).events, hasLength(1));
 
       // Act
       final later = _build(clock: _now.add(const Duration(days: 31)));
@@ -549,7 +597,7 @@ void main() {
 
       // Assert — gone from both the screen and storage
       expect(later.inbox.state.entries, isEmpty);
-      expect((await const AnnouncementStore().load()).events, isEmpty);
+      expect((await _stored(later.inbox)).events, isEmpty);
     });
 
     test('a cached announcement that expires while offline is swept', () async {
@@ -559,7 +607,7 @@ void main() {
       final w = _build();
       w.inbox.open();
       await _deliver(w.backend, _event(expiration: _nowSeconds + 86400));
-      expect((await const AnnouncementStore().load()).events, hasLength(1));
+      expect((await _stored(w.inbox)).events, hasLength(1));
 
       // Act — two days later, still offline
       final later = _build(clock: _now.add(const Duration(days: 2)));
@@ -567,7 +615,7 @@ void main() {
 
       // Assert
       expect(later.inbox.state.entries, isEmpty);
-      expect((await const AnnouncementStore().load()).events, isEmpty);
+      expect((await _stored(later.inbox)).events, isEmpty);
     });
 
     test('a valid neighbour survives the sweep', () async {
@@ -582,7 +630,7 @@ void main() {
         w.backend,
         _event(id: 'e2', d: 'lasting', expiration: _nowSeconds + 8640000),
       );
-      expect((await const AnnouncementStore().load()).events, hasLength(2));
+      expect((await _stored(w.inbox)).events, hasLength(2));
 
       // Act
       final later = _build(clock: _now.add(const Duration(days: 2)));
@@ -621,7 +669,82 @@ void main() {
 
       // Assert
       expect(inbox.state.entries, isEmpty);
-      expect((await const AnnouncementStore().load()).events, isEmpty);
+      expect((await _stored(inbox)).events, isEmpty);
+    });
+
+    test('a restore after a correction has arrived does not mark it read',
+        () async {
+      // Arrange — what a previous run cached: the announcement, and a read
+      // mark stamped with the revision that was read
+      final cached = _event(title: 'Sunday at 9');
+      final store = _SeededStore(
+        AnnouncementCache(
+          events: [cached],
+          read: {
+            '$kAnnouncementKind:$_publisher:release-2-1': AnnouncementRevision(
+                createdAt: cached.createdAt, eventId: 'e1'),
+          },
+        ),
+      );
+
+      // Act — the lifecycle order the app cannot guarantee: on a slow cold
+      // start the OS can resume before the post-frame callback runs, so the
+      // subscription opens and admits the correction *before* the cache is
+      // read back
+      final w = _build(store: store);
+      w.inbox.open();
+      await _deliver(
+        w.backend,
+        _event(id: 'e2', createdAt: _nowSeconds - 30, title: 'Sunday at 10'),
+      );
+      await w.inbox.restore();
+
+      // Assert — the read mark belongs to the revision it was taken against,
+      // and this is not that revision
+      expect(w.inbox.state.entries, hasLength(1));
+      expect(
+        w.inbox.state.entries.single.announcement.textFor('en').title,
+        'Sunday at 10',
+      );
+      expect(w.inbox.state.hasUnread, isTrue);
+    });
+
+    test('a restore in the ordinary order still restores the read mark',
+        () async {
+      // Arrange — the same cache, read back before anything arrives
+      final cached = _event();
+      final store = _SeededStore(
+        AnnouncementCache(
+          events: [cached],
+          read: {
+            '$kAnnouncementKind:$_publisher:release-2-1': AnnouncementRevision(
+                createdAt: cached.createdAt, eventId: 'e1'),
+          },
+        ),
+      );
+
+      // Act
+      final w = _build(store: store);
+      await w.inbox.restore();
+
+      // Assert
+      expect(w.inbox.state.entries, hasLength(1));
+      expect(w.inbox.state.hasUnread, isFalse);
+    });
+
+    test('a store that throws does not take the caller down with it', () async {
+      // Arrange — AnnouncementStore swallows its own failures, but the store
+      // is injectable and the next implementation owes nothing
+      final w = _build(store: const _FailingStore());
+      w.inbox.open();
+
+      // Act + Assert — an awaited write, and a fire-and-forget one
+      await _deliver(w.backend, _event());
+      await expectLater(
+        w.inbox.markRead(w.inbox.state.entries.single.address),
+        completes,
+      );
+      await expectLater(w.inbox.pendingWrites, completes);
     });
 
     test('a restore with nothing stored leaves an empty inbox', () async {
@@ -713,11 +836,12 @@ void main() {
           _event(id: 'e$i', d: 'a$i', createdAt: _nowSeconds - i * 60),
         );
       }
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await Future<void>.delayed(Duration.zero);
+      await w.inbox.pendingWrites;
 
       // Assert — storage agrees with the screen rather than with some state
       // the app was in several events ago
-      final stored = await const AnnouncementStore().load();
+      final stored = await _stored(w.inbox);
       expect(w.inbox.state.entries, hasLength(10));
       expect(stored.events, hasLength(10));
     });
@@ -733,7 +857,7 @@ void main() {
 
       // Assert
       expect(w.inbox.state.entries, isEmpty);
-      expect((await const AnnouncementStore().load()).isEmpty, isTrue);
+      expect((await _stored(w.inbox)).isEmpty, isTrue);
     });
   });
 }

--- a/test/features/announcements/announcement_inbox_test.dart
+++ b/test/features/announcements/announcement_inbox_test.dart
@@ -688,6 +688,40 @@ void main() {
       expect(w.inbox.state.entries, hasLength(1));
     });
 
+    test('disposing tells the relays, not just the stream', () async {
+      // Arrange — cancelling the listener alone leaves a REQ open on every
+      // socket, feeding a stream nobody reads
+      final w = _build();
+      w.inbox.open();
+
+      // Act
+      w.inbox.dispose();
+
+      // Assert
+      expect(w.backend.unsubscribed, [kAnnouncementSubscriptionId]);
+    });
+
+    test('a burst of events leaves storage holding the last state', () async {
+      // Arrange — a relay redelivering on reconnect is a burst, and two
+      // unordered writes can land newest-first
+      final w = _build();
+      w.inbox.open();
+
+      // Act — no awaiting between them, which is how they actually arrive
+      for (var i = 0; i < 10; i++) {
+        w.backend.eventsController.add(
+          _event(id: 'e$i', d: 'a$i', createdAt: _nowSeconds - i * 60),
+        );
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Assert — storage agrees with the screen rather than with some state
+      // the app was in several events ago
+      final stored = await const AnnouncementStore().load();
+      expect(w.inbox.state.entries, hasLength(10));
+      expect(stored.events, hasLength(10));
+    });
+
     test('forgetting everything empties the screen and the storage', () async {
       // Arrange
       final w = _build();

--- a/test/main_lifecycle_test.dart
+++ b/test/main_lifecycle_test.dart
@@ -1,6 +1,7 @@
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/announcements/announcement_providers.dart';
+import 'package:choke/features/announcements/models/app_version.dart';
 import 'package:choke/main.dart';
 import 'package:choke/services/key_management/key_manager.dart';
 import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
@@ -46,6 +47,10 @@ void main() {
           nostrCryptoProvider.overrideWithValue(crypto),
           keyManagerProvider.overrideWithValue(keyManager),
           nostrServiceProvider.overrideWithValue(service),
+          // Version targeting for the announcement channel. main() reads this
+          // from package_info_plus; a widget test says what it wants instead,
+          // the same way it does for the Nostr stack.
+          appVersionProvider.overrideWithValue(AppVersion.tryParse('2.0.1')!),
         ],
         child: const ChokeApp(),
       ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:choke/features/announcements/announcement_providers.dart';
+import 'package:choke/features/announcements/models/app_version.dart';
 import 'package:choke/main.dart';
 import 'package:choke/services/key_management/key_manager.dart';
 import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
@@ -20,6 +22,11 @@ List<Override> _fakeNostrStack() {
     nostrServiceProvider.overrideWithValue(
       NostrService(keyManager, crypto: crypto, backend: FakeRelayBackend()),
     ),
+    // The announcement channel targets by app version, which is a plugin read
+    // in main() and not something a widget test has. Any version will do here:
+    // the allowlist these tests run with is empty, so nothing is subscribed to
+    // and nothing is targeted.
+    appVersionProvider.overrideWithValue(AppVersion.tryParse('2.0.1')!),
   ];
 }
 


### PR DESCRIPTION
Phase 2 of 5 for [docs/specs/announcement-channel.md](docs/specs/announcement-channel.md). Stacked on #166 — review that one first, and this diff is only the second commit.

The channel is wired end to end here, but `kAnnouncementPublishers` is still empty, so merging this opens **no subscription and no socket**. It goes live in the one-line commit that adds the key.

## The shape

`AnnouncementInbox` is a single door, and a cached event goes through the same one an arriving event does:

1. author is on the allowlist (§3.1)
2. signature verifies, in the crate, every time (§3.2)
3. the §2 schema parses
4. not stale, not post-dated, not expired (§3.3, §3.4)
5. targets this app version (§2.1)
6. wins at its address (§3.3)

## Decisions worth arguing with

- **The cache stores signed events, not parsed announcements.** A restore re-verifies rather than trusting what a previous build parsed. It costs 20 signature checks at launch and buys: a key dropped from the allowlist takes its cached announcements with it, and there is exactly one definition of an acceptable announcement instead of two.
- **Revalidation is on restore *and* foreground.** Freshness and expiry are otherwise only enforced on arrival, and a phone offline for five weeks receives nothing to displace what it has — "we are down for maintenance tonight" would outlive its own `expiration` precisely because nothing came in.
- **`close()` cancels the listener before unsubscribing.** An event already in flight is discarded rather than processed. Phase 3's switch needs that to take effect at the tap rather than at the next background transition.
- **`subscribeWithFilter` on `NostrService`** instead of a fourth near-identical `subscribeToX` helper. The announcement filter is a shape no match subscription has (fixed kind, a *list* of authors, `since`, `limit`), and `unsubscribe` was already general in the same way.
- **`appVersionProvider` throws when unoverridden**, like `nostrCryptoProvider`. That costs two existing widget tests an extra override; the alternative is a silent default that mis-targets in production.

## Test plan

- [x] `flutter analyze` — no new issues
- [x] `flutter test` — 800 pass, 45 new
- [x] Allowlist, verification (including the native call throwing), freshness, expiry, targeting, replay, the `(created_at, id)` tie-break, the cap, read/dismiss persistence
- [x] Offline ageing: cached fresh, restored 31 days later — gone from the screen *and* from `shared_preferences`, with a valid neighbour surviving
- [x] Consent mechanics: nothing before `open()`, a queued event discarded across `close()`, delivery resuming on reopen
- [ ] No screen yet — the bell and the list are phase 4

## Stack

1. #166 — parsing, validation, allowlist
2. **this PR** — fetch, verify, freshness, expiry, storage
3. the Announcements setting (§5)
4. bell, screen, four locales of chrome (§4.3)
5. the `tool/` publisher script (§6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an announcement inbox that receives verified announcements from approved publishers.
  * Supports unread counts, read and dismissed states, expiration, version targeting, and revision updates.
  * Restores announcements across app launches and limits the cache to 20 items.
  * Automatically refreshes announcements when the app resumes and clears all saved announcements on request.

* **Reliability**
  * Invalid, expired, outdated, or unverifiable announcements are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->