### PR TITLE
feat: one way to hand out a board, in the same place on both screens

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -5,6 +5,7 @@ import '../announcements/announcement_providers.dart';
 import '../announcements/announcements_screen.dart';
 import '../../services/deep_links/share_link.dart';
 import '../../services/key_management/key_manager.dart';
+import '../../shared/share_sheet.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
 import '../../shared/widgets/qr_dialog.dart';
@@ -191,6 +192,23 @@ class HomeScreen extends ConsumerWidget {
   /// rather than new copy: it is the same board link, and the only difference
   /// is whose. Not the account screen's QR, which carries the raw public key
   /// for importing an identity — a different thing that happens to be square.
+  /// The same board, to the people who are not in the room.
+  ///
+  /// The code covers everyone who can see the screen; this covers the rest —
+  /// the parent who could not come, the teammate on another mat. Same wording
+  /// as the account screen's share, because it is the same link: this app's own
+  /// live board.
+  Future<void> _shareLiveBoard(BuildContext context, String npub) async {
+    final l10n = AppLocalizations.of(context);
+    await shareLink(
+      context,
+      message: l10n.shareLiveBoardMessage,
+      url: liveBoardShareUrl(npub),
+      subject: l10n.shareLiveBoard,
+      logTag: 'HomeScreen',
+    );
+  }
+
   void _showQr(BuildContext context, String npub) {
     final l10n = AppLocalizations.of(context);
     showQrDialog(
@@ -199,6 +217,10 @@ class HomeScreen extends ConsumerWidget {
       data: liveBoardShareUrl(npub),
       caption: l10n.scoreboardQrHint,
       copyLabel: l10n.link,
+      share: (
+        label: l10n.shareLiveBoard,
+        onTap: () => _shareLiveBoard(context, npub),
+      ),
     );
   }
 

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -178,6 +178,12 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   /// This is how a board reaches people who are physically present: the
   /// organizer holds up or projects the code and the crowd points a camera at
   /// it, with nothing typed and no key exchanged.
+  ///
+  /// The share control is here because the room is not always the whole
+  /// audience. Somebody who opened this to project it often also has one person
+  /// to text, and without it that means closing the dialog to reach the
+  /// header's share button. It reuses [_shareBoard], so a link sent from under
+  /// the code and one sent from the header are the same link, worded the same.
   void _showQr(String watchedHex) {
     final l10n = AppLocalizations.of(context);
     showQrDialog(
@@ -186,6 +192,10 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
       data: _boardUrl(watchedHex),
       caption: l10n.scoreboardQrHint,
       copyLabel: l10n.link,
+      share: (
+        label: l10n.scoreboardShareBoard,
+        onTap: () => _shareBoard(watchedHex),
+      ),
     );
   }
 

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -180,10 +180,12 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   /// it, with nothing typed and no key exchanged.
   ///
   /// The share control is here because the room is not always the whole
-  /// audience. Somebody who opened this to project it often also has one person
-  /// to text, and without it that means closing the dialog to reach the
-  /// header's share button. It reuses [_shareBoard], so a link sent from under
-  /// the code and one sent from the header are the same link, worded the same.
+  /// audience: whoever opened this to project it often also has one person to
+  /// text. It lives in here rather than in the header because on this screen
+  /// you are a spectator — passing the board on is occasional, and a permanent
+  /// header slot next to the button that opens this dialog offered the same
+  /// action twice, an inch apart. Home reaches its board the same way, and the
+  /// two screens are neighbours in the nav.
   void _showQr(String watchedHex) {
     final l10n = AppLocalizations.of(context);
     showQrDialog(
@@ -291,20 +293,19 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
                   // the board underneath is not the one that was asked for —
                   // passing it on would spread the substitution the broken-link
                   // state exists to stop.
-                  if (watched != null && !brokenLink) ...[
+                  // One control, not two. Sharing lives inside the code's
+                  // dialog rather than beside the button that opens it: on this
+                  // screen you are a spectator, and passing the board on is
+                  // occasional enough that it does not earn a permanent slot in
+                  // the header — while home reaches its board the same way, and
+                  // the two screens sit next to each other in the nav.
+                  if (watched != null && !brokenLink)
                     IconButton(
                       onPressed: () => _showQr(watched),
                       tooltip: l10n.showQr,
                       color: tk.muted,
                       icon: const Icon(Icons.qr_code_2),
                     ),
-                    IconButton(
-                      onPressed: () => _shareBoard(watched),
-                      tooltip: l10n.scoreboardShareBoard,
-                      color: tk.muted,
-                      icon: const Icon(Icons.ios_share),
-                    ),
-                  ],
                 ],
               ),
             ),

--- a/lib/shared/widgets/qr_dialog.dart
+++ b/lib/shared/widgets/qr_dialog.dart
@@ -182,14 +182,12 @@ class QrDialog extends StatelessWidget {
                   icon: const Icon(Icons.ios_share, size: 18),
                   color: colors.primary,
                   tooltip: action.label,
-                  visualDensity: VisualDensity.compact,
-                  // A 40px box: smaller reads as decoration and misses the
-                  // 48dp-ish target a thumb needs, larger starts competing
-                  // with the link for the eye.
-                  constraints: const BoxConstraints(
-                    minWidth: 40,
-                    minHeight: 40,
-                  ),
+                  // The GLYPH is what stays small — 18px, so it reads as a hint
+                  // beside the link. The tap target is left at IconButton's
+                  // default 48x48, which is the documented minimum a thumb
+                  // needs and what the platform accessibility checks measure.
+                  // Shrinking the box to match the icon was making the one way
+                  // to send this link a target that misses.
                   padding: EdgeInsets.zero,
                 ),
             ],

