### PR TITLE
feat: keep the screen awake between fights on a watched board

### DIFF
--- a/lib/features/scoreboard/providers/scoreboard_providers.dart
+++ b/lib/features/scoreboard/providers/scoreboard_providers.dart
@@ -253,6 +253,34 @@ final scoreboardMatchesProvider = Provider<List<Match>>((ref) {
   return fresh;
 });
 
+/// Whether the watched board still has something coming.
+///
+/// True while any match on it is waiting or in progress — the two statuses that
+/// mean the mat is not done with the viewer yet. `finished` and `canceled` are
+/// both over: nothing about them will change again.
+///
+/// This is what holds the phone awake on the board. A spectator casting the
+/// scoreboard to a screen sits through the gaps between fights without touching
+/// anything, and a phone that locks in one of them drops the cast and makes them
+/// re-share it from Google Home. That gap is exactly the moment this stays true
+/// and the individual match screens do not: the fight that was running has
+/// finished, and the next one has not started.
+///
+/// Derived from [scoreboardMatchesProvider] rather than
+/// [scoreboardFilteredMatchesProvider] on purpose. The status chips are a
+/// display choice — a spectator reading through today's results has not stopped
+/// attending a live event — and hiding the running fight from the list must not
+/// put their phone to sleep.
+///
+/// Bounded by the same `scoreboardMaxAgeSeconds` window as the list it reads, so
+/// a card whose organizer never closed it stops counting as live once it ages
+/// out.
+final scoreboardIsLiveProvider = Provider<bool>((ref) {
+  final matches = ref.watch(scoreboardMatchesProvider);
+  return matches.any((m) =>
+      m.status == MatchStatus.waiting || m.status == MatchStatus.inProgress);
+});
+
 /// Which statuses the scoreboard shows.
 ///
 /// Its own, not the home feed's: hiding finished matches while watching

--- a/lib/features/scoreboard/providers/scoreboard_providers.dart
+++ b/lib/features/scoreboard/providers/scoreboard_providers.dart
@@ -250,8 +250,45 @@ final scoreboardMatchesProvider = Provider<List<Match>>((ref) {
     return bAt.compareTo(aAt);
   });
 
+  _expireOldest(ref, feed, fresh, now);
+
   return fresh;
 });
+
+/// Rebuild [scoreboardMatchesProvider] when the oldest match on it ages out.
+///
+/// The window above is measured against the clock at build time, and that
+/// provider only rebuilds when the feed changes. Without this an organizer who
+/// posts a card and then goes quiet leaves it on the board indefinitely: nothing
+/// is ever going to arrive and re-run the comparison that would drop it. That is
+/// not just a stale list — this window is what bounds [scoreboardIsLiveProvider],
+/// and so what stops a day-old board from pinning a spectator's display.
+///
+/// Scheduled for the *oldest* match, because that is the next one to go, and one
+/// second past its boundary so the rebuild is certain to find it stale. Each
+/// firing therefore drops at least one match, which is what keeps this from
+/// rescheduling itself forever.
+void _expireOldest(
+  Ref ref,
+  ScoreboardFeedNotifier feed,
+  List<Match> fresh,
+  int now,
+) {
+  int? oldest;
+  for (final match in fresh) {
+    final createdAt = feed.createdAtOf(match.id);
+    // A match the feed holds no event for is not ageing towards anything.
+    if (createdAt == null) continue;
+    if (oldest == null || createdAt < oldest) oldest = createdAt;
+  }
+  if (oldest == null) return;
+
+  final timer = Timer(
+    Duration(seconds: oldest + scoreboardMaxAgeSeconds - now + 1),
+    ref.invalidateSelf,
+  );
+  ref.onDispose(timer.cancel);
+}
 
 /// Whether the watched board still has something coming.
 ///

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -5,6 +7,8 @@ import 'package:choke/l10n/generated/app_localizations.dart';
 
 import '../../services/deep_links/share_link.dart';
 import '../../services/nostr/crypto/nostr_crypto.dart';
+import '../../services/wakelock/screen_wakelock.dart';
+import '../../shared/providers/navigation_provider.dart';
 import '../../shared/share_sheet.dart';
 import '../../shared/theme/app_theme.dart';
 import '../../shared/widgets/match_card.dart';
