### PR TITLE
feat: turn on the announcement channel — three real publisher keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Copyright (C) 2026 ProtoLayer OÜ.
 ## Connect
 
 - GitHub: [@protolayer-io/choke](https://github.com/protolayer-io/choke)
-- Nostr: `npub14e8x7ggcvgy4j0wcsqh6kv4pfmtax7rkryenux9u7ytemjcuce7q9qpjtk`
+- Nostr: `npub1ch0kezdtt0f89pfgaqqyz2n3xee3jk4k7j7hrwmcpl5ua39danqsrs9y9t`
 
 ---
 

--- a/docs/publishing-announcements.md
+++ b/docs/publishing-announcements.md
@@ -1,0 +1,189 @@
+# Publishing an Announcement
+
+How to send a message to everyone using the app, with `tool/announce.dart`.
+
+There is no admin UI and none is planned. An announcement is a signed Nostr
+event published from the announcement key, and this guide is the whole
+procedure. See [the spec](specs/announcement-channel.md) for why the channel is
+shaped this way.
+
+**The failure mode of this channel is silence.** Publish a malformed
+announcement and nothing tells you — not the relay, not the app, not the
+readers. The tool exists to catch what it can before you sign, and step 5 exists
+because it cannot catch everything.
+
+## Before you start
+
+You need the private key of one of the publishers listed in
+`lib/features/announcements/announcement_publishers.dart`. The app checks the
+author of every event against that allowlist and drops everything else without a
+word. An announcement signed by any other key is not a quieter announcement; it
+is no announcement at all.
+
+That key lives offline and is used for nothing else (§3.1). It is deliberately
+not on the machine that writes the copy, which is why this tool signs nothing.
+
+You also need [`nak`](https://github.com/fiatjaf/nak) to sign and publish.
+
+## 1. Generate a template
+
+```sh
+dart run tool/announce.dart --template --out draft.json
+```
+
+## 2. Write the announcement
+
+Edit `draft.json`. What the tool will hold you to (§6):
+
+| Field | Rule |
+|---|---|
+| `d` | Unique identifier. Reusing one **corrects** the earlier announcement rather than adding a new one — see [Corrections](#corrections). |
+| `locales` | All four — `en`, `es`, `ja`, `pt` — and no others. There is no fallback: a missing locale is a reader who sees nothing. |
+| `expires_at` | An instant in the future, ISO-8601 or unix seconds. Nothing published here is permanent (§3.4). |
+| `title` | 80 characters max, measured after trimming. |
+| `body` | 500 characters max, measured after trimming. |
+| `url` | Optional. If present, `https` with a host — the app drops anything else silently. |
+| `min_version` | Optional. Oldest app version this is for, inclusive. |
+| `max_version` | Optional. The version this announcement is *about*, **exclusive**. |
+
+Two things worth reading twice:
+
+- **The Japanese block in the template is an English placeholder.** Replace it or
+  you will publish that sentence verbatim to every Japanese reader.
+- **`max_version` is exclusive.** If the app is at `2.0.1` and you write
+  `"max_version": "2.1.0"`, builds below 2.1.0 see it — including yours. Write
+  `"2.0.1"` and you have excluded yourself, which is the usual way a test
+  announcement appears to vanish. **For a test, omit both bounds** so it reaches
+  every build.
+
+Version bounds must parse: at most three numeric components, an optional
+pre-release suffix, and **no build metadata** — write `2.1.0`, never `2.1.0+454`.
+A bound the app cannot read invalidates the whole announcement (§2.1).
+
+### Example draft
+
+A test announcement with no version bounds, so every build receives it:
+
+```json
+{
+  "d": "local-test-1",
+  "expires_at": "2026-08-10T00:00:00Z",
+  "locales": {
+    "en": {
+      "title": "Test announcement",
+      "body": "If you can read this, the announcement channel works."
+    },
+    "es": {
+      "title": "Anuncio de prueba",
+      "body": "Si puedes leer esto, el canal de anuncios funciona."
+    },
+    "pt": {
+      "title": "Anúncio de teste",
+      "body": "Se você consegue ler isto, o canal de anúncios funciona."
+    },
+    "ja": {
+      "title": "テストのお知らせ",
+      "body": "これが読めれば、お知らせチャンネルは動作しています。"
+    }
+  }
+}
+```
+
+Give a real test an `expires_at` a few days out. One that expires while you are
+looking at it disappears from the screen, which reads as a bug in the channel
+when it is the channel working (§3.4).
+
+## 3. Validate
+
+```sh
+dart run tool/announce.dart draft.json --out event.json
+```
+
+Either it prints
+
+```
+Valid. Sign it, publish it, and check that it arrives — nothing downstream will
+tell you if it does not.
+```
+
+or it lists **everything** wrong at once, so a draft with four problems takes one
+pass, not four.
+
+Use `--out`, not a shell redirect. In this package `dart run` prints its own
+build progress to stdout, and `> event.json` puts that progress in the file.
+
+The tool writes an event with no `pubkey`, no `id` and no `sig`. Those come from
+whatever holds the key.
+
+## 4. Sign and publish
+
+```sh
+nak event --sec <the announcement key> wss://nos.lol wss://relay.primal.net < event.json
+```
+
+Relays are **positional arguments to `nak event`**; there is no `nak publish`
+subcommand. The event is read from stdin.
+
+Those two relays are the defaults a fresh install starts with
+(`lib/shared/nostr_relays.dart`). If your app has others configured under
+Settings, publish to those instead — an announcement on a relay nobody in the
+allowlist reads is an announcement nobody receives.
+
+Sign reasonably soon after validating. `created_at` is carried over from
+`event.json`, and readers ignore anything dated more than five minutes in the
+future (§3.3).
+
+## 5. Confirm it arrived
+
+Not optional. Nothing downstream will tell you if it did not.
+
+```sh
+nak req -k 31416 -a <the announcement pubkey, hex> wss://nos.lol
+```
+
+Then open the app: the bell appears in the top bar, and tapping it opens the
+announcements screen. Remember the channel is opt-in — a reader who never
+enabled it in Settings sees nothing, by design (§5).
+
+If the event is on the relay but not in the app, the usual causes are, in order:
+the signing key is not in the allowlist; a version bound excluded the build; the
+channel is switched off in Settings; the event is older than the 30-day
+freshness window.
+
+## Corrections
+
+The address of an announcement is `(kind, pubkey, d)`. Publishing again with the
+**same `d` from the same key** replaces the earlier one and re-announces it to
+readers who had already dismissed it. That is the fix mechanism: there is no
+delete, and no way to edit in place.
+
+Two consequences:
+
+- Republishing a correction **from a different allowlisted key** creates a second
+  announcement rather than fixing the first. Both will be on screen.
+- A `d` you have used before will silently overwrite that announcement. Pick a
+  new one unless replacing is what you mean.
+
+## Expiry and the freshness window
+
+Two separate limits, and they do not extend each other:
+
+- **`expires_at`** — when you decide the announcement stops being true.
+- **The 30-day freshness window** (§3.3) — readers ignore any event whose
+  `created_at` is older than 30 days, however long a relay keeps serving it.
+
+An `expires_at` beyond 30 days is not an error, and the tool accepts it with a
+warning: readers will stop showing the announcement after 30 days regardless, so
+the expiry you wrote is not the one that applies.
+
+## Reference
+
+| Path | What it is |
+|---|---|
+| `tool/announce.dart` | The CLI: template, validation, unsigned event. |
+| `tool/announcement_draft.dart` | The draft model and every check in step 3. |
+| `lib/features/announcements/announcement_publishers.dart` | The allowlist — the whole trust model. |
+| `lib/shared/nostr_relays.dart` | The relays a fresh install starts with. |
+| `docs/specs/announcement-channel.md` | The spec every § here refers to. |
+
+Run `dart run tool/announce.dart --help` for the usage text.

--- a/docs/publishing-announcements.md
+++ b/docs/publishing-announcements.md
@@ -40,8 +40,8 @@ Edit `draft.json`. What the tool will hold you to (§6):
 | `d` | Unique identifier. Reusing one **corrects** the earlier announcement rather than adding a new one — see [Corrections](#corrections). |
 | `locales` | All four — `en`, `es`, `ja`, `pt` — and no others. There is no fallback: a missing locale is a reader who sees nothing. |
 | `expires_at` | An instant in the future, ISO-8601 or unix seconds. Nothing published here is permanent (§3.4). |
-| `title` | 80 characters max, measured after trimming. |
-| `body` | 500 characters max, measured after trimming. |
+| `locales.<code>.title` | 80 characters max, measured after trimming. |
+| `locales.<code>.body` | 500 characters max, measured after trimming. |
 | `url` | Optional. If present, `https` with a host — the app drops anything else silently. |
 | `min_version` | Optional. Oldest app version this is for, inclusive. |
 | `max_version` | Optional. The version this announcement is *about*, **exclusive**. |
@@ -101,7 +101,7 @@ dart run tool/announce.dart draft.json --out event.json
 
 Either it prints
 
-```
+```text
 Valid. Sign it, publish it, and check that it arrives — nothing downstream will
 tell you if it does not.
 ```

--- a/lib/features/announcements/announcement_publishers.dart
+++ b/lib/features/announcements/announcement_publishers.dart
@@ -18,11 +18,24 @@ import '../../services/nostr/crypto/nostr_crypto.dart';
 ///    published elsewhere, and every surface in this app speaks `npub`.
 ///    Decoding happens in the crate (AGENTS.md), never in Dart.
 ///
-/// Empty on purpose: the dedicated offline key does not exist yet, and an
-/// empty allowlist is inert by construction — no authors means no
-/// subscription, so shipping this cannot open a channel nobody can speak on.
-/// Adding the real key is a one-line change here.
-const List<String> kAnnouncementPublishers = <String>[];
+/// The three keys below are trusted equally: any one of them can put an
+/// announcement in front of every user who has the channel on, and none of them
+/// can be revoked without shipping a build. That is the cost of a hardcoded
+/// allowlist, and it is deliberate — a list that could be updated over the wire
+/// would be a channel for taking over the channel.
+///
+/// Successors ship *before* they are needed, which is the whole reason this is
+/// a list. A key that turns out to be lost or leaked is simply dropped here in
+/// the next release; the others keep working in the meantime, and the channel
+/// never goes dark waiting on a store review.
+const List<String> kAnnouncementPublishers = <String>[
+  // c5df6c89ab5bd2728528e800412a713673195ab6f4bd71bb780fe9cec4adecc1
+  'npub1ch0kezdtt0f89pfgaqqyz2n3xee3jk4k7j7hrwmcpl5ua39danqsrs9y9t',
+  // afb8fe8d6825e9290da89267bbfe828f6a2196aa528fc7af899f4e06202ab077
+  'npub147u0artgyh5jjrdgjfnmhl5z3a4zr942228u0tufna8qvgp2kpms7ch0ke',
+  // c5df6014c19fdda51a52c0d0406135d687d968bfe19a700468e00a15d757e946
+  'npub1ch0kq9xpnlw62xjjcrgyqcf466raj69luxd8qprguq9pt46ha9rqyf6a6u',
+];
 
 /// The hex keys a subscription filter needs, from the npubs in [npubs].
 ///

--- a/test/features/announcements/announcement_publishers_rust_test.dart
+++ b/test/features/announcements/announcement_publishers_rust_test.dart
@@ -1,0 +1,66 @@
+@Tags(['rust'])
+library;
+
+import 'dart:io';
+
+import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/features/announcements/announcement_publishers.dart';
+import 'package:choke/services/nostr/crypto/rust_nostr_crypto.dart';
+import 'package:choke/src/rust/frb_generated.dart';
+
+/// The shipped allowlist, put through the decoder that actually runs.
+///
+/// `announcement_publishers_test.dart` covers the decoding *rules* against a
+/// fake, which is the right shape for testing behaviour but cannot say whether
+/// the npubs in the constant are real bech32. Only the crate can, and the
+/// consequence of them not being is invisible: an entry that fails to decode is
+/// dropped with a `debugPrint` and the channel comes up one publisher short,
+/// with nothing on any screen to say so (§3.1).
+///
+/// A typo here is not a crash and not a test failure anywhere else — it is a key
+/// that quietly cannot speak until someone notices an announcement never
+/// arrived. Hence the hex: it pins each npub to the key it is meant to be, so a
+/// mistyped-but-still-valid bech32 string fails here rather than in production.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final libraryPath = _findNativeLibrary();
+  if (libraryPath == null) {
+    group('the shipped allowlist', skip: 'native library not built', () {
+      test('needs cargo build --manifest-path rust/Cargo.toml', () {});
+    });
+    return;
+  }
+
+  setUpAll(() async {
+    await RustLib.init(externalLibrary: ExternalLibrary.open(libraryPath));
+  });
+
+  test('every shipped publisher decodes, to the key it says it is', () {
+    // Act — the same call announcementPublishersProvider makes at startup
+    final hex = decodeAnnouncementPublishers(RustNostrCrypto());
+
+    // Assert — nothing silently dropped on the way through
+    expect(hex, hasLength(kAnnouncementPublishers.length));
+    expect(hex, [
+      'c5df6c89ab5bd2728528e800412a713673195ab6f4bd71bb780fe9cec4adecc1',
+      'afb8fe8d6825e9290da89267bbfe828f6a2196aa528fc7af899f4e06202ab077',
+      'c5df6014c19fdda51a52c0d0406135d687d968bfe19a700468e00a15d757e946',
+    ]);
+  });
+}
+
+String? _findNativeLibrary() {
+  final name = Platform.isMacOS
+      ? 'librust_lib_choke.dylib'
+      : Platform.isWindows
+          ? 'rust_lib_choke.dll'
+          : 'librust_lib_choke.so';
+
+  for (final profile in ['debug', 'release']) {
+    final path = 'rust/target/$profile/$name';
+    if (File(path).existsSync()) return path;
+  }
+  return null;
+}

--- a/test/features/announcements/announcement_publishers_test.dart
+++ b/test/features/announcements/announcement_publishers_test.dart
@@ -102,11 +102,14 @@ void main() {
       }
     });
 
-    test('is empty until a dedicated offline key exists', () {
-      // Assert — an empty allowlist is inert by construction: nothing to
-      // decode means no authors, and §4.1 opens no subscription without them.
-      // Delete this test in the commit that adds the real key.
-      expect(kAnnouncementPublishers, isEmpty);
+    test('lists each key once', () {
+      // Assert — decodeAnnouncementPublishers collapses duplicates, so a key
+      // pasted twice does not break the filter; it just means the allowlist
+      // holds one fewer publisher than whoever edited it believed (§3.1).
+      expect(
+        kAnnouncementPublishers.toSet(),
+        hasLength(kAnnouncementPublishers.length),
+      );
     });
   });
 }

--- a/tool/announce.dart
+++ b/tool/announce.dart
@@ -9,7 +9,8 @@ import 'announcement_draft.dart';
 /// dart run tool/announce.dart --template --out draft.json
 /// # edit draft.json — all four locales, an expiry in the future
 /// dart run tool/announce.dart draft.json --out event.json
-/// nak event --sec <the offline key of §3.1> < event.json | nak publish wss://…
+/// # relays are positional arguments to `nak event`; there is no `nak publish`
+/// nak event --sec <the offline key of §3.1> wss://nos.lol < event.json
 /// ```
 ///
 /// It does not sign and does not publish, and that is the point: the key of


### PR DESCRIPTION
Turns the announcement channel on. It has been inert since it was built: an
empty allowlist decodes to no authors, and §4.1 opens no subscription without
them, so nothing shipped so far could put an announcement in front of anyone.

## The allowlist

Three keys, trusted equally. Any of them can reach every user who has the
channel enabled, and none can be revoked without shipping a build — that is the
price of a hardcoded allowlist and it is deliberate, since a list updatable over
the wire would be a channel for taking over the channel. Successors travel in
the app *before* they are needed, so a lost or leaked key is dropped in the next
release while the others keep working.

| npub | hex |
|---|---|
| `npub1ch0ke…rs9y9t` | `c5df6c89ab5bd272…c4adecc1` |
| `npub147u0a…7ch0ke` | `afb8fe8d6825e929…202ab077` |
| `npub1ch0kq…yf6a6u` | `c5df6014c19fdda5…d757e946` |

**Please check the three npubs against the source you trust before approving.**
All three were verified to decode with a valid bech32 checksum and round-trip
exactly, and they are three distinct keys — but that only proves they are
well-formed, not that they are the right keys.

The README contact npub is now the first of the three, so a reader can check an
announcement's author against something published outside the app.

## Tests

The tripwire asserting the list was empty is gone — its own comment said to
delete it in the commit that adds the real key. Two things replace it:

- `lists each key once`. `decodeAnnouncementPublishers` collapses duplicates, so
  a key pasted twice breaks nothing; it just leaves the allowlist one publisher
  short of what the editor believed.
- `announcement_publishers_rust_test.dart` (new, `rust`-tagged). The existing
  suite exercises the decoding rules against a fake, which is right for
  behaviour but cannot say whether these particular strings are real bech32.
  Only the crate can, and a string that is not decodes to nothing, is dropped
  with a `debugPrint`, and leaves the channel one publisher short with nothing on
  any screen to say so. The test pins each npub to its intended hex, so a typo
  that is still valid bech32 fails in CI rather than in production.

## Docs

`docs/publishing-announcements.md` — the whole publishing procedure, which until
now lived only in a doc comment and §6 of the spec. Not linked from the README,
on request.

It also fixes a `nak` line in `tool/announce.dart` that never worked: it piped
into `nak publish`, and `nak` has no such subcommand — relays are positional
arguments to `nak event`. Every command in the guide was run end to end against
a local `nak serve` relay: signed, published, read back with tags and all four
locales intact.

## Test plan

- [x] `flutter test` — 868 pass
- [x] `flutter test --tags rust` — the new publisher decode test passes against
      the real crate
- [x] `dart analyze` — no errors
- [ ] Confirm the three npubs are the intended keys
- [ ] Confirm none of them is a personal key (§3.1) — not checkable from the
      code, where they are three indistinguishable pubkeys
- [ ] Publish a real announcement end to end and confirm it lands in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmBYiwK7XTGSYhNujN2P1v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trusted publisher verification for announcements using an allowlist of approved signing keys.
  * Added guidance for publishing, validating, signing, delivering, correcting, and expiring announcements.
  * Updated connection information with a new Nostr public key.

* **Documentation**
  * Updated the announcement publishing command and relay usage instructions.

* **Tests**
  * Added validation that configured publisher keys are valid and unique.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->