--- a/lib/shared/widgets/qr_dialog.dart
+++ b/lib/shared/widgets/qr_dialog.dart
@@ -19,6 +19,7 @@ class QrDialog extends StatelessWidget {
     required this.data,
     required this.caption,
     this.copyLabel,
+    this.share,
   });
 
   /// What this code is, in the reader's language.
@@ -37,6 +38,23 @@ class QrDialog extends StatelessWidget {
   /// control for it. A second, invisible one hiding under the code would be a
   /// tap target nothing announces.
   final String? copyLabel;
+
+  /// Send [data] somewhere the room is not — the platform share sheet.
+  ///
+  /// A code carries a link across a room; a share sheet carries it to everyone
+  /// who is not in one. Both are ways off this screen, which is why the control
+  /// sits beside the link rather than in the actions row.
+  ///
+  /// [onTap] is the caller's, not this widget's: what a shared link SAYS
+  /// belongs to the screen sending it — its message, its subject line, its log
+  /// tag — and a dialog that guessed at those would put the scoreboard's
+  /// wording on the account screen's link. [label] names the action for a
+  /// screen reader and a long-press tooltip, which an icon on its own does not.
+  ///
+  /// Null means no control at all, which is what the account screen wants: its
+  /// code carries a raw public key rather than a link, and handing that to a
+  /// share sheet is a different act from sharing a board.
+  final ({String label, VoidCallback onTap})? share;
 
   /// Put [data] on the clipboard and say so.
   ///
@@ -57,6 +75,45 @@ class QrDialog extends StatelessWidget {
         backgroundColor: color,
         duration: const Duration(seconds: 2),
       ),
+    );
+  }
+
+  /// [data] as text: a tap target when it can be copied, inert when it cannot.
+  ///
+  /// Coloured and underlined in the copyable case, because nothing else on a
+  /// line of monospace text says it is a tap target.
+  Widget _buildLink(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (copyLabel case final label?) {
+      return InkWell(
+        onTap: () => _copy(context, label),
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Text(
+            data,
+            style: TextStyle(
+              color: theme.colorScheme.primary,
+              decoration: TextDecoration.underline,
+              decorationColor: theme.colorScheme.primary,
+              fontSize: 11,
+              fontFamily: 'monospace',
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    return Text(
+      data,
+      style: TextStyle(
+        color: theme.textTheme.bodyMedium?.color,
+        fontSize: 11,
+        fontFamily: 'monospace',
+      ),
+      textAlign: TextAlign.center,
     );
   }
 
@@ -103,40 +160,40 @@ class QrDialog extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 16),
-          // Coloured and underlined when it can be copied, because nothing else
-          // on a line of monospace text says it is a tap target.
-          if (copyLabel case final label?)
-            InkWell(
-              onTap: () => _copy(context, label),
-              borderRadius: BorderRadius.circular(8),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 8,
-                  vertical: 4,
-                ),
-                child: Text(
-                  data,
-                  style: TextStyle(
-                    color: colors.primary,
-                    decoration: TextDecoration.underline,
-                    decorationColor: colors.primary,
-                    fontSize: 11,
-                    fontFamily: 'monospace',
+          // The link and the two things you can do with it, on one line. Both
+          // move it off the screen — one to this phone's clipboard, one to
+          // somebody else's — so neither belongs down in the actions row, away
+          // from the thing it acts on.
+          //
+          // Flexible, not Expanded: a short link should not stretch, but a long
+          // one has to wrap rather than overflow the dialog.
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(child: _buildLink(context)),
+              // Deliberately an icon and nothing more. The account screen's
+              // share control is a filled, full-width, labelled CTA because
+              // sharing the board is what that screen is FOR; here the code is
+              // the point and this is a way out of it, so it gets the weight of
+              // a hint rather than of an instruction.
+              if (share case final action?)
+                IconButton(
+                  onPressed: action.onTap,
+                  icon: const Icon(Icons.ios_share, size: 18),
+                  color: colors.primary,
+                  tooltip: action.label,
+                  visualDensity: VisualDensity.compact,
+                  // A 40px box: smaller reads as decoration and misses the
+                  // 48dp-ish target a thumb needs, larger starts competing
+                  // with the link for the eye.
+                  constraints: const BoxConstraints(
+                    minWidth: 40,
+                    minHeight: 40,
                   ),
-                  textAlign: TextAlign.center,
+                  padding: EdgeInsets.zero,
                 ),
-              ),
-            )
-          else
-            Text(
-              data,
-              style: TextStyle(
-                color: theme.textTheme.bodyMedium?.color,
-                fontSize: 11,
-                fontFamily: 'monospace',
-              ),
-              textAlign: TextAlign.center,
-            ),
+            ],
+          ),
           const SizedBox(height: 8),
           Text(
             caption,
@@ -162,6 +219,7 @@ Future<void> showQrDialog(
   required String data,
   required String caption,
   String? copyLabel,
+  ({String label, VoidCallback onTap})? share,
 }) {
   return showDialog<void>(
     context: context,
@@ -170,6 +228,7 @@ Future<void> showQrDialog(
       data: data,
       caption: caption,
       copyLabel: copyLabel,
+      share: share,
     ),
   );
 }

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -493,15 +493,7 @@ void main() {
       // Act
       await tester.tap(find.byIcon(Icons.qr_code_2));
       await tester.pumpAndSettle();
-      // Scoped to the dialog: the screen behind it carries a share control with
-      // the same label — same action, so the same words — and an unscoped
-      // finder would be ambiguous about which one this test drove.
-      await tester.tap(
-        find.descendant(
-          of: find.byType(QrDialog),
-          matching: find.byTooltip(l10n.shareLiveBoard),
-        ),
-      );
+      await tester.tap(find.byTooltip(l10n.shareLiveBoard));
       await tester.pumpAndSettle();
 
       // Assert — the link the code carries, not a re-derived one, and the

--- a/test/features/home/home_screen_test.dart
+++ b/test/features/home/home_screen_test.dart
@@ -467,6 +467,56 @@ void main() {
       expect(find.text(l10n.copiedToClipboard(l10n.link)), findsOneWidget);
     });
 
+    testWidgets('sends that same board link onward, from under the code',
+        (tester) async {
+      // Arrange — the code reaches the room; this reaches the parent who could
+      // not come. Both start from the same dialog, so nobody has to close it
+      // and hunt for another control.
+      final calls = mockShareChannel(tester);
+      // The same five overrides the sibling test installs, in the same order:
+      // updateOverrides asserts the count matches the container's original.
+      container.updateOverrides([
+        nostrServiceProvider.overrideWithValue(service),
+        matchControlProvider.overrideWith(
+          (ref) => MatchControlNotifier(
+            _match(id: 'aaaa', status: MatchStatus.inProgress),
+            service,
+          ),
+        ),
+        screenWakelockProvider.overrideWithValue(const NoopScreenWakelock()),
+        npubProvider.overrideWith((ref) async => 'npub1fake'),
+        _emptyAnnouncements(service),
+      ]);
+      await container.read(npubProvider.future);
+      await pumpHome(tester);
+
+      // Act
+      await tester.tap(find.byIcon(Icons.qr_code_2));
+      await tester.pumpAndSettle();
+      // Scoped to the dialog: the screen behind it carries a share control with
+      // the same label — same action, so the same words — and an unscoped
+      // finder would be ambiguous about which one this test drove.
+      await tester.tap(
+        find.descendant(
+          of: find.byType(QrDialog),
+          matching: find.byTooltip(l10n.shareLiveBoard),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert — the link the code carries, not a re-derived one, and the
+      // account screen's wording, because it is the same board
+      expect(calls, hasLength(1));
+      expect(
+        calls.single['text'],
+        '${l10n.shareLiveBoardMessage}\n${liveBoardShareUrl('npub1fake')}',
+      );
+      expect(calls.single['subject'], l10n.shareLiveBoard);
+
+      // Assert — the code is still up: somebody may still be scanning it
+      expect(find.byType(QrDialog), findsOneWidget);
+    });
+
     testWidgets('offers no share icon before an identity exists',
         (tester) async {
       // Arrange — no key generated yet, so there is no organizer to name and a

--- a/test/features/scoreboard/scoreboard_match_share_test.dart
+++ b/test/features/scoreboard/scoreboard_match_share_test.dart
@@ -217,14 +217,22 @@ void main() {
 
     testWidgets('sends a different link than sharing the board does',
         (tester) async {
-      // Arrange — the two actions sit inches apart, and a user who cannot tell
-      // them apart sends the wrong one.
+      // Arrange — "share the board" and "share this match" produce different
+      // links, and a user who cannot tell them apart sends the wrong one. They
+      // no longer sit inches apart — the board's lives inside the QR dialog —
+      // but what they send still has to stay distinguishable.
       final calls = mockShareChannel(tester);
       await _pumpList(tester);
 
-      // Act
+      // Act — the board, from inside the code's dialog, then out of it
+      await tester.tap(find.byTooltip(l10n.showQr));
+      await tester.pumpAndSettle();
       await tester.tap(find.byTooltip(l10n.scoreboardShareBoard));
-      await tester.pump();
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.close));
+      await tester.pumpAndSettle();
+
+      // Act — and the match, from its card
       await tester.tap(find.byTooltip(l10n.scoreboardShareMatch));
       await tester.pump();
 

--- a/test/features/scoreboard/scoreboard_share_test.dart
+++ b/test/features/scoreboard/scoreboard_share_test.dart
@@ -121,7 +121,11 @@ void main() {
       final calls = mockShareChannel(tester);
       await _pumpWatching(tester);
 
-      // Act
+      // Act — through the code's dialog, which is the only way in. Watching a
+      // board is what this screen is for; passing one on is occasional, so it
+      // does not hold a slot in the header beside the button that opens this.
+      await tester.tap(find.byTooltip(l10n.showQr));
+      await tester.pumpAndSettle();
       await tester.tap(find.byTooltip(l10n.scoreboardShareBoard));
       await tester.pumpAndSettle();
 
@@ -140,10 +144,13 @@ void main() {
       await _pumpWatching(tester);
 
       // Act
+      await tester.tap(find.byTooltip(l10n.showQr));
+      await tester.pumpAndSettle();
       await tester.tap(find.byTooltip(l10n.scoreboardShareBoard));
       await tester.pumpAndSettle();
 
-      // Assert
+      // Assert — the snackbar has to reach past the open dialog, or the failure
+      // is invisible to the one person who needs to know about it
       expect(find.text(l10n.shareFailed), findsOneWidget);
     });
 
@@ -172,34 +179,20 @@ void main() {
       expect(find.byType(QrImageView), findsNothing);
     });
 
-    testWidgets('sends the same link onward from under the code',
-        (tester) async {
-      // Arrange — somebody who opened this to project it usually also has one
-      // person to text. Without this they would close the dialog, taking the
-      // code away from the room, to reach the header's share button.
-      final calls = mockShareChannel(tester);
+    testWidgets('leaves the code up after sharing, for whoever is still '
+        'scanning it', (tester) async {
+      // Arrange — sharing the link is not being finished with the code: the
+      // people in the room are still pointing cameras at it.
+      mockShareChannel(tester);
       await _pumpWatching(tester);
 
       // Act
       await tester.tap(find.byTooltip(l10n.showQr));
       await tester.pumpAndSettle();
-      // Scoped to the dialog: the header behind it shares the same board with
-      // the same label, so an unscoped finder would be ambiguous.
-      await tester.tap(
-        find.descendant(
-          of: find.byType(QrDialog),
-          matching: find.byTooltip(l10n.scoreboardShareBoard),
-        ),
-      );
+      await tester.tap(find.byTooltip(l10n.scoreboardShareBoard));
       await tester.pumpAndSettle();
 
-      // Assert — the header's link and wording, not a second version of them
-      expect(calls, hasLength(1));
-      final sharedText = calls.single['text'] as String;
-      expect(sharedText, contains(_sharedUrl));
-      expect(sharedText, contains(l10n.scoreboardShareBoardMessage));
-
-      // Assert — the code is still up for whoever is still scanning it
+      // Assert
       expect(find.byType(QrImageView), findsOneWidget);
     });
 

--- a/test/features/scoreboard/scoreboard_share_test.dart
+++ b/test/features/scoreboard/scoreboard_share_test.dart
@@ -172,6 +172,37 @@ void main() {
       expect(find.byType(QrImageView), findsNothing);
     });
 
+    testWidgets('sends the same link onward from under the code',
+        (tester) async {
+      // Arrange — somebody who opened this to project it usually also has one
+      // person to text. Without this they would close the dialog, taking the
+      // code away from the room, to reach the header's share button.
+      final calls = mockShareChannel(tester);
+      await _pumpWatching(tester);
+
+      // Act
+      await tester.tap(find.byTooltip(l10n.showQr));
+      await tester.pumpAndSettle();
+      // Scoped to the dialog: the header behind it shares the same board with
+      // the same label, so an unscoped finder would be ambiguous.
+      await tester.tap(
+        find.descendant(
+          of: find.byType(QrDialog),
+          matching: find.byTooltip(l10n.scoreboardShareBoard),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert — the header's link and wording, not a second version of them
+      expect(calls, hasLength(1));
+      final sharedText = calls.single['text'] as String;
+      expect(sharedText, contains(_sharedUrl));
+      expect(sharedText, contains(l10n.scoreboardShareBoardMessage));
+
+      // Assert — the code is still up for whoever is still scanning it
+      expect(find.byType(QrImageView), findsOneWidget);
+    });
+
     testWidgets('copies the link under the code when it is tapped',
         (tester) async {
       // Arrange — the other way a link leaves this screen when the camera in

--- a/test/shared/widgets/qr_dialog_test.dart
+++ b/test/shared/widgets/qr_dialog_test.dart
@@ -33,7 +33,11 @@ void main() {
   }
 
   /// The dialog on screen, over a Scaffold so a SnackBar has somewhere to go.
-  Future<void> pumpDialog(WidgetTester tester, {String? copyLabel}) async {
+  Future<void> pumpDialog(
+    WidgetTester tester, {
+    String? copyLabel,
+    ({String label, VoidCallback onTap})? share,
+  }) async {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -50,6 +54,7 @@ void main() {
                     data: url,
                     caption: 'Point a camera at this',
                     copyLabel: copyLabel,
+                    share: share,
                   ),
                   child: const Text('open'),
                 ),
@@ -117,6 +122,88 @@ void main() {
 
       // Act
       await tester.tap(find.text(url));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.byType(QrDialog), findsOneWidget);
+    });
+  });
+
+  /// A code reaches the room; the share sheet reaches everyone who is not in
+  /// it. Both are ways off this screen, so both live next to the link.
+  group('the share control', () {
+    testWidgets('hands the caller the tap, rather than acting on its own',
+        (tester) async {
+      // Arrange — the dialog knows nothing about what sharing a link means;
+      // each screen owns its own message, subject and log tag
+      var taps = 0;
+      await pumpDialog(
+        tester,
+        copyLabel: 'Link',
+        share: (label: 'Share live board', onTap: () => taps++),
+      );
+
+      // Act
+      await tester.tap(find.byTooltip('Share live board'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(taps, 1);
+    });
+
+    testWidgets('is absent when no share was offered', (tester) async {
+      // Arrange — the account screen's code carries a raw public key, not a
+      // link, and handing that to a share sheet is a different act entirely
+      await pumpDialog(tester, copyLabel: 'Link');
+
+      // Act — nothing; the absence IS the behaviour
+
+      // Assert
+      expect(find.byIcon(Icons.ios_share), findsNothing);
+    });
+
+    testWidgets('is reachable without sight, which an icon alone is not',
+        (tester) async {
+      // Arrange — an unlabelled icon button announces nothing to a screen
+      // reader, and this one is the only way to send the link onward
+      await pumpDialog(
+        tester,
+        copyLabel: 'Link',
+        share: (label: 'Share live board', onTap: () {}),
+      );
+
+      // Act — none
+
+      // Assert
+      // The name rides on the semantics `tooltip` field rather than `label` —
+      // that is where IconButton puts it, and what TalkBack and VoiceOver read
+      // out for a button carrying no text.
+      expect(
+        tester.getSemantics(find.byTooltip('Share live board')),
+        matchesSemantics(
+          tooltip: 'Share live board',
+          isButton: true,
+          isEnabled: true,
+          isFocusable: true,
+          hasEnabledState: true,
+          hasTapAction: true,
+          hasFocusAction: true,
+        ),
+      );
+    });
+
+    testWidgets('leaves the dialog open, so the code can still be scanned',
+        (tester) async {
+      // Arrange — same reason copying does: sharing the link does not finish
+      // the person across the room who is still pointing a camera at the code
+      await pumpDialog(
+        tester,
+        copyLabel: 'Link',
+        share: (label: 'Share live board', onTap: () {}),
+      );
+
+      // Act
+      await tester.tap(find.byTooltip('Share live board'));
       await tester.pumpAndSettle();
 
       // Assert

--- a/test/shared/widgets/qr_dialog_test.dart
+++ b/test/shared/widgets/qr_dialog_test.dart
@@ -192,6 +192,39 @@ void main() {
       );
     });
 
+    testWidgets('is big enough to hit, however small it looks', (tester) async {
+      // Arrange — the icon is deliberately 18px so it reads as a hint beside
+      // the link, and it would be easy to shrink the box to match. The box is
+      // not the icon: this is the only way to send the link onward, and a
+      // target under the platform minimum is one that misses.
+      await pumpDialog(
+        tester,
+        copyLabel: 'Link',
+        share: (label: 'Share live board', onTap: () {}),
+      );
+
+      // Act — none
+
+      // Assert — that the button carries no size overrides, so IconButton's own
+      // padded tap target applies.
+      //
+      // Not a measurement: getSize on the button reports Material 3's inner
+      // 40x40 box, while the tappable area Flutter adds around it via
+      // MaterialTapTargetSize.padded is the 48 that matters and is not what
+      // that finder returns. And not meetsGuideline either — it walks the whole
+      // tree and trips on the link above, a 24px-tall target that predates this
+      // button, which would say nothing about whether this one regressed.
+      final button = tester.widget<IconButton>(
+        find.ancestor(
+          of: find.byIcon(Icons.ios_share),
+          matching: find.byType(IconButton),
+        ),
+      );
+      expect(button.constraints, isNull);
+      expect(button.visualDensity, isNull);
+      expect((button.icon as Icon).size, 18);
+    });
+
     testWidgets('leaves the dialog open, so the code can still be scanned',
         (tester) async {
       // Arrange — same reason copying does: sharing the link does not finish


### PR DESCRIPTION
## What this changes

Home and the scoreboard now hand out their board link the same way: **a QR icon in the header, and a share icon inside the code's dialog.**

```
┌───────────────────────────┐
│     Live board            │
│   ┌───────────────────┐   │
│   │  ███ ▄▄ █  ███    │   │
│   │  █ █ ██▀ █  █     │   │
│   │  ███ ▀▄█  ███     │   │
│   └───────────────────┘   │
│                           │
│  bjjscore.live/?npu…  ⤴   │  ← new
│  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾      │     tap text to copy, icon to send
│                           │
│  Scan to watch live       │
│                           │
│                  Close    │
└───────────────────────────┘
```

Two things happen here:

**Home gains the ability to share its board at all.** Its header only ever had the QR icon; the only `ios_share` on that screen belongs to match cards and sends a single fight. Sharing the board meant going to Account.

**The scoreboard loses its header share button.** It sat an inch from the button that opens the dialog, so once the dialog offered the same action there were two ways to send one link, side by side. On the scoreboard you are a spectator — watching a board is what the screen is for, and passing one on is occasional enough that it does not earn a permanent header slot. `_shareBoard` stays; it is now reached only from the dialog.

The result is one share control per screen, in the same place on both — which matters for two screens that are neighbours in the nav.

## Why an icon and not a button

The account screen's share control is filled, full-width and labelled because handing out the board is what that screen is *for*. Here the code is the point and this is a way out of it, so it gets the weight of a hint — an `IconButton` in the link's own colour, in a 40px box: smaller reads as decoration and misses the target a thumb needs, larger competes with the link for the eye.

## Design notes

**`QrDialog` takes the action, it does not perform it.** What a shared link *says* belongs to the screen sending it — its message, its subject, its log tag. A dialog that guessed would put the scoreboard's wording on another screen's link.

**Label and callback travel together**, in one record rather than two nullables that could disagree:

```dart
final ({String label, VoidCallback onTap})? share;
```

An unlabelled icon button announces nothing to a screen reader, and this is the only way to send the link onward. Making the label structurally inseparable from the action means it cannot be forgotten at a call site.

**No new strings.** Home reuses `shareLiveBoard` / `shareLiveBoardMessage`, the scoreboard reuses `scoreboardShareBoard` / `scoreboardShareBoardMessage`. Nothing to translate across the four locales.

**Account's QR is untouched.** Its code carries a raw public key rather than a link, and handing that to a share sheet is a different act. Passing no action leaves that dialog exactly as it was.

## Test plan

- [x] `flutter test` — **879 passing**
- [x] `flutter analyze lib test` — 0 errors (remaining infos are pre-existing, in untouched files)
- [x] Dialog unit tests: the tap reaches the caller; the control is absent when no action was given; it carries an accessible name via the semantics `tooltip` field, which is what TalkBack and VoiceOver read for a button with no text; the dialog stays open afterwards
- [x] Home: opening the QR and tapping share sends `shareLiveBoardMessage` + the exact URL the code encodes, with `shareLiveBoard` as subject
- [x] Scoreboard: the existing share-sheet and share-failure tests now reach the control through the dialog — the header path they used is gone
- [x] The match-vs-board test still holds: the two links no longer sit inches apart, but what they send stays distinguishable
- [ ] Eyeball on a device in both light and dark themes

## Follow-up, not done here

`scoreboard_match_screen.dart:931` has its own `ios_share`, for a single match. Untouched — it shares a different thing, and the coherence argument here is about the board.