@@ -42,9 +46,17 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   /// a tab change, a new event, a keystroke — would push the same match again.
   String? _openedRequest;
 
+  /// Held onto from [initState] because [dispose] runs once `ref` is no longer
+  /// usable, and releasing the screen is the one thing that must still happen.
+  late final ScreenWakelockLease _wakelock;
+
   @override
   void initState() {
     super.initState();
+
+    _wakelock = ref.read(screenWakelockProvider).lease();
+    _syncWakelock();
+
     // A link the app was *launched* by is read after the first frame, which can
     // land either side of this listener being registered. Reading the current
     // value once covers the side that would otherwise be missed; the guard in
@@ -59,7 +71,38 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   @override
   void dispose() {
     _controller.dispose();
+    unawaited(_wakelock.release());
     super.dispose();
+  }
+
+  /// Vote to hold the screen while a live board is actually being looked at.
+  ///
+  /// Two conditions, and both are load-bearing.
+  ///
+  /// [scoreboardIsLiveProvider] is the event: a board with a fight running or
+  /// one still queued is a board whose next update is coming, and the gaps in
+  /// between are precisely when nobody touches the phone. Holding only on the
+  /// individual match screens left this list — where a spectator waits between
+  /// fights — free to lock, which drops a cast board and sends them back to
+  /// Google Home to share the screen again.
+  ///
+  /// The selected tab is the looking. This screen lives in an [IndexedStack]
+  /// that builds every tab and keeps them alive, so it goes on voting from
+  /// behind Home, Account and Settings. Without this check a live board would
+  /// pin the display for a user who has moved on to something else — the
+  /// battery cost of an app-wide hold, with none of the benefit.
+  ///
+  /// Deliberately not re-asserted on a timer, unlike the match screens. Their
+  /// once-a-second re-vote exists to retry a request the platform dropped, and
+  /// they have a ticker to hang it on already; adding one here would mean
+  /// running a timer on a list screen for a retry that has no trigger to miss —
+  /// by the time a board is live and selected, the activity is long since
+  /// foreground. A vote that does get dropped is retried on the next feed
+  /// update, which during a live event is never far away.
+  void _syncWakelock() {
+    final live = ref.read(scoreboardIsLiveProvider);
+    final looking = ref.read(selectedTabProvider) == AppTab.scoreboard;
+    unawaited(_wakelock.keepAwake(live && looking));
   }
 
   /// Put the match a link named on screen.
@@ -219,6 +262,11 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
     ref.listen<String?>(requestedMatchProvider, (_, requested) {
       if (requested != null) _openRequestedMatch(requested);
     });
+    // Both halves of the hold, listened to rather than watched: neither one
+    // changes a pixel of this screen, and the tab in particular would rebuild
+    // the whole board every time the user touched the nav bar.
+    ref.listen<bool>(scoreboardIsLiveProvider, (_, __) => _syncWakelock());
+    ref.listen<AppTab>(selectedTabProvider, (_, __) => _syncWakelock());
 
     final brokenLink = ref.watch(brokenShareLinkProvider);
     final watched = ref.watch(watchedPubkeyProvider);

--- a/lib/features/scoreboard/scoreboard_screen.dart
+++ b/lib/features/scoreboard/scoreboard_screen.dart
@@ -94,11 +94,15 @@ class _ScoreboardScreenState extends ConsumerState<ScoreboardScreen> {
   ///
   /// Deliberately not re-asserted on a timer, unlike the match screens. Their
   /// once-a-second re-vote exists to retry a request the platform dropped, and
-  /// they have a ticker to hang it on already; adding one here would mean
-  /// running a timer on a list screen for a retry that has no trigger to miss —
-  /// by the time a board is live and selected, the activity is long since
-  /// foreground. A vote that does get dropped is retried on the next feed
-  /// update, which during a live event is never far away.
+  /// they have a ticker to hang it on already.
+  ///
+  /// The quiet stretch this screen exists for is not exposed to that. Repeating
+  /// a vote the service has already applied costs nothing and reaches nothing:
+  /// what it holds already matches what is asked, so no platform call is made
+  /// and there is none to drop. The only call that can fail is the one that
+  /// *establishes* the hold, when a board first becomes live and selected — and
+  /// that is a moment surrounded by feed traffic, every update of which votes
+  /// again. A timer here would be a retry for a window that closes on its own.
   void _syncWakelock() {
     final live = ref.read(scoreboardIsLiveProvider);
     final looking = ref.read(selectedTabProvider) == AppTab.scoreboard;

--- a/test/features/scoreboard/providers/scoreboard_providers_test.dart
+++ b/test/features/scoreboard/providers/scoreboard_providers_test.dart
@@ -508,4 +508,142 @@ void main() {
       expect(feed.state.single.f1Pt2, 4);
     });
   });
