### PR TITLE
docs: add Play Store badge and demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 A modern decentralized BJJ match scoring and publishing app via Nostr.
 
+<p align="center">
+  <a href="https://play.google.com/store/apps/details?id=io.protolayer.choke">
+    <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
+         height="60" alt="Get it on Google Play" />
+  </a>
+</p>
+
+## Demo
+
+https://github.com/user-attachments/assets/ce7a8c10-4f1a-4bc7-ab7f-55c1a14e954f
+
 ## What is Choke?
 
 Choke lets you create, score, and publish Brazilian Jiu-Jitsu matches in real time using the Nostr protocol. Every scoring action is broadcast as a Nostr event, making match data open, verifiable, and accessible from any compatible dashboard.


### PR DESCRIPTION
The README jumped straight from the pitch to build instructions, leaving non-developers with no way to install the app. This adds both entry points a visitor needs first:

- **Play Store badge** under the title, linking to `io.protolayer.choke` (now live in production).
- **Demo section** with the 2:17 walkthrough video, hosted as a GitHub attachment so the repo stays free of a 5 MB binary.

The video URL is intentionally a bare link on its own line — that is the only form GitHub renders as an inline player.

## Test plan

- [ ] Badge renders and links to the correct Play Store listing
- [ ] Demo video plays inline in the rendered README (check the Files changed preview)
- [ ] Layout looks right on mobile GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered Google Play download badge linking to the Android app.
  * Added a Demo section with a hosted demonstration video.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->