### PR TITLE
feat: tap the link under a QR code to copy it

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -198,6 +198,7 @@ class HomeScreen extends ConsumerWidget {
       title: l10n.scoreboardQrTitle,
       data: liveBoardShareUrl(npub),
       caption: l10n.scoreboardQrHint,
+      copyLabel: l10n.link,
     );
   }
 

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -185,6 +185,7 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
       title: l10n.scoreboardQrTitle,
       data: _boardUrl(watchedHex),
       caption: l10n.scoreboardQrHint,
+      copyLabel: l10n.link,
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -976,6 +976,10 @@
   "@scoreboardQrHint": {
     "description": "Caption under the QR code of the watched board's link"
   },
+  "link": "Link",
+  "@link": {
+    "description": "What was copied, used as the {label} of copiedToClipboard when the user taps the link spelled out under a QR code"
+  },
   "scoreboardMatchPendingTitle": "Looking for that match…",
   "@scoreboardMatchPendingTitle": {
     "description": "Title shown after a shared link named one match and before the relays have answered. Never says the match is missing: at this point nothing is known either way, and saying so is the failure the pending state exists to prevent"

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -247,6 +247,7 @@
   "scoreboardShareMatchMessage": "Mirá esta lucha de BJJ en vivo en bjjscore.live:",
   "scoreboardQrTitle": "Escaneá para ver en vivo",
   "scoreboardQrHint": "Apuntá la cámara del teléfono a este código para abrir el tablero en vivo",
+  "link": "Enlace",
   "scoreboardMatchPendingTitle": "Buscando esa lucha…",
   "scoreboardMatchPendingBody": "El link nombraba una lucha de este tablero. Esperando a que llegue.",
   "scoreboardMatchUnresolvedTitle": "Esa lucha no está en este tablero",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -247,6 +247,7 @@
   "scoreboardShareMatchMessage": "bjjscore.live でこの BJJ の試合をライブで観戦:",
   "scoreboardQrTitle": "スキャンしてライブ観戦",
   "scoreboardQrHint": "スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます",
+  "link": "リンク",
   "scoreboardMatchPendingTitle": "その試合を探しています…",
   "scoreboardMatchPendingBody": "リンクはこのスコアボードの試合を指しています。届くのを待っています。",
   "scoreboardMatchUnresolvedTitle": "その試合はこのスコアボードにありません",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -247,6 +247,7 @@
   "scoreboardShareMatchMessage": "Assista a esta luta de BJJ ao vivo em bjjscore.live:",
   "scoreboardQrTitle": "Escaneie para ver ao vivo",
   "scoreboardQrHint": "Aponte a câmera do celular para este código para abrir o placar ao vivo",
+  "link": "Link",
   "scoreboardMatchPendingTitle": "Procurando essa luta…",
   "scoreboardMatchPendingBody": "O link apontava para uma luta deste placar. Aguardando ela chegar.",
   "scoreboardMatchUnresolvedTitle": "Essa luta não está neste placar",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1542,6 +1542,12 @@ abstract class AppLocalizations {
   /// **'Point a phone camera at this code to open the live board'**
   String get scoreboardQrHint;
 
+  /// What was copied, used as the {label} of copiedToClipboard when the user taps the link spelled out under a QR code
+  ///
+  /// In en, this message translates to:
+  /// **'Link'**
+  String get link;
+
   /// Title shown after a shared link named one match and before the relays have answered. Never says the match is missing: at this point nothing is known either way, and saying so is the failure the pending state exists to prevent
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -792,6 +792,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Point a phone camera at this code to open the live board';
 
   @override
+  String get link => 'Link';
+
+  @override
   String get scoreboardMatchPendingTitle => 'Looking for that match…';
 
   @override

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -796,6 +796,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Apuntá la cámara del teléfono a este código para abrir el tablero en vivo';
 
   @override
+  String get link => 'Enlace';
+
+  @override
   String get scoreboardMatchPendingTitle => 'Buscando esa lucha…';
 
   @override

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -763,6 +763,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get scoreboardQrHint => 'スマートフォンのカメラをこのコードに向けると、ライブスコアボードが開きます';
 
   @override
+  String get link => 'リンク';
+
+  @override
   String get scoreboardMatchPendingTitle => 'その試合を探しています…';
 
   @override

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -797,6 +797,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Aponte a câmera do celular para este código para abrir o placar ao vivo';
 
   @override
+  String get link => 'Link';
+
+  @override
   String get scoreboardMatchPendingTitle => 'Procurando essa luta…';
 
   @override

--- a/lib/shared/widgets/qr_dialog.dart
+++ b/lib/shared/widgets/qr_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:choke/l10n/generated/app_localizations.dart';
 
@@ -17,6 +18,7 @@ class QrDialog extends StatelessWidget {
     required this.title,
     required this.data,
     required this.caption,
+    this.copyLabel,
   });
 
   /// What this code is, in the reader's language.
@@ -27,6 +29,36 @@ class QrDialog extends StatelessWidget {
 
   /// What to do with it — "scan this to…".
   final String caption;
+
+  /// What [data] is called in the confirmation — "Link copied to clipboard".
+  ///
+  /// Null leaves the text inert, which is what the account screen wants: its
+  /// code carries a public key and the screen already offers a labelled copy
+  /// control for it. A second, invisible one hiding under the code would be a
+  /// tap target nothing announces.
+  final String? copyLabel;
+
+  /// Put [data] on the clipboard and say so.
+  ///
+  /// The dialog stays open on purpose. Copying the link is not being finished
+  /// with the code — the person across the room is still pointing a camera at
+  /// it, and closing here would take the code away from them.
+  Future<void> _copy(BuildContext context, String label) async {
+    final l10n = AppLocalizations.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final color = Theme.of(context).colorScheme.primary;
+
+    await Clipboard.setData(ClipboardData(text: data));
+
+    // A copy that says nothing is indistinguishable from a tap that missed.
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(l10n.copiedToClipboard(label)),
+        backgroundColor: color,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -71,15 +103,40 @@ class QrDialog extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 16),
-          Text(
-            data,
-            style: TextStyle(
-              color: theme.textTheme.bodyMedium?.color,
-              fontSize: 11,
-              fontFamily: 'monospace',
+          // Coloured and underlined when it can be copied, because nothing else
+          // on a line of monospace text says it is a tap target.
+          if (copyLabel case final label?)
+            InkWell(
+              onTap: () => _copy(context, label),
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 4,
+                ),
+                child: Text(
+                  data,
+                  style: TextStyle(
+                    color: colors.primary,
+                    decoration: TextDecoration.underline,
+                    decorationColor: colors.primary,
+                    fontSize: 11,
+                    fontFamily: 'monospace',
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            )
+          else
+            Text(
+              data,
+              style: TextStyle(
+                color: theme.textTheme.bodyMedium?.color,
+                fontSize: 11,
+                fontFamily: 'monospace',
+              ),
+              textAlign: TextAlign.center,
             ),
-            textAlign: TextAlign.center,
-          ),
           const SizedBox(height: 8),
           Text(
             caption,
@@ -104,9 +161,15 @@ Future<void> showQrDialog(
   required String title,
   required String data,
   required String caption,
+  String? copyLabel,
 }) {
   return showDialog<void>(
     context: context,
-    builder: (_) => QrDialog(title: title, data: data, caption: caption),
+    builder: (_) => QrDialog(
+      title: title,
+      data: data,
+      caption: caption,
+      copyLabel: copyLabel,
+    ),
   );
 }

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qr_flutter/qr_flutter.dart';
@@ -442,6 +443,28 @@ void main() {
       expect(dialog.data, liveBoardShareUrl('npub1fake'));
       expect(find.text(l10n.scoreboardQrTitle), findsOneWidget);
       expect(find.text(l10n.scoreboardQrHint), findsOneWidget);
+
+      // Act — tapping the link under the code copies it
+      final copied = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied.add((call.arguments as Map)['text'] as String);
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+      await tester.tap(find.text(liveBoardShareUrl('npub1fake')));
+      await tester.pumpAndSettle();
+
+      // Assert — the same link the code carries, and the user was told
+      expect(copied, [liveBoardShareUrl('npub1fake')]);
+      expect(find.text(l10n.copiedToClipboard(l10n.link)), findsOneWidget);
     });
 
     testWidgets('offers no share icon before an identity exists',

--- a/test/features/scoreboard/scoreboard_share_test.dart
+++ b/test/features/scoreboard/scoreboard_share_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qr_flutter/qr_flutter.dart';
@@ -169,6 +170,37 @@ void main() {
 
       // Assert
       expect(find.byType(QrImageView), findsNothing);
+    });
+
+    testWidgets('copies the link under the code when it is tapped',
+        (tester) async {
+      // Arrange — the other way a link leaves this screen when the camera in
+      // the room will not scan
+      final copied = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied.add((call.arguments as Map)['text'] as String);
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, null);
+      });
+      await _pumpWatching(tester);
+      await tester.tap(find.byTooltip(l10n.showQr));
+      await tester.pumpAndSettle();
+
+      // Act
+      await tester.tap(find.text(_sharedUrl));
+      await tester.pumpAndSettle();
+
+      // Assert — the same link the code carries, and the user was told
+      expect(copied, [_sharedUrl]);
+      expect(find.text(l10n.copiedToClipboard(l10n.link)), findsOneWidget);
     });
 
     testWidgets('offers nothing to share behind a broken link', (tester) async {

--- a/test/shared/widgets/qr_dialog_test.dart
+++ b/test/shared/widgets/qr_dialog_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/shared/widgets/qr_dialog.dart';
+
+/// The link under a QR code is there because codes fail to scan — bad light, an
+/// angle, cracked glass. Reading it out loud is the fallback, and copying it is
+/// the other half of the same idea: the two ways to move a link off a screen
+/// when the camera will not.
+void main() {
+  const url = 'https://bjjscore.live/?npub=npub1fake';
+
+  late AppLocalizations l10n;
+
+  /// Capture every Clipboard.setData the dialog makes.
+  List<String> mockClipboard(WidgetTester tester) {
+    final copied = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied.add((call.arguments as Map)['text'] as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+    return copied;
+  }
+
+  /// The dialog on screen, over a Scaffold so a SnackBar has somewhere to go.
+  Future<void> pumpDialog(WidgetTester tester, {String? copyLabel}) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            l10n = AppLocalizations.of(context);
+            return Scaffold(
+              body: Builder(
+                builder: (inner) => ElevatedButton(
+                  onPressed: () => showQrDialog(
+                    inner,
+                    title: 'Scan to watch live',
+                    data: url,
+                    caption: 'Point a camera at this',
+                    copyLabel: copyLabel,
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('the link under the code', () {
+    testWidgets('copies what the code encodes when tapped', (tester) async {
+      // Arrange
+      final copied = mockClipboard(tester);
+      await pumpDialog(tester, copyLabel: 'Link');
+
+      // Act
+      await tester.tap(find.text(url));
+      await tester.pumpAndSettle();
+
+      // Assert — the same string the QR carries, not a re-derived one
+      expect(copied, [url]);
+    });
+
+    testWidgets(
+        'says so, because a silent copy is indistinguishable from a tap that '
+        'did nothing', (tester) async {
+      // Arrange
+      mockClipboard(tester);
+      await pumpDialog(tester, copyLabel: 'Link');
+
+      // Act
+      await tester.tap(find.text(url));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text(l10n.copiedToClipboard('Link')), findsOneWidget);
+    });
+
+    testWidgets('stays put when the dialog did not ask to be copyable',
+        (tester) async {
+      // Arrange — the account screen's QR carries a public key and offers its
+      // own copy control; a second, invisible one under the code is not it
+      final copied = mockClipboard(tester);
+      await pumpDialog(tester);
+
+      // Act
+      await tester.tap(find.text(url));
+      await tester.pumpAndSettle();
+
+      // Assert — nothing copied, and the link is still just text
+      expect(copied, isEmpty);
+      expect(find.text(url), findsOneWidget);
+    });
+
+    testWidgets('leaves the dialog open, so the code can still be scanned',
+        (tester) async {
+      // Arrange — copying a link is not finishing with the dialog: the person
+      // across the room is still pointing a camera at it
+      mockClipboard(tester);
+      await pumpDialog(tester, copyLabel: 'Link');
+
+      // Act
+      await tester.tap(find.text(url));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.byType(QrDialog), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Tapping the link spelled out under a QR code now copies it to the clipboard, in
both modals: the home card's and the scoreboard's.

## Why

The link is under every code because codes fail to scan — bad light, an angle,
cracked glass — and somebody has to be able to read it out. Copying is the other
half of that idea. Until now the only way to move the link off the screen was to
read it aloud and have someone type it.

Both modals already shared one widget (`QrDialog`), so this is one change rather
than two that drift apart.

## Scope

The **account screen's** QR deliberately does not opt in. Its code carries a
public key and the screen already offers a labelled copy control for it; a
second, invisible one hiding under the code would be a tap target nothing
announces. That is what the nullable `copyLabel` is for — scoping to the two
modals asked for, not generality for its own sake. Enabling it there later is
one argument.

## Two decisions worth a look

- **The link is coloured and underlined when copyable.** Nothing else about a
  line of monospace text says it is a tap target, and an affordance nobody can
  see is a feature nobody finds. This is the only visual change.
- **The dialog stays open after copying.** Copying is not being finished with
  the code — the person across the room is still pointing a camera at it.

## Copy

New `link` string in all four locales, used as the `{label}` of the existing
`copiedToClipboard`, so the confirmation reads "Link copied to clipboard". The
dialog title (`scoreboardQrTitle`, "Scan to watch live") is an instruction, not
a name for the thing, so reusing it would have read "Scan to watch live copied
to clipboard".

| locale | `link` |
|---|---|
| en | Link |
| es | Enlace |
| pt | Link |
| ja | リンク |

## Tests

Written first, and they failed before the widget changed.

- `test/shared/widgets/qr_dialog_test.dart` (new) — copies exactly what the code
  encodes; shows the confirmation, since a silent copy is indistinguishable from
  a tap that missed; leaves the dialog open; and stays inert when no `copyLabel`
  was given, which guards the account screen.
- One test per screen — home and scoreboard — because "both modals" is the
  requirement, and a shared widget is only evidence for it until each caller is
  checked.

## Test plan

- [x] `flutter test` — 872 pass (4 new in the shared dialog, 2 across the screens)
- [x] `dart analyze` — no new errors or warnings
- [ ] Tap the link in both modals on a device and confirm the snackbar reads
      well over the dialog's scrim

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmBYiwK7XTGSYhNujN2P1v