### PR TITLE
fix: ship the 32-bit ARM devices Play was hiding the app from

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,16 +423,24 @@ jobs:
           echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> android/key.properties
           echo "storeFile=choke-upload-key.jks" >> android/key.properties
 
-      # arm64 only. A plain `flutter build apk` packs native code for three ABIs
-      # into one file — and since the Nostr stack became a Rust library, that is
-      # three copies of it. Every 64-bit Android phone made in the last decade
-      # runs arm64-v8a; armeabi-v7a and x86_64 were costing ~40 MB to serve
-      # 32-bit hardware nobody referees on, and emulators.
+      # arm64 only, and this is the ONLY build that narrows itself. A plain
+      # `flutter build apk` packs native code for three ABIs into one file — and
+      # since the Nostr stack became a Rust library, that is three copies of it,
+      # ~40 MB. A sideload APK is a single artifact every downloader pays for in
+      # full, and anyone installing one off GitHub Releases is on arm64.
+      #
+      # `-PchokeAbis` is what actually narrows it: `--target-platform` only
+      # trims Flutter's own libraries, not Cargokit's output or a plugin AAR's
+      # prebuilt .so files. See android/app/build.gradle.kts. The AAB below must
+      # NOT inherit this flag.
       #
       # Deliberately NOT --split-per-abi: that renames the output to
       # app-arm64-v8a-release.apk and would break the step below.
       - name: Build APK
-        run: flutter build apk --release --target-platform android-arm64
+        run: >-
+          flutter build apk --release
+          --target-platform android-arm64
+          -PchokeAbis=arm64-v8a
 
       - name: Rename APK
         env:
@@ -440,10 +448,19 @@ jobs:
         run: cp build/app/outputs/flutter-apk/app-release.apk "choke-${FULL_TAG}.apk"
 
       # The Android App Bundle for Google Play. Unlike the sideload APK above,
-      # this deliberately keeps ALL ABIs (the default): Play generates optimized
-      # per-device APKs from the bundle, so every user still downloads only their
-      # own architecture — including all ABIs here costs nothing at install time
-      # and is what lets Play serve arm64, armeabi-v7a, and x86_64 devices.
+      # this passes NO -PchokeAbis, so it gets the default set from
+      # android/app/build.gradle.kts: arm64-v8a AND armeabi-v7a. Play splits the
+      # bundle per device, so the 32-bit libraries cost an arm64 user nothing at
+      # install time — while leaving them out costs every 32-bit user the app.
+      #
+      # That is the bug this replaces. The abiFilters lived on the `release`
+      # buildType, which `bundleRelease` uses too, so the bundle uploaded to Play
+      # was arm64-only no matter what this comment claimed. Play filters its
+      # device catalog by ABI, so every armeabi-v7a phone got "your device isn't
+      # compatible" — including the Galaxy A13 4G, which has a 64-bit SoC but a
+      # 32-bit Android userspace and is one of the best-selling phones in the
+      # region Choke is refereed in.
+      #
       # It is signed with the same upload key as the APK via android/key.properties.
       - name: Build App Bundle (AAB for Google Play)
         run: flutter build appbundle --release

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,6 +26,47 @@ val hasReleaseKeystore = releaseKeystoreFile?.exists() == true
 val debugSignRelease = (project.findProperty("debugSignRelease") as String?)
     ?.let { it.isEmpty() || it.toBoolean() } == true
 
+/// Every Android ABI the toolchain can produce, in the order Gradle names them.
+val ALL_ABIS = listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+
+/// The ABIs a release build packages. Override with `-PchokeAbis=arm64-v8a`
+/// (comma-separated) for a single-architecture build.
+///
+/// The DEFAULT includes 32-bit ARM, and that default is the one Google Play
+/// gets. Play splits an App Bundle per device, so an extra ABI in the bundle
+/// costs a user on arm64 exactly nothing at install time — while leaving it out
+/// costs every 32-bit user the app entirely. That is not a hypothetical: the
+/// Galaxy A13 4G (SM-A135F/M, SM-A137F) — one of the best-selling phones in
+/// Latin America — has a 64-bit SoC but ships a 32-bit Android userspace, so
+/// Play served it "your device isn't compatible" for as long as the bundle was
+/// arm64-only. The same is true of much of the entry-level Galaxy A and
+/// Android Go range.
+///
+/// The sideload APK on GitHub Releases is the case that DOES pay per ABI: it is
+/// one file containing all of them, and since the Nostr stack became a Rust
+/// library that is a full copy of the crate each time (~40 MB across three).
+/// That build passes `-PchokeAbis=arm64-v8a` explicitly — see the release
+/// workflow. Anyone refereeing off a sideloaded APK is on arm64.
+///
+/// x86_64 stays out of the default: it means Chromebooks and emulators, and an
+/// emulator runs debug builds, which are never filtered.
+val releaseAbis = (project.findProperty("chokeAbis") as String?)
+    ?.split(",")
+    ?.map { it.trim() }
+    ?.filter { it.isNotEmpty() }
+    ?: listOf("arm64-v8a", "armeabi-v7a")
+
+// A typo here is invisible until a device is missing from Play weeks later:
+// `abiFilters += "arm64"` silently matches nothing and packages no native code
+// at all. Fail the build instead.
+val unknownAbis = releaseAbis - ALL_ABIS.toSet()
+if (unknownAbis.isNotEmpty()) {
+    throw GradleException(
+        "Unknown ABI(s) in -PchokeAbis: ${unknownAbis.joinToString(", ")}.\n" +
+            "Valid values are: ${ALL_ABIS.joinToString(", ")}"
+    )
+}
+
 // Refuse to BUILD a release we cannot sign properly — and refuse it here, when
 // the task graph is known, rather than while configuring: a check in the
 // `release {}` block runs for every build in the project, so it would break
