### PR TITLE
Revert the two Origins commits pushed directly to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,18 +294,6 @@ wording or add your own language? See the
 [Translations & i18n guide](docs/translations.md) — no Dart experience needed to
 translate.
 
-## Origins
-
-Choke officially started at [btc++ Floripa 2026](https://btcpp.dev/floripa26),
-built by a two-person hackathon team: this mobile scoring app on one side, and a
-live scoreboard by [@gotcha](https://github.com/gotcha) on the other —
-[bjj-scoreboard-floripa26](https://github.com/gotcha/bjj-scoreboard-floripa26).
-
-The scoreboard Choke uses today,
-[choke-scoreboard](https://github.com/protolayer-io/choke-scoreboard), is a
-rewrite, but it exists because gotcha built the first one during that hackathon.
-Credit where it's due. 🙏
-
 ## License
 
 GNU General Public License v3.0 — see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -297,15 +297,14 @@ translate.
 ## Origins
 
 Choke officially started at [btc++ Floripa 2026](https://btcpp.dev/floripa26),
-where it was built by a two-person team. [@gotcha](https://github.com/gotcha)
-joined the project there and we split the work: the mobile scoring app on one
-side, and the live scoreboard on the other, which gotcha implemented to spec —
+built by a two-person hackathon team: this mobile scoring app on one side, and a
+live scoreboard by [@gotcha](https://github.com/gotcha) on the other —
 [bjj-scoreboard-floripa26](https://github.com/gotcha/bjj-scoreboard-floripa26).
 
 The scoreboard Choke uses today,
 [choke-scoreboard](https://github.com/protolayer-io/choke-scoreboard), is a
-rewrite, but gotcha wrote the first working one at that hackathon and deserves
-the credit for it. 🙏
+rewrite, but it exists because gotcha built the first one during that hackathon.
+Credit where it's due. 🙏
 
 ## License
 


### PR DESCRIPTION
Reverts `98df275` and `532cabc`, which added the `## Origins` credit section to the README. Both were committed straight to `main` without a pull request — that was a process mistake on my side, not a problem with the content.

This PR restores `main` to the state it had after #177 (Play Store badge and demo video stay). The credit note can be reintroduced afterwards through a normal branch + PR if wanted.

## Test plan

- [ ] README on `main` after merge has the badge and Demo section, no `## Origins`
- [ ] No other section affected by the reverts