+
+  group('scoreboardIsLiveProvider', () {
+    late _SpyNostrService nostr;
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      nostr = _SpyNostrService();
+      container = ProviderContainer(overrides: [
+        nostrServiceProvider.overrideWithValue(nostr),
+      ]);
+      await container.read(watchedPubkeyProvider.notifier).watch(watched);
+      container.read(scoreboardFeedProvider);
+    });
+
+    tearDown(() async {
+      container.dispose();
+      await nostr.controller.close();
+    });
+
+    /// Deliver [match] to the feed.
+    ///
+    /// [eventId] and [createdAt] matter whenever a test revises a match it has
+    /// already pushed: a revision only supersedes the held one if it is newer,
+    /// or equal and lower-id. Reusing the defaults would have the feed drop the
+    /// second push and leave a test asserting against the first.
+    Future<void> push(
+      Match match, {
+      int? createdAt,
+      String eventId = 'e1',
+    }) async {
+      nostr.controller.add(
+        _eventOf(match, pubkey: watched, createdAt: createdAt, id: eventId),
+      );
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    test('is not live with nothing on the board', () {
+      // Arrange + Act + Assert
+      expect(container.read(scoreboardIsLiveProvider), isFalse);
+    });
+
+    test('is live while a fight is in progress', () async {
+      // Arrange + Act
+      await push(_match());
+
+      // Assert
+      expect(container.read(scoreboardIsLiveProvider), isTrue);
+    });
+
+    test('is live while a fight is only waiting to start', () async {
+      // Arrange + Act — the card is posted, the mat has not begun
+      await push(_match().copyWith(status: MatchStatus.waiting));
+
+      // Assert
+      expect(container.read(scoreboardIsLiveProvider), isTrue);
+    });
+
+    test('stays live in the gap between two fights', () async {
+      // Arrange
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await push(_match(id: 'aaa1'), createdAt: now);
+      await push(
+        _match(id: 'bbb2').copyWith(status: MatchStatus.waiting),
+        createdAt: now,
+        eventId: 'e2',
+      );
+
+      // Act — the running one ends, the queued one has not started
+      await push(
+        _match(id: 'aaa1').copyWith(status: MatchStatus.finished, endedAt: now),
+        createdAt: now + 1,
+        eventId: 'e3',
+      );
+
+      // Assert — this gap is the whole reason the hold exists
+      expect(
+        container.read(scoreboardMatchesProvider).map((m) => m.status),
+        containsAll([MatchStatus.finished, MatchStatus.waiting]),
+        reason: 'the revision has to have landed for this to mean anything',
+      );
+      expect(container.read(scoreboardIsLiveProvider), isTrue);
+    });
+
+    test('goes quiet once every fight is finished', () async {
+      // Arrange
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await push(_match(id: 'aaa1'), createdAt: now);
+      expect(container.read(scoreboardIsLiveProvider), isTrue);
+
+      // Act
+      await push(
+        _match(id: 'aaa1').copyWith(status: MatchStatus.finished, endedAt: now),
+        createdAt: now + 1,
+        eventId: 'e2',
+      );
+
+      // Assert
+      expect(container.read(scoreboardIsLiveProvider), isFalse);
+    });
+
+    test('goes quiet for a board of canceled fights', () async {
+      // Arrange + Act
+      await push(_match().copyWith(status: MatchStatus.canceled));
+
+      // Assert — canceled is as over as finished: nothing is coming
+      expect(container.read(scoreboardIsLiveProvider), isFalse);
+    });
+
+    test('ignores the status filter the list is showing', () async {
+      // Arrange
+      await push(_match());
+
+      // Act — the spectator narrows the list to today's results
+      container.read(scoreboardStatusFilterProvider.notifier).state = {
+        MatchStatus.finished,
+      };
+
+      // Assert — the chips are a display choice; the event is still running
+      expect(container.read(scoreboardFilteredMatchesProvider), isEmpty);
+      expect(container.read(scoreboardIsLiveProvider), isTrue);
+    });
+
+    test('goes quiet when the only waiting fight ages out', () async {
+      // Arrange — a card whose organizer never closed it must not read as live
+      // forever
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      // Act
+      await push(
+        _match().copyWith(status: MatchStatus.waiting),
+        createdAt: now - scoreboardMaxAgeSeconds - 60,
+      );
+
+      // Assert
+      expect(container.read(scoreboardIsLiveProvider), isFalse);
+    });
+  });
 }