@@ -157,7 +198,7 @@ android {
                 "proguard-rules.pro"
             )
 
-            // Release ships one architecture. `flutter build apk
+            // Narrow the release to `releaseAbis`. `flutter build apk
             // --target-platform android-arm64` only narrows Flutter's own
             // libraries — it does not stop Cargokit from building the Rust
             // crate for every Android ABI. This does.
@@ -166,7 +207,7 @@ android {
             // x86_64 emulator at runtime, with an UnsatisfiedLinkError and no
             // hint as to why.
             ndk {
-                abiFilters += "arm64-v8a"
+                abiFilters += releaseAbis
             }
         }
     }
@@ -174,8 +215,10 @@ android {
 
 // `abiFilters` above does not reach native code that arrives *prebuilt* inside
 // a plugin's AAR: ML Kit's barcode scanner (the QR reader on the Account
-// screen) was still shipping 8.8 MB of x86_64 and armeabi-v7a libraries in
-// every release. Nothing on an arm64 phone will ever load them.
+// screen) was still shipping 8.8 MB of x86_64 and armeabi-v7a libraries into
+// arm64-only releases. This drops whatever `releaseAbis` did not ask for, so
+// the two mechanisms cannot disagree — an AAR ABI that outlives the filter is
+// exactly how the bundle ends up carrying architectures the app cannot run.
 //
 // Scoped to the release variant, not to the Gradle invocation. Keying off the
 // task names would flip this on for debug too the moment anything built both in
@@ -183,11 +226,8 @@ android {
 // build output would never explain.
 androidComponents {
     onVariants(selector().withBuildType("release")) { variant ->
-        variant.packaging.jniLibs.excludes.addAll(
-            "**/x86/**",
-            "**/x86_64/**",
-            "**/armeabi-v7a/**",
-        )
+        val excluded = ALL_ABIS - releaseAbis.toSet()
+        variant.packaging.jniLibs.excludes.addAll(excluded.map { "**/$it/**" })
     }
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -50,11 +50,26 @@ val ALL_ABIS = listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 ///
 /// x86_64 stays out of the default: it means Chromebooks and emulators, and an
 /// emulator runs debug builds, which are never filtered.
+val DEFAULT_RELEASE_ABIS = listOf("arm64-v8a", "armeabi-v7a")
+
 val releaseAbis = (project.findProperty("chokeAbis") as String?)
     ?.split(",")
     ?.map { it.trim() }
     ?.filter { it.isNotEmpty() }
-    ?: listOf("arm64-v8a", "armeabi-v7a")
+    ?: DEFAULT_RELEASE_ABIS
+
+// An empty list is NOT the default — the elvis above only catches an unset
+// property, so `-PchokeAbis=` or a stray `-PchokeAbis=,` lands here instead.
+// Left alone it produces a release that looks built and is not: `abiFilters`
+// with nothing in it filters nothing, while the jniLibs rule below subtracts
+// from ALL_ABIS and so strips every prebuilt .so a plugin AAR shipped. Fail.
+if (releaseAbis.isEmpty()) {
+    throw GradleException(
+        "-PchokeAbis was set but named no ABI. Pass a comma-separated list " +
+            "(e.g. -PchokeAbis=arm64-v8a), or omit the property entirely to " +
+            "get the default: ${DEFAULT_RELEASE_ABIS.joinToString(", ")}."
+    )
+}
 
 // A typo here is invisible until a device is missing from Play weeks later:
 // `abiFilters += "arm64"` silently matches nothing and packages no native code

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,21 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- The camera is optional, and Google Play must be told so explicitly.
+
+         mobile_scanner (the QR reader on Account and the scoreboard) declares
+         android.permission.CAMERA, and a CAMERA permission IMPLIES
+         android.hardware.camera AND android.hardware.camera.autofocus as
+         REQUIRED features unless something overrides them. Play then hides the
+         app from every device missing either — which on the entry-level range
+         means fixed-focus cameras, exactly the phones this project cares about
+         reaching.
+
+         mobile_scanner already relaxes android.hardware.camera itself; the
+         autofocus one it does not, so it is set here. Nothing breaks on a phone
+         without one: scanning a QR is a shortcut, and every code it reads can
+         also be pasted or opened as a link. -->
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
+
     <application
         android:label="choke"
         android:name="${applicationName}"


### PR DESCRIPTION
## The bug

A referee tried to install Choke on a Samsung Galaxy A13 and Google Play said the device isn't supported.

The App Bundle uploaded to Play carried `arm64-v8a` and nothing else. [Play filters its device catalog by CPU architecture](https://developer.android.com/google/play/filters), so every `armeabi-v7a` device was removed from the app's catalog — no install button, no explanation beyond "your device isn't compatible."

The devices behind that are not old hardware. The Galaxy A13 4G (SM-A135F/M, SM-A137F) has a 64-bit SoC but [Samsung ships it a 32-bit Android userspace](https://eu.community.samsung.com/t5/galaxy-a-series/requires-arm64-software-for-galaxy-a13-sm-a135f/td-p/9673992) — `arm32-binder64`, [confirmed across XDA](https://xdaforums.com/t/samsung-a13-64bit-architecture-but-32bit-os-is-there-a-solution.4578205/) — and it was the fourth best-selling phone in the world in 2022, heavily so in the region Choke is refereed in. Much of the entry-level Galaxy A and Android Go range is the same. (The A13 **5G**, SM-A136, is arm64 and was never affected.)

## Why the bundle was narrowed

`abiFilters` lived on the `release` buildType. `bundleRelease` uses that buildType just as much as `assembleRelease` does, so the App Bundle inherited a filter that was only ever meant for the sideload APK. The comment beside the AAB step in `release.yml` claimed the opposite —

> this deliberately keeps ALL ABIs (the default) … is what lets Play serve arm64, armeabi-v7a, and x86_64 devices

— and had been wrong since the filter landed.

## The fix

Release ABIs now come from a `releaseAbis` list, defaulting to `arm64-v8a` **and** `armeabi-v7a`.

- **The AAB takes the default.** Play splits a bundle per device, so the 32-bit libraries cost an arm64 user nothing at install time — while leaving them out costs every 32-bit user the app.
- **Only the APK step narrows itself**, via `-PchokeAbis=arm64-v8a`. That artifact is a single file every downloader pays for in full — three copies of the Rust crate, ~40 MB — and it is the case the original filter was written for. Anyone sideloading off GitHub Releases is on arm64.
- The `jniLibs` exclusion for native code arriving prebuilt inside a plugin AAR (ML Kit's barcode scanner) is now derived from the same list instead of hardcoded, so the two mechanisms cannot drift apart and leave the bundle carrying an architecture the app can't run.
- An unrecognised value in `-PchokeAbis` fails the build. `abiFilters += "arm64"` silently matches nothing and packages no native code at all — that failure is invisible until a device goes missing from Play weeks later.

Nothing in the toolchain needed changing: `rust/rust-toolchain.toml` already carries `armv7-linux-androideabi`, so Cargokit cross-compiles the Nostr crate for 32-bit without help, and ML Kit already ships its v7a `.so` files in the AAR.

## Also: the autofocus filter

`mobile_scanner`'s `android.permission.CAMERA` **implies** `android.hardware.camera` and `android.hardware.camera.autofocus` as *required* features. The plugin relaxes the first; it does not relax the second, so Play was also hiding the app from fixed-focus cameras — the same entry-level devices, filtered a second way. Both are now declared optional. Nothing breaks without a camera: scanning a QR is a shortcut, and every code it reads can also be pasted or opened as a link.

## Test plan

Verified locally on this branch:

- [x] `flutter build appbundle --release` → the AAB contains **7 `.so` files each for `arm64-v8a` and `armeabi-v7a`**, and no x86 at all:
  ```
  $ unzip -l app-release.aab | grep '\.so$' | ... | uniq -c
        7 arm64-v8a
        7 armeabi-v7a
  ```
- [x] Merged release manifest carries both `uses-feature` entries with `android:required="false"`.
- [x] `flutter build apk --release --target-platform android-arm64 -PchokeAbis=arm64-v8a` still produces an arm64-only APK (7 `.so`, 34.7 MB) — the sideload artifact does not grow, and Cargokit builds the crate for `aarch64` only.
- [ ] After release: Play Console → **App Bundle Explorer** shows both ABIs under Supported ABIs.
- [ ] After release: Play Console → **Reach and devices → Device catalog**, filter *Excluded devices*, confirm `SM-A135M` is no longer listed. The exported CSV's ABIs column is the first-party answer for anything else still excluded.
- [ ] Install on a physical Galaxy A13 4G.

## Cost

| | Change |
|---|---|
| Play download per user | none — Play serves one ABI per device |
| AAB uploaded | 49 MB (was ~34 MB) |
| Sideload APK on GitHub Releases | none — still arm64-only |
| CI time | one extra Rust cross-compile in the Android job |

`x86_64` deliberately stays out of the default: it means Chromebooks and emulators, and an emulator runs debug builds, which are never filtered.