### PR TITLE
feat: reach Chromebooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,9 +449,11 @@ jobs:
 
       # The Android App Bundle for Google Play. Unlike the sideload APK above,
       # this passes NO -PchokeAbis, so it gets the default set from
-      # android/app/build.gradle.kts: arm64-v8a AND armeabi-v7a. Play splits the
-      # bundle per device, so the 32-bit libraries cost an arm64 user nothing at
-      # install time — while leaving them out costs every 32-bit user the app.
+      # android/app/build.gradle.kts: arm64-v8a, armeabi-v7a AND x86_64. Play
+      # splits the bundle per device, so an ABI a given phone cannot use costs
+      # its owner nothing at install time — while leaving one out costs every
+      # device on that architecture the app entirely (32-bit ARM phones, and
+      # ChromeOS for x86_64).
       #
       # That is the bug this replaces. The abiFilters lived on the `release`
       # buildType, which `bundleRelease` uses too, so the bundle uploaded to Play

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -48,9 +48,17 @@ val ALL_ABIS = listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 /// That build passes `-PchokeAbis=arm64-v8a` explicitly — see the release
 /// workflow. Anyone refereeing off a sideloaded APK is on arm64.
 ///
-/// x86_64 stays out of the default: it means Chromebooks and emulators, and an
-/// emulator runs debug builds, which are never filtered.
-val DEFAULT_RELEASE_ABIS = listOf("arm64-v8a", "armeabi-v7a")
+/// x86_64 is in the default for ChromeOS. Chromebooks run Android apps and are
+/// listed in Play's device catalog like any phone; the Intel and AMD ones can
+/// usually translate ARM code, but "usually" is doing real work in that sentence
+/// — it is per-model and Google's own guidance is to ship x86_64 rather than
+/// rely on it. The ARM Chromebooks were already covered by arm64-v8a above.
+/// Emulators are the other x86_64 consumer, and they run debug builds, which
+/// this never filters.
+///
+/// 32-bit x86 is deliberately absent: no Chromebook ships it, and the only
+/// devices that did were Android tablets that stopped being made a decade ago.
+val DEFAULT_RELEASE_ABIS = listOf("arm64-v8a", "armeabi-v7a", "x86_64")
 
 val releaseAbis = (project.findProperty("chokeAbis") as String?)
     ?.split(",")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,16 @@
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
 
+    <!-- A touchscreen is optional, which is what makes the app reach
+         Chromebooks. Play treats android.hardware.touchscreen as REQUIRED
+         unless an app says otherwise, and a large share of Chromebooks have no
+         touch panel — they would be filtered out of the catalog while running
+         the app perfectly well with a trackpad.
+
+         Nothing here needs touch specifically: every control is a button or a
+         tap target that a mouse click drives just as well. -->
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
+
     <application
         android:label="choke"
         android:name="${applicationName}"


### PR DESCRIPTION
## What kept Choke off ChromeOS

Chromebooks run Android apps and appear in Play's device catalog like any phone. Two filters were excluding them, and neither was about the app being unsuitable — a Chromebook runs Choke fine, with a trackpad instead of a thumb.

**1. No `x86_64` in the bundle.** Intel and AMD Chromebooks can usually translate ARM code through ChromeOS's native bridge, but "usually" is doing real work in that sentence: it is per-model, and [Google's guidance is to ship x86_64](https://developer.android.com/topic/arc/manifest) rather than rely on it. ARM Chromebooks (MediaTek, Snapdragon) were already covered by the `arm64-v8a` added in #174.

**2. `android.hardware.touchscreen` was implied-required.** Play assumes an app needs a touchscreen unless the manifest says otherwise, and a large share of Chromebooks have no touch panel. They were filtered out of the catalog while being perfectly capable of running the app — every control here is a button or a tap target a mouse click drives just as well.

32-bit `x86` deliberately stays out: no Chromebook ships it, and the only devices that did were Android tablets discontinued a decade ago.

## Android TV / Chromecast: deliberately not addressed

Worth stating so nobody re-opens it as an oversight. Scoring a match is a thumb-driven job during a live fight — it makes no sense on a remote and a D-pad. The thing that *does* belong on a big screen is the live board, and that already runs at `bjjscore.live/?npub=...` and casts to a Chromecast from any browser. Porting to leanback would reimplement that worse. The app has no `LEANBACK_LAUNCHER` category and the Android TV form factor stays un-opted-in.

## Test plan

Verified locally on this branch:

- [x] `flutter build appbundle --release` → the AAB carries **7 `.so` files each for `arm64-v8a`, `armeabi-v7a` and `x86_64`**:
  ```
  $ unzip -l app-release.aab | grep '\.so$' | ... | uniq -c
        7 arm64-v8a
        7 armeabi-v7a
        7 x86_64
  ```
- [x] Merged release manifest carries `android.hardware.touchscreen` with `android:required="false"`, alongside the two camera entries.
- [x] No plugin re-introduces a hardware requirement: the only `uses-feature` across every plugin manifest is mobile_scanner's camera one, already `required="false"`.
- [x] `MainActivity` declares no `android:screenOrientation`, so it stays resizable — what ChromeOS windowing needs.
- [ ] After release: Play Console → **Advanced settings → Form factors** shows ChromeOS, and the device catalog lists Chromebooks as supported.
- [ ] Install on a physical Chromebook.

Not re-verified here: the sideload APK path. It passes `-PchokeAbis=arm64-v8a` and this PR does not touch that flag, so it stays arm64-only at 34.7 MB.

## Cost

| | Change |
|---|---|
| Play download per user | none — Play serves one ABI per device |
| AAB uploaded | 70 MB (was 49 MB) |
| Sideload APK on GitHub Releases | none — still arm64-only |
| CI time | one more Rust cross-compile in the Android job |

## Note on landscape

`match_control_screen.dart` and `scoreboard_match_screen.dart` call `SystemChrome.setPreferredOrientations([landscapeLeft, landscapeRight])`. On ChromeOS that is a hint the window manager largely ignores for a resizable window — it is not a Play filter and does not affect the catalog. Left alone: the landscape preference is deliberate on phones, and changing it for ChromeOS is a separate UX question.