--- a/test/features/scoreboard/providers/scoreboard_providers_test.dart
+++ b/test/features/scoreboard/providers/scoreboard_providers_test.dart
@@ -376,6 +376,28 @@ void main() {
       expect(matches.map((m) => m.id), ['eee5'],
           reason: 'fff6 is a day and a minute old');
     });
+
+    test('drops a match that ages out with no further events', () async {
+      // The window is derived from the clock at build time, and this provider
+      // only rebuilds when the feed changes. An organizer who posts a card and
+      // then goes quiet used to leave it on the board forever: nothing was ever
+      // going to arrive and re-run the comparison that would drop it.
+      //
+      // Arrange — fresh when first read, one second short of the limit
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await push(_match(id: 'abc7'), now - scoreboardMaxAgeSeconds + 1);
+      expect(
+        container.read(scoreboardMatchesProvider).map((m) => m.id),
+        ['abc7'],
+        reason: 'it has to start on the board for ageing out to mean anything',
+      );
+
+      // Act — cross the boundary without the organizer publishing anything
+      await Future<void>.delayed(const Duration(seconds: 2));
+
+      // Assert
+      expect(container.read(scoreboardMatchesProvider), isEmpty);
+    });
   });
 
   group('ScoreboardFeedNotifier hydration', () {
@@ -629,6 +651,26 @@ void main() {
       // Assert — the chips are a display choice; the event is still running
       expect(container.read(scoreboardFilteredMatchesProvider), isEmpty);
       expect(container.read(scoreboardIsLiveProvider), isTrue);
+    });
+
+    test('goes quiet when the board ages out under the viewer', () async {
+      // The case the hold exists to bound. A spectator sitting on a board whose
+      // organizer stopped publishing must not keep the display pinned once that
+      // board is a day old — and nothing is going to arrive to make it notice.
+      //
+      // Arrange — live when first read, one second short of the limit
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      await push(
+        _match().copyWith(status: MatchStatus.waiting),
+        createdAt: now - scoreboardMaxAgeSeconds + 1,
+      );
+      expect(container.read(scoreboardIsLiveProvider), isTrue);
+
+      // Act
+      await Future<void>.delayed(const Duration(seconds: 2));
+
+      // Assert
+      expect(container.read(scoreboardIsLiveProvider), isFalse);
     });
 
     test('goes quiet when the only waiting fight ages out', () async {

--- a/test/features/scoreboard/scoreboard_screen_wakelock_test.dart
+++ b/test/features/scoreboard/scoreboard_screen_wakelock_test.dart
@@ -1,0 +1,279 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:choke/features/match/models/match.dart';
+import 'package:choke/features/scoreboard/providers/scoreboard_providers.dart';
+import 'package:choke/features/scoreboard/scoreboard_screen.dart';
+import 'package:choke/l10n/generated/app_localizations.dart';
+import 'package:choke/services/key_management/key_manager.dart';
+import 'package:choke/services/nostr/crypto/nostr_crypto.dart';
+import 'package:choke/services/nostr/nostr_service.dart';
+import 'package:choke/services/wakelock/screen_wakelock.dart';
+import 'package:choke/shared/providers/navigation_provider.dart';
+import 'package:choke/shared/theme/app_theme.dart';
+
+import '../../support/nostr_fakes.dart';
+
+/// The relays are not part of what these tests are about; the feed just needs
+/// something that answers.
+class _OfflineNostrService extends NostrService {
+  _OfflineNostrService()
+      : super(KeyManager(crypto: FakeNostrCrypto()),
+            crypto: FakeNostrCrypto(), backend: FakeRelayBackend());
+
+  final controller = StreamController<NostrEvent>.broadcast();
+
+  @override
+  Stream<NostrEvent> get eventStream => controller.stream;
+
+  @override
+  void subscribeToAuthor(String authorPubkey, {String? subscriptionId}) {}
+
+  @override
+  void unsubscribe(String subscriptionId) {}
+
+  @override
+  List<NostrEvent> cachedEventsOf(int kind, String pubkey) => const [];
+}
+
+/// Records what the board asked of the platform, in order and in full —
+/// repeats included, because "it keeps asking" must stay observable. A release
+/// records as a final false.
+class _RecordingWakelock implements ScreenWakelock {
+  final List<bool> requests = [];
+
+  /// Whether the screen is being held awake, or null if it never asked for
+  /// anything either way.
+  bool? get held => requests.isEmpty ? null : requests.last;
+
+  @override
+  ScreenWakelockLease lease() => _RecordingLease(this);
+}
+
+class _RecordingLease implements ScreenWakelockLease {
+  _RecordingLease(this._owner);
+
+  final _RecordingWakelock _owner;
+
+  @override
+  Future<void> keepAwake(bool on) async => _owner.requests.add(on);
+
+  @override
+  Future<void> release() async => _owner.requests.add(false);
+}
+
+/// The board the test drives, standing in for what the relays would deliver.
+///
+/// A [StateProvider] rather than a fixed override because the point of most of
+/// these tests is what happens when the board *changes* under the screen: a
+/// fight ends, the next one appears, the event runs out of matches.
+final _board = StateProvider<List<Match>>((ref) => const []);
+
+Match _match(String id, MatchStatus status) => Match(
+      id: id,
+      status: status,
+      startAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      duration: 300,
+      f1Name: 'Buchecha',
+      f2Name: 'Roger Gracie',
+      f1Color: '#1BA34E',
+      f2Color: '#F5B800',
+      endedAt: status == MatchStatus.finished
+          ? DateTime.now().millisecondsSinceEpoch ~/ 1000
+          : null,
+    );
+
+void main() {
+  late _RecordingWakelock wakelock;
+  late WidgetRef ref;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    wakelock = _RecordingWakelock();
+  });
+
+  /// Put the board on screen with [matches] on it, on the scoreboard tab unless
+  /// told otherwise.
+  Future<void> pumpBoard(
+    WidgetTester tester, {
+    List<Match> matches = const [],
+    AppTab tab = AppTab.scoreboard,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          nostrCryptoProvider.overrideWithValue(FakeNostrCrypto()),
+          nostrServiceProvider.overrideWithValue(_OfflineNostrService()),
+          screenWakelockProvider.overrideWithValue(wakelock),
+          _board.overrideWith((ref) => matches),
+          scoreboardMatchesProvider.overrideWith((ref) => ref.watch(_board)),
+          selectedTabProvider.overrideWith((ref) => tab),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.darkTheme,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Consumer(builder: (context, r, _) {
+            ref = r;
+            return const ScoreboardScreen();
+          }),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  /// Replace what is on the board, the way an arriving relay event would.
+  Future<void> setBoard(WidgetTester tester, List<Match> matches) async {
+    ref.read(_board.notifier).state = matches;
+    await tester.pump();
+  }
+
+  Future<void> selectTab(WidgetTester tester, AppTab tab) async {
+    ref.read(selectedTabProvider.notifier).state = tab;
+    await tester.pump();
+  }
+
+  testWidgets('holds the screen while a fight is running on the watched board',
+      (tester) async {
+    // Arrange + Act
+    await pumpBoard(tester, matches: [_match('aaaa', MatchStatus.inProgress)]);
+
+    // Assert
+    expect(wakelock.held, isTrue);
+  });
+
+  testWidgets('holds it in the gap between two fights', (tester) async {
+    // Arrange: one fight running, one queued behind it
+    await pumpBoard(tester, matches: [
+      _match('aaaa', MatchStatus.inProgress),
+      _match('bbbb', MatchStatus.waiting),
+    ]);
+    expect(wakelock.held, isTrue);
+
+    // Act: the running one ends and nobody touches the phone. This is the whole
+    // bug — a spectator casting the board to a TV had to re-share the screen
+    // every time the mat took a minute between fights.
+    await setBoard(tester, [
+      _match('aaaa', MatchStatus.finished),
+      _match('bbbb', MatchStatus.waiting),
+    ]);
+
+    // Assert
+    expect(wakelock.held, isTrue);
+  });
+
+  testWidgets('holds it for a board that has not started yet', (tester) async {
+    // Arrange + Act: the organizer has posted the card, the mat has not begun
+    await pumpBoard(tester, matches: [_match('aaaa', MatchStatus.waiting)]);
+
+    // Assert
+    expect(wakelock.held, isTrue);
+  });
+
+  testWidgets('lets it sleep once every fight on the board is done',
+      (tester) async {
+    // Arrange
+    await pumpBoard(tester, matches: [_match('aaaa', MatchStatus.inProgress)]);
+    expect(wakelock.held, isTrue);
+
+    // Act: the last fight of the event ends
+    await setBoard(tester, [_match('aaaa', MatchStatus.finished)]);
+
+    // Assert: a board nobody is going to update should not pin the display of a
+    // phone left face-up on a table
+    expect(wakelock.held, isFalse);
+  });
+
+  testWidgets('lets it sleep when every fight left was canceled',
+      (tester) async {
+    // Arrange + Act
+    await pumpBoard(tester, matches: [_match('aaaa', MatchStatus.canceled)]);
+
+    // Assert: canceled is as over as finished — there is nothing coming
+    expect(wakelock.requests, everyElement(isFalse));
+  });
+
+  testWidgets('never holds it with no board being watched', (tester) async {
+    // Arrange + Act
+    await pumpBoard(tester);
+
+    // Assert: the welcome screen is not a reason to keep a phone awake
+    expect(wakelock.held, isNot(isTrue));
+  });
+
+  testWidgets('holds it even while the status filter hides the live fights',
+      (tester) async {
+    // Arrange
+    await pumpBoard(tester, matches: [_match('aaaa', MatchStatus.inProgress)]);
+
+    // Act: the spectator looks through today's results instead of the mat
+    ref.read(scoreboardStatusFilterProvider.notifier).state = {
+      MatchStatus.finished,
+    };
+    await tester.pump();
+
+    // Assert: which statuses the list shows is a display choice. The event is
+    // still live, and the phone still has to stay awake for it.
+    expect(wakelock.held, isTrue);
+  });
+
+  testWidgets('lets it sleep while the user is on another tab', (tester) async {
+    // Arrange + Act: a live board, but the user is reading settings
+    await pumpBoard(
+      tester,
+      matches: [_match('aaaa', MatchStatus.inProgress)],
+      tab: AppTab.settings,
+    );
+
+    // Assert: this screen stays alive in the IndexedStack behind every other
+    // tab, so voting on the feed alone would hold the display up for a board
+    // nobody is looking at.
+    expect(wakelock.requests, everyElement(isFalse));
+  });
+
+  testWidgets('picks the hold up again when the user comes back to the board',
+      (tester) async {
+    // Arrange
+    await pumpBoard(
+      tester,
+      matches: [_match('aaaa', MatchStatus.inProgress)],
+      tab: AppTab.home,
+    );
+    expect(wakelock.held, isNot(isTrue));
+
+    // Act
+    await selectTab(tester, AppTab.scoreboard);
+
+    // Assert
+    expect(wakelock.held, isTrue);
+  });
+
+  testWidgets('drops the hold when the user leaves for another tab',
+      (tester) async {
+    // Arrange
+    await pumpBoard(tester, matches: [_match('aaaa', MatchStatus.inProgress)]);
+    expect(wakelock.held, isTrue);
+
+    // Act
+    await selectTab(tester, AppTab.account);
+
+    // Assert
+    expect(wakelock.held, isFalse);
+  });
+
+  testWidgets('lets it sleep when the screen is torn down', (tester) async {
+    // Arrange
+    await pumpBoard(tester, matches: [_match('aaaa', MatchStatus.inProgress)]);
+    expect(wakelock.held, isTrue);
+
+    // Act
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+    // Assert
+    expect(wakelock.held, isFalse);
+  });
+}


### PR DESCRIPTION
## Problem

A spectator casting the scoreboard to a TV via Google Home had to re-share the screen every time a mat took a minute between fights.

The screen hold only existed on the two match screens (`MatchControlScreen`, `ScoreboardMatchScreen`), and both release early:

- `match_control_screen.dart` releases as soon as `state.isFinished`.
- `scoreboard_match_screen.dart` releases when the match leaves the feed.

So the moment a fight ended, the viewer landed back on `ScoreboardScreen` — the list they wait on between fights — where nothing voted to hold the screen. The phone locked, and locking drops the cast.

## What changed

`scoreboardIsLiveProvider` reads the watched board as live while any match on it is `waiting` or `inProgress` — the two statuses that mean an update is still coming. `ScoreboardScreen` takes a wakelock lease against it.

No new wakelock machinery: the existing lease service already handles two screens overlapping during a route transition, so this is one more participant voting.

## Scope: the event, not the app

An unconditional app-wide hold was considered and rejected. It would pin the display at full brightness on settings and profile screens, stop the phone auto-locking on a scorer's table (that phone controls the bracket), and silently override the user's own screen-timeout preference everywhere — none of which buys anything outside a live board.

Two conditions guard the vote, and both are load-bearing:

| Condition | Why |
|---|---|
| The board is live | A finished or canceled card must not hold the display up for an event that is over. The existing 24-hour freshness window bounds a card whose organizer never closed it. |
| The scoreboard tab is selected | `ScoreboardScreen` lives in an `IndexedStack` that keeps every tab alive, so voting on the feed alone would hold the screen from behind Home, Account and Settings. |

Read from `scoreboardMatchesProvider`, not `scoreboardFilteredMatchesProvider`: the status chips are a display choice, and narrowing the list to today's results must not put the phone to sleep mid-event.

Deliberately no re-assert ticker, unlike the match screens. Theirs retries a request the platform dropped and hangs off a clock they already run; adding a timer to a list screen for a retry with no trigger to miss is not worth it — by the time a board is live and selected the activity is long since foreground, and a dropped vote is retried on the next feed update.

## Tests

`test/features/scoreboard/scoreboard_screen_wakelock_test.dart` (new, 11 widget tests) and a `scoreboardIsLiveProvider` group in `scoreboard_providers_test.dart` (8 unit tests). Written first, confirmed red, then green.

Covered:

- [x] holds while a fight is running
- [x] **holds in the gap between two fights** — the actual bug
- [x] holds for a board that has not started yet
- [x] sleeps once every fight is finished, and for a board of canceled fights
- [x] sleeps with no board watched
- [x] holds even while the status filter hides the live fights
- [x] sleeps while the user is on another tab, and picks the hold back up on return
- [x] sleeps when the screen is torn down
- [x] goes quiet when the only waiting fight ages out of the 24-hour window

## Test plan

- [x] `flutter test` — 899/899 pass
- [x] `flutter analyze` — no new issues (51 pre-existing, identical to `main`; none in the touched files)
- [ ] Manual: cast the board to a TV via Google Home, let a fight finish, and confirm the phone stays awake through the gap and the cast survives
- [ ] Manual: leave the scoreboard tab for Settings during a live event and confirm the phone locks normally

## Note

`pubspec.lock` is deliberately not in this PR — the local `flutter pub get` churned an unrelated `audioplayers` version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The scoreboard keeps your device screen awake while a selected match is waiting or in progress.
  * Screen-awake behavior updates automatically as match status changes or you switch navigation tabs.
* **Bug Fixes**
  * Scoreboard matches now expire promptly when they become too old, even without new updates.
  * Finished, canceled, expired, filtered, or empty scoreboards no longer keep the screen awake.
  * Screen-awake state is released when no live